### PR TITLE
internaltypes: Adding generateSSLRedirectConfigurationName func; Extend frontendListenerAzureConfig struct

### DIFF
--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -45,8 +45,9 @@ const (
 
 // create xxx -> xxxconfiguration mappings to contain all the information
 type frontendListenerAzureConfig struct {
-	Protocol network.ApplicationGatewayProtocol
-	Secret   secretIdentifier
+	Protocol                     network.ApplicationGatewayProtocol
+	Secret                       secretIdentifier
+	SslRedirectConfigurationName string
 }
 
 func (s serviceIdentifier) serviceFullName() string {
@@ -91,6 +92,10 @@ func generateURLPathMapName(frontendListenerID frontendListenerIdentifier) strin
 
 func generateRequestRoutingRuleName(frontendListenerID frontendListenerIdentifier) string {
 	return fmt.Sprintf("%s-%v-%v-rr", agPrefix, frontendListenerID.HostName, frontendListenerID.FrontendPort)
+}
+
+func generateSSLRedirectConfigurationName(namespace, ingress string) string {
+	return fmt.Sprintf("%s-%s-%s-sslr", agPrefix, namespace, ingress)
 }
 
 const defaultBackendHTTPSettingsName = agPrefix + "-defaulthttpsetting"

--- a/pkg/appgw/internaltypes_test.go
+++ b/pkg/appgw/internaltypes_test.go
@@ -1,0 +1,22 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package appgw
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGenerateSSLRedirectConfigurationName(t *testing.T) {
+	namespace := "nmspc"
+	ingress := "ingrs"
+	actual := generateSSLRedirectConfigurationName(namespace, ingress)
+	expected := "k8s-ag-ingress-nmspc-ingrs-sslr"
+	if actual != expected {
+		t.Error(fmt.Sprintf("\nExpected %s\nActually %s", expected, actual))
+	}
+}
+


### PR DESCRIPTION
A tiny piece of a larger PR - https://github.com/Azure/application-gateway-kubernetes-ingress/pull/132

  - Adding `SslRedirectConfigurationName` to `frontendListenerAzureConfig`
  - Adding `generateSSLRedirectConfigurationName()`

Tests will start running on TravisCI (via cmake) once https://github.com/Azure/application-gateway-kubernetes-ingress/pull/141 is comitted. 