### PR TITLE
k8scontext: Rename interface to SecretsKeeper; struct to SecretsStore

### DIFF
--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -44,7 +44,7 @@ type CacheCollection struct {
 type Context struct {
 	informers              *InformerCollection
 	Caches                 *CacheCollection
-	CertificateSecretStore SecretStore
+	CertificateSecretStore SecretsKeeper
 
 	ingressSecretsMap utils.ThreadsafeMultiMap
 	stopChannel       chan struct{}

--- a/pkg/k8scontext/secretstore.go
+++ b/pkg/k8scontext/secretstore.go
@@ -17,21 +17,21 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// SecretStore is the interface definition for secret store
-type SecretStore interface {
+// SecretsKeeper is the interface definition for secret store
+type SecretsKeeper interface {
 	GetPfxCertificate(secretKey string) []byte
 	convertSecret(secretKey string, secret *v1.Secret) bool
 	eraseSecret(secretKey string)
 }
 
-type secretStore struct {
+type SecretsStore struct {
 	conversionSync sync.Mutex
 	Cache          cache.ThreadSafeStore
 }
 
-// NewSecretStore creates a new Secret Store object
-func NewSecretStore() SecretStore {
-	return &secretStore{
+// NewSecretStore creates a new SecretsKeeper object
+func NewSecretStore() SecretsKeeper {
+	return &SecretsStore{
 		Cache: cache.NewThreadSafeStore(cache.Indexers{}, cache.Indices{}),
 	}
 }
@@ -46,7 +46,7 @@ func writeFileDecode(data []byte, fileHandle *os.File) error {
 	return nil
 }
 
-func (s *secretStore) GetPfxCertificate(secretKey string) []byte {
+func (s *SecretsStore) GetPfxCertificate(secretKey string) []byte {
 	certInterface, exists := s.Cache.Get(secretKey)
 	if exists {
 		if cert, ok := certInterface.([]byte); ok {
@@ -56,14 +56,14 @@ func (s *secretStore) GetPfxCertificate(secretKey string) []byte {
 	return nil
 }
 
-func (s *secretStore) eraseSecret(secretKey string) {
+func (s *SecretsStore) eraseSecret(secretKey string) {
 	s.conversionSync.Lock()
 	defer s.conversionSync.Unlock()
 
 	s.Cache.Delete(secretKey)
 }
 
-func (s *secretStore) convertSecret(secretKey string, secret *v1.Secret) bool {
+func (s *SecretsStore) convertSecret(secretKey string, secret *v1.Secret) bool {
 	s.conversionSync.Lock()
 	defer s.conversionSync.Unlock()
 

--- a/pkg/k8scontext/secretstore.go
+++ b/pkg/k8scontext/secretstore.go
@@ -24,6 +24,7 @@ type SecretsKeeper interface {
 	eraseSecret(secretKey string)
 }
 
+// SecretsStore maintains a cache of the deployment secrets.
 type SecretsStore struct {
 	conversionSync sync.Mutex
 	Cache          cache.ThreadSafeStore
@@ -46,6 +47,7 @@ func writeFileDecode(data []byte, fileHandle *os.File) error {
 	return nil
 }
 
+// GetPfxCertificate returns the certificate for the given secret key.
 func (s *SecretsStore) GetPfxCertificate(secretKey string) []byte {
 	certInterface, exists := s.Cache.Get(secretKey)
 	if exists {


### PR DESCRIPTION
Carving out a small piece of a [larger PR](https://github.com/Azure/application-gateway-kubernetes-ingress/pull/132/files) here to make the changes more palatable.

The goal of this change is to make the struct exportable and reusable within other packages. Also this brings the interface naming a bit closer to the ` 'er' appended to it` [idea](https://talks.golang.org/2014/names.slide#13).