### PR TITLE
Fix docker push

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -45,9 +45,6 @@ CMakeLists.txt text eol=lf
 *.py text eol=lf
 *.go text eol=lf
 
-# Text files
-*.md text eol=lf
-
 # Patch files.
 *.patch text eol=lf
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ add_custom_target(dockerpush
     COMMAND docker tag ${deployment_image_name}:${deployment_image_version} ${deployment_push_prefix}/${deployment_image_name}:latest
     COMMAND docker push ${deployment_push_prefix}/${deployment_image_name}:${deployment_image_version}
     COMMAND docker push ${deployment_push_prefix}/${deployment_image_name}:latest
+    DEPENDS dockerize
     COMMENT "pushing to container registry"
 )
 

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-06-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
@@ -16,6 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 )
 
 var _ = Describe("Tests `appgw.ConfigBuilder`", func() {

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -6,12 +6,13 @@
 package appgw
 
 import (
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-06-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
 func (builder *appGwConfigBuilder) BackendAddressPools(ingressList [](*v1beta1.Ingress)) (ConfigBuilder, error) {

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -9,13 +9,14 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-06-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
 func (builder *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList [](*v1beta1.Ingress)) (ConfigBuilder, error) {


### PR DESCRIPTION
 `docker-push` didn't have a dependency on the `dockerize` target because of which it was not building the deployment image before pushing it to the registry. Introduced the dependency to make `docker-push` work.