### PR TITLE
Removed YAML and XML files from being treated as regular text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,9 +6,6 @@
 *.ini text
 *.json text
 *.txt text
-*.xml text
-*.yml text
-*.yaml text
 
 # Denote all files that are truly binary and should not be modified.
 *.dll binary


### PR DESCRIPTION
This it ends up causing git to do line-ending conversions that can cause unnecessary changes to appear when we rebase.