### PR TITLE
cmake: Combine Go test targets; Test all packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,42 +76,15 @@ add_custom_target(
     DEPENDS ${CMAKE_SOURCE_DIR}/bin/appgw-ingress
 )
 
-# Test target for pkg/utils
-add_custom_target(test-pkg-utils
-    COMMAND docker run --rm --security-opt seccomp:unconfined  -t
-            -v ${CMAKE_SOURCE_DIR}:${devenv_workpath}
-            -w ${devenv_workpath}
-            --name ${devenv_image_name}-devenv ${devenv_image_name}
-            ginkgo -v pkg/utils
-    DEPENDS appgw-ingress
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
-# Test target for pkg/k8scontext
-add_custom_target(test-pkg-k8scontext
-    COMMAND docker run --rm --security-opt seccomp:unconfined  -t
-            -v ${CMAKE_SOURCE_DIR}:${devenv_workpath}
-            -w ${devenv_workpath}
-            --name ${devenv_image_name}-devenv ${devenv_image_name}
-            ginkgo -v pkg/k8scontext
-    DEPENDS appgw-ingress
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
-# Test target for pkg/appgw
-add_custom_target(test-pkg-appgw
-    COMMAND docker run --rm --security-opt seccomp:unconfined  -t
-            -v ${CMAKE_SOURCE_DIR}:${devenv_workpath}
-            -w ${devenv_workpath}
-            --name ${devenv_image_name}-devenv ${devenv_image_name}
-            ginkgo -v pkg/appgw
-    DEPENDS appgw-ingress
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
-# Top-level test target for running all go tests
+# Test target for all Go tests
 add_custom_target(go-tests
-    DEPENDS test-pkg-utils test-pkg-k8scontext test-pkg-appgw
+    COMMAND docker run --rm --security-opt seccomp:unconfined  -t
+            -v ${CMAKE_SOURCE_DIR}:${devenv_workpath}
+            -w ${devenv_workpath}
+            --name ${devenv_image_name}-devenv ${devenv_image_name}
+            go test -v ./...
+    DEPENDS appgw-ingress
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 
 # Target for building a docker image for deploying on a Kubernetes cluster.


### PR DESCRIPTION
Reading [the ginkgo documentation](https://onsi.github.io/ginkgo/) it turns out we can generalize running the tests w/ `go tests`
This allows for generic Go tests to be executed as well. (Generic go tests come w/ https://github.com/Azure/application-gateway-kubernetes-ingress/pull/132)


### Comparing `go test` and `ginkgo` to show that same tests are executed

#### Using `ginkgo`:
```
$ ginkgo ./...

[1556908432] Appgw Suite - 4/4 specs I0503 11:34:01.287623   30971 context.go:287] k8s context run started
I0503 11:34:01.287934   30971 context.go:374] start waiting for initial cache sync
I0503 11:34:01.489000   30971 context.go:389] ingress initial sync done
I0503 11:34:01.489029   30971 context.go:289] k8s context run finished
•I0503 11:34:01.489426   30971 context.go:287] k8s context run started
I0503 11:34:01.489442   30971 context.go:374] start waiting for initial cache sync
I0503 11:34:01.690370   30971 context.go:389] ingress initial sync done
I0503 11:34:01.690417   30971 context.go:289] k8s context run finished
I0503 11:34:01.690527   30971 context.go:342] unable to get service from store, no such service test-ingress-controller/hello-world
I0503 11:34:01.690573   30971 backendhttpsettings.go:51] unable to get the service [test-ingress-controller/hello-world]
I0503 11:34:01.690685   30971 context.go:324] unable to get endpoints from store, no such service test-ingress-controller/hello-world
W0503 11:34:01.690737   30971 backendaddresspools.go:26] unable to get endpoints for service key [test-ingress-controller/hello-world]
•I0503 11:34:01.692133   30971 context.go:287] k8s context run started
I0503 11:34:01.692171   30971 context.go:374] start waiting for initial cache sync
I0503 11:34:01.816800   30971 secretstore.go:121] converted secret [test-ingress-controller/test-ag-secret]
I0503 11:34:01.893736   30971 context.go:389] ingress initial sync done
I0503 11:34:01.893788   30971 context.go:289] k8s context run finished
•I0503 11:34:01.894623   30971 context.go:287] k8s context run started
I0503 11:34:01.894652   30971 context.go:374] start waiting for initial cache sync
I0503 11:34:02.095524   30971 context.go:389] ingress initial sync done
I0503 11:34:02.095577   30971 context.go:289] k8s context run finished
• SUCCESS! 809.2751ms PASS
[1556908432] K8scontext Suite - 4/4 specs I0503 11:34:02.122957   30987 context.go:287] k8s context run started
I0503 11:34:02.123354   30987 context.go:374] start waiting for initial cache sync
I0503 11:34:02.325009   30987 context.go:389] ingress initial sync done
I0503 11:34:02.325049   30987 context.go:289] k8s context run finished
•I0503 11:34:02.325460   30987 context.go:287] k8s context run started
I0503 11:34:02.325476   30987 context.go:374] start waiting for initial cache sync
I0503 11:34:02.526796   30987 context.go:389] ingress initial sync done
I0503 11:34:02.526823   30987 context.go:289] k8s context run finished
•I0503 11:34:02.527088   30987 context.go:287] k8s context run started
I0503 11:34:02.527101   30987 context.go:374] start waiting for initial cache sync
•I0503 11:34:02.728022   30987 context.go:389] ingress initial sync done
I0503 11:34:02.728043   30987 context.go:289] k8s context run finished
I0503 11:34:02.728633   30987 context.go:287] k8s context run started
I0503 11:34:02.728652   30987 context.go:374] start waiting for initial cache sync
I0503 11:34:02.929680   30987 context.go:389] ingress initial sync done
I0503 11:34:02.929730   30987 context.go:289] k8s context run finished
• SUCCESS! 809.3092ms PASS
[1556908432] Utils Suite - 9/9 specs ••••••••• SUCCESS! 946.6µs PASS

Ginkgo ran 3 suites in 10.8155646s
Test Suite Passed
```

#### Using `go test`:
```
$ go test -v ./...

?       github.com/Azure/application-gateway-kubernetes-ingress/cmd/appgw-ingress       [no test files]
?       github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations [no test files]
=== RUN   TestAppgw
Running Suite: Appgw Suite
==========================
Random Seed: 1556899875
Will run 4 of 4 specs

I0503 09:11:15.118780   28214 context.go:287] k8s context run started
I0503 09:11:15.119077   28214 context.go:374] start waiting for initial cache sync
I0503 09:11:15.319932   28214 context.go:389] ingress initial sync done
I0503 09:11:15.319953   28214 context.go:289] k8s context run finished
•I0503 09:11:15.320394   28214 context.go:287] k8s context run started
I0503 09:11:15.320414   28214 context.go:374] start waiting for initial cache sync
I0503 09:11:15.521223   28214 context.go:389] ingress initial sync done
I0503 09:11:15.521260   28214 context.go:289] k8s context run finished
I0503 09:11:15.521329   28214 context.go:342] unable to get service from store, no such service test-ingress-controller/hello-world
I0503 09:11:15.521345   28214 backendhttpsettings.go:51] unable to get the service [test-ingress-controller/hello-world]
I0503 09:11:15.521405   28214 context.go:324] unable to get endpoints from store, no such service test-ingress-controller/hello-world
W0503 09:11:15.521434   28214 backendaddresspools.go:26] unable to get endpoints for service key [test-ingress-controller/hello-world]
•I0503 09:11:15.529061   28214 context.go:287] k8s context run started
I0503 09:11:15.529102   28214 context.go:374] start waiting for initial cache sync
I0503 09:11:15.674778   28214 secretstore.go:121] converted secret [test-ingress-controller/test-ag-secret]
I0503 09:11:15.730877   28214 context.go:389] ingress initial sync done
I0503 09:11:15.730899   28214 context.go:289] k8s context run finished
•I0503 09:11:15.731406   28214 context.go:287] k8s context run started
I0503 09:11:15.731426   28214 context.go:374] start waiting for initial cache sync
I0503 09:11:15.932574   28214 context.go:389] ingress initial sync done
I0503 09:11:15.932596   28214 context.go:289] k8s context run finished
•
Ran 4 of 4 Specs in 0.816 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAppgw (0.82s)
PASS
ok      github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw       (cached)
?       github.com/Azure/application-gateway-kubernetes-ingress/pkg/controller  [no test files]
=== RUN   TestK8scontext
Running Suite: K8scontext Suite
===============================
Random Seed: 1556899874
Will run 4 of 4 specs

I0503 09:11:14.506853   28200 context.go:287] k8s context run started
I0503 09:11:14.507177   28200 context.go:374] start waiting for initial cache sync
I0503 09:11:14.708333   28200 context.go:389] ingress initial sync done
I0503 09:11:14.708377   28200 context.go:289] k8s context run finished
•I0503 09:11:14.708984   28200 context.go:287] k8s context run started
I0503 09:11:14.709002   28200 context.go:374] start waiting for initial cache sync
I0503 09:11:14.910684   28200 context.go:389] ingress initial sync done
I0503 09:11:14.910707   28200 context.go:289] k8s context run finished
•I0503 09:11:14.910968   28200 context.go:287] k8s context run started
I0503 09:11:14.911012   28200 context.go:374] start waiting for initial cache sync
I0503 09:11:15.112085   28200 context.go:389] ingress initial sync done
I0503 09:11:15.112140   28200 context.go:289] k8s context run finished
•I0503 09:11:15.114772   28200 context.go:287] k8s context run started
I0503 09:11:15.114794   28200 context.go:374] start waiting for initial cache sync
I0503 09:11:15.316683   28200 context.go:389] ingress initial sync done
I0503 09:11:15.316718   28200 context.go:289] k8s context run finished
•
Ran 4 of 4 Specs in 0.811 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestK8scontext (0.81s)
PASS
ok      github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext  (cached)
=== RUN   TestUtils
Running Suite: Utils Suite
==========================
Random Seed: 1556899872
Will run 9 of 9 specs

•••••••••
Ran 9 of 9 Specs in 0.000 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestUtils (0.00s)
PASS
ok      github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils       (cached)
```