### PR TITLE
Moved the docker login to `deploy` stage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ language: c
 services:
     - docker
 
-install:
-    # Setting up docker credentials.
-    - echo "$DOCKER_PASSWORD" | docker login $ACR_REGISTRY -u "$DOCKER_USERNAME" --password-stdin
-
 script:
     - cd $TRAVIS_BUILD_DIR
     - chmod u+x scripts/*
@@ -24,7 +20,9 @@ script:
 deploy:
   provider: script
   skip_cleanup: true
-  script: cd $TRAVIS_BUILD_DIR/build && cmake --build . --target dockerpush
+  script:
+    - echo "$DOCKER_PASSWORD" | docker login $ACR_REGISTRY -u "$DOCKER_USERNAME" --password-stdin
+    - cd $TRAVIS_BUILD_DIR/build && cmake --build . --target dockerpush
   on:
     repo: Azure/application-gateway-kubernetes-ingress
     tags: true


### PR DESCRIPTION
We would need the docker login only when we push the container images to
our public respoitories. This event would happen only during a release
which should never be performed from a forked repository.

Moving the `docker login` to the deploy stage would thus ensure that the
encrypted environment variables are never accessed from a forked repo.