### PR TITLE
annotations: Adding IsSslRedirect function

### DIFF
--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -5,9 +5,15 @@ import (
 )
 
 const (
+	// ApplicationGatewayPrefix defines the prefix for all keys associated with Application Gateway Ingress controller.
+	ApplicationGatewayPrefix = "appgw.ingress.kubernetes.io"
+
 	// BackendPathPrefixKey defines the key for Path which should be used as a prefix for all HTTP requests.
 	// Null means no path will be prefixed. Default value is null.
-	BackendPathPrefixKey = "appgw.ingress.kubernetes.io/backend-path-prefix"
+	BackendPathPrefixKey = ApplicationGatewayPrefix + "/backend-path-prefix"
+
+	// SslRedirectKey defines the key for defining with SSL redirect should be turned on for an HTTP endpoint.
+	SslRedirectKey = ApplicationGatewayPrefix + "/ssl-redirect"
 
 	// IngressClassKey defines the key of the annotation which needs to be set in order to specify
 	// that this is an ingress resource meant for the application gateway ingress controller.
@@ -34,4 +40,10 @@ func IngressClass(ing *v1beta1.Ingress) string {
 func IsApplicationGatewayIngress(ing *v1beta1.Ingress) bool {
 	controllerName := ing.Annotations[IngressClassKey]
 	return controllerName == ApplicationGatewayIngressClass
+}
+
+// IsSslRedirect for HTTP end points.
+func IsSslRedirect(ing *v1beta1.Ingress) bool {
+	val, ok := ing.Annotations[SslRedirectKey]
+	return ok && val == "true"
 }

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -1,0 +1,43 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package annotations
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var ingress = v1beta1.Ingress{
+	ObjectMeta: v1.ObjectMeta{
+		Annotations: map[string]string{},
+	},
+}
+
+func TestIsSslRedirectYes(t *testing.T) {
+	redirectKey := "true"
+	ingress.Annotations[SslRedirectKey] = redirectKey
+	if !IsSslRedirect(&ingress) {
+		t.Error(fmt.Sprintf("IsSslRedirect is expected to return true since %s = %s", SslRedirectKey, redirectKey))
+	}
+}
+
+func TestIsSslRedirectNo(t *testing.T) {
+	redirectKey := "nope"
+	ingress.Annotations[SslRedirectKey] = redirectKey
+	if IsSslRedirect(&ingress) {
+		t.Error(fmt.Sprintf("IsSslRedirect is expected to return false since %s = %s", SslRedirectKey, redirectKey))
+	}
+}
+func TestIsSslRedirectMissingKey(t *testing.T) {
+	delete(ingress.Annotations, SslRedirectKey)
+	if IsSslRedirect(&ingress) {
+		t.Error(fmt.Sprintf("IsSslRedirect is expected to return false since there is no %s annotation", SslRedirectKey))
+	}
+}
+


### PR DESCRIPTION
In this PR we introduce `IsSslRedirect`, which at this point is unused. This is a small chunk of https://github.com/Azure/application-gateway-kubernetes-ingress/pull/132
The goal of this small PR is to reduce the noise in https://github.com/Azure/application-gateway-kubernetes-ingress/pull/132 -- surface the actual changes that need to be carefully reviewed.

The added unit test will **not** be executed w/ the current CMake targets.

PR https://github.com/Azure/application-gateway-kubernetes-ingress/pull/141 introduces a change, which will execute all tests.

Will merge https://github.com/Azure/application-gateway-kubernetes-ingress/pull/141 first, then test the PR here w/ the new CMake and then merge.