### PR TITLE
unorderedset: Adding ToSlice()

### DIFF
--- a/pkg/utils/unorderedset.go
+++ b/pkg/utils/unorderedset.go
@@ -17,6 +17,7 @@ type UnorderedSet interface {
 	ForEach(func(interface{}))
 	Union(s UnorderedSet) UnorderedSet
 	Intersect(s UnorderedSet) UnorderedSet
+	ToSlice() []interface{}
 }
 
 type unorderedSet struct {
@@ -87,4 +88,12 @@ func (s *unorderedSet) Intersect(set UnorderedSet) UnorderedSet {
 		}
 	})
 	return set
+}
+
+func (s *unorderedSet) ToSlice() []interface{} {
+	keys := make([]interface{}, 0, len(s.v))
+	for elem := range s.v {
+		keys = append(keys, elem)
+	}
+	return keys
 }

--- a/pkg/utils/unorderedset_test.go
+++ b/pkg/utils/unorderedset_test.go
@@ -1,0 +1,27 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package utils
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestToSlice(t *testing.T) {
+	set := NewUnorderedSet()
+	set.Insert("one")
+	set.Insert("two")
+	set.Insert("one")
+	expected := []string{"one", "two"}
+	actual := set.ToSlice()
+	if len(actual) != 2 {
+		t.Error(fmt.Sprintf("Expected length to be 2; It is %d", len(actual)))
+	}
+
+	if actual[0] != expected[0] && actual[1] != expected[1] {
+		t.Error(fmt.Sprintf("\nExpected: %+v\nActually: %+v\n", expected, actual))
+	}
+}


### PR DESCRIPTION
Adding `ToSlice()` to our implementation of Sets in Go.
Would like to get this library closer to https://github.com/deckarep/golang-set and eventually replace it with it.