### PR TITLE
tests: Augmenting test fixtures with needed structs

### DIFF
--- a/pkg/appgw/test_fixtures.go
+++ b/pkg/appgw/test_fixtures.go
@@ -8,6 +8,9 @@ package appgw
 import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +19,14 @@ import (
 
 func makeConfigBuilderTestFixture() appGwConfigBuilder {
 
-	return appGwConfigBuilder{
+	cb := appGwConfigBuilder{
+		serviceBackendPairMap:         make(map[backendIdentifier]serviceBackendPortPair),
+		httpListenersMap:              make(map[frontendListenerIdentifier]*network.ApplicationGatewayHTTPListener),
+		httpListenersAzureConfigMap:   make(map[frontendListenerIdentifier]*frontendListenerAzureConfig),
+		ingressKeyHostnameSecretIDMap: make(map[string]map[string]secretIdentifier),
+		secretIDCertificateMap:        make(map[secretIdentifier]*string),
+		backendHTTPSettingsMap:        make(map[backendIdentifier]*network.ApplicationGatewayBackendHTTPSettings),
+		backendPoolMap:                make(map[backendIdentifier]*network.ApplicationGatewayBackendAddressPool),
 		k8sContext: &k8scontext.Context{
 			Caches: &k8scontext.CacheCollection{
 				Secret: cache.NewStore(func(obj interface{}) (string, error) {
@@ -25,13 +35,49 @@ func makeConfigBuilderTestFixture() appGwConfigBuilder {
 			},
 			CertificateSecretStore: nil,
 		},
-		secretIDCertificateMap: make(map[secretIdentifier]*string),
 	}
+
+	return cb
+}
+
+func addCertsTestFixture(cb *appGwConfigBuilder) {
+	ingressKey := "--ingress-key--"
+	hostName := "--some-hostname--"
+	secretsIdent := secretIdentifier{
+		Namespace: "--namespace--",
+		Name:      "--name--",
+	}
+	cb.ingressKeyHostnameSecretIDMap[ingressKey] = make(map[string]secretIdentifier)
+	cb.ingressKeyHostnameSecretIDMap[ingressKey][hostName] = secretsIdent
+	// Wild card
+	cb.ingressKeyHostnameSecretIDMap[ingressKey][""] = secretsIdent
+
+	cb.secretIDCertificateMap[secretsIdent] = to.StringPtr("")
 }
 
 func makeIngressTestFixture() v1beta1.Ingress {
 	return v1beta1.Ingress{
 		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: "-some-host-",
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								{
+									Path: "////",
+									Backend: v1beta1.IngressBackend{
+										ServiceName: "",
+										ServicePort: intstr.IntOrString{
+											IntVal: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			TLS: []v1beta1.IngressTLS{
 				{
 					Hosts: []string{


### PR DESCRIPTION
Pulling a small piece of a [larger PR](https://github.com/Azure/application-gateway-kubernetes-ingress/pull/132) here.

With this change we createa more comprehensive `appGwConfigBuilder` struct.