### PR TITLE
Fixed deploy stage for travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,11 @@ script:
               -Ddeployment_image_name="public/azure-application-gateway/kubernetes-ingress" 
               -Ddeployment_image_version="$IMAGE_VERSION" 
   - cmake --build .
-  
+
 deploy:
   provider: script
   skip_cleanup: true
-  script:
-    - echo "$DOCKER_PASSWORD" | docker login $ACR_REGISTRY -u "$DOCKER_USERNAME" --password-stdin
-    - cd $TRAVIS_BUILD_DIR/build && cmake --build . --target dockerpush
+  script: $TRAVIS_BUILD_DIR/scripts/deploy.sh
   on:
     repo: Azure/application-gateway-kubernetes-ingress
     tags: true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,6 +4,7 @@ echo "$DOCKER_PASSWORD" | docker login $ACR_REGISTRY -u "$DOCKER_USERNAME" --pas
 echo "Login successful. Getting ready to deploy."
 
 set -x
-popd $TRAVIS_BUILD_DIR/build
+pushd $TRAVIS_BUILD_DIR/build
 cmake --build . --target dockerpush
+popd
 set +x

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo "Logging into docker...."
+echo "$DOCKER_PASSWORD" | docker login $ACR_REGISTRY -u "$DOCKER_USERNAME" --password-stdin
+echo "Login successful. Getting ready to deploy."
+
+set -x
+popd $TRAVIS_BUILD_DIR/build
+cmake --build . --target dockerpush
+set +x


### PR DESCRIPTION
The script provider in deploy stage apparently needs to be a scalar and hence cannot take multiple commands. We therefore need to setup the `docker login` in a stage before the deploy begins.