### PR TITLE
Fix 2 typos in documentation and comment

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -115,7 +115,7 @@ Now the `guestbook` application will be available on both HTTP and HTTPS.
 ### With specified hostname
 
 You can also specify the hostname on the ingress in order to multiplex TLS configurations and services.
-By specifying hostname, the guestbook service will only be availble on the specified host.
+By specifying hostname, the guestbook service will only be available on the specified host.
 
 1. Define the following ingress.
     In the ingress, specify the name of the secret in the `secretName` section and replace the hostname in the `hosts` section accordingly.

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -60,12 +60,12 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		},
 		Spec: v1beta1.IngressSpec{
 			Rules: []v1beta1.IngressRule{
-				v1beta1.IngressRule{
+				{
 					Host: domainName,
 					IngressRuleValue: v1beta1.IngressRuleValue{
 						HTTP: &v1beta1.HTTPIngressRuleValue{
 							Paths: []v1beta1.HTTPIngressPath{
-								v1beta1.HTTPIngressPath{
+								{
 									Path: hiPath,
 									Backend: v1beta1.IngressBackend{
 										ServiceName: serviceName,
@@ -248,7 +248,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 			// Retrieve the implementation of the `ConfigBuilder` interface.
 			appGW = configBuilder.Build()
-			// Ingress allows listners on port 80 or port 443. Therefore in this particular case we would have only a single listener
+			// Ingress allows listeners on port 80 or port 443. Therefore in this particular case we would have only a single listener
 			Expect(len(*appGW.HTTPListeners)).To(Equal(1), "Expected a single HTTP listener, but got: %d", len(*appGW.HTTPListeners))
 
 			// Test the listener.


### PR DESCRIPTION
Fix the following typos found by misspell:
```
docs/tutorial.md:118:59: "availble" is a misspelling of "available"
pkg/appgw/appgw_test.go:251:21: "listners" is a misspelling of "listeners"
```