### PR TITLE
controller: Introducing EventProcessor interface - provides an event actor

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -39,14 +39,14 @@ func NewAppGwIngressController(appGwClient network.ApplicationGatewaysClient, ap
 		k8sContext:       k8sContext,
 		k8sUpdateChannel: k8sContext.UpdateChannel,
 	}
-	controller.eventQueue = NewEventQueue(controller.processEvent)
+	controller.eventQueue = NewEventQueue(controller)
 	return controller
 }
 
-// processEvent is the callback function that will be executed for every event
+// Process is the callback function that will be executed for every event
 // in the EventQueue.
-func (c *AppGwIngressController) processEvent(event queuedEvent) error {
-	glog.V(1).Infof("controller.processEvent called with type %T", event.Event)
+func (c AppGwIngressController) Process(event QueuedEvent) error {
+	glog.V(1).Infof("controller.Process called with type %T", event.Event)
 
 	ctx := context.Background()
 

--- a/pkg/controller/eventqueue.go
+++ b/pkg/controller/eventqueue.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
-// EventProcessor provides a mechanism to act on events in the internal queue.
+// Provides a generic mechanism to act on events in the internal queue.
 type EventProcessor interface {
 	Process(QueuedEvent) error
 }

--- a/pkg/controller/eventqueue.go
+++ b/pkg/controller/eventqueue.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
-// Provides a generic mechanism to act on events in the internal queue.
+// EventProcessor provides a mechanism to act on events in the internal queue.
 type EventProcessor interface {
 	Process(QueuedEvent) error
 }

--- a/pkg/controller/eventqueue.go
+++ b/pkg/controller/eventqueue.go
@@ -16,15 +16,15 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
-// QueuedEventEventProcessor provides a mechanism to act on events in the internal queue.
-type QueuedEventEventProcessor interface {
+// EventProcessor provides a mechanism to act on events in the internal queue.
+type EventProcessor interface {
 	Process(QueuedEvent) error
 }
 
 // EventQueue is a queue accepting events and run callback function
 // for each events.
 type EventQueue struct {
-	QueuedEventEventProcessor
+	EventProcessor
 
 	queue              workqueue.RateLimitingInterface
 	workerFinished     chan struct{}
@@ -42,9 +42,9 @@ type QueuedEvent struct {
 
 // NewEventQueue creates an EventQueue with a callback function. The callback
 // function processFunc is executed for each event in the queue.
-func NewEventQueue(processor QueuedEventEventProcessor) *EventQueue {
+func NewEventQueue(processor EventProcessor) *EventQueue {
 	q := &EventQueue{
-		QueuedEventEventProcessor: processor,
+		EventProcessor: processor,
 
 		queue:              workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		workerFinished:     make(chan struct{}),


### PR DESCRIPTION
@asridharan Following up on [your comment](https://github.com/Azure/application-gateway-kubernetes-ingress/pull/149#discussion_r281185114) on https://github.com/Azure/application-gateway-kubernetes-ingress/pull/149 and my promise to introduce this Interface.

Here it is - a bit verbose, but otherwise unambigous interface: `QueuedEventEventProcessor`