### PR TITLE
Ignore more files created by text editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ jsconfig.json
 [._]ss[a-gi-z]
 [._]sw[a-p]
 
+# Other editors
+.idea/
+*~
 
 ######### Project Specific ########
 # ignore binary directory


### PR DESCRIPTION
Adding `.idea/` and `*~` to `.gitignore`.
These are directory and files created by Intellij/Goland and Emacs respectively.