### PR TITLE
gitignore: Ignore Emacs autosave files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ jsconfig.json
 # Other editors
 .idea/
 *~
+*#*
 
 ######### Project Specific ########
 # ignore binary directory


### PR DESCRIPTION
Ignore file names containing `#`. These are typically  backup (autosave) files created by Emacs. (For instance: `#azure-pipelines.yml#`)