### PR TITLE
for loop using idx and rule & path in backendIdentifier

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -6,6 +6,9 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
@@ -16,10 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
-
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
 type appGWSettingsChecker struct {
@@ -170,7 +169,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 	defaultBackendHTTPSettingsChecker := func(appGW *network.ApplicationGatewayPropertiesFormat) {
 		expectedBackend := &ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend
-		httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), backendPort, ingress.Name)
+		httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), backendPort, ingress.Name)
 		httpSettings := &network.ApplicationGatewayBackendHTTPSettings{
 			Etag: to.StringPtr("*"),
 			Name: &httpSettingsName,
@@ -189,7 +188,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 	defaultBackendAddressPoolChecker := func(appGW *network.ApplicationGatewayPropertiesFormat) {
 		expectedBackend := &ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend
-		addressPoolName := generateAddressPoolName(generateBackendID(ingress, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), backendPort)
+		addressPoolName := generateAddressPoolName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), backendPort)
 		addressPoolAddresses := [](network.ApplicationGatewayBackendAddress){{IPAddress: &endpoint1}, {IPAddress: &endpoint2}, {IPAddress: &endpoint3}}
 
 		addressPool := &network.ApplicationGatewayBackendAddressPool{
@@ -427,7 +426,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 			EmptyBackendHTTPSettingsChecker := func(appGW *network.ApplicationGatewayPropertiesFormat) {
 				expectedBackend := &ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend
-				httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), servicePort, ingress.Name)
+				httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), servicePort, ingress.Name)
 				httpSettings := &network.ApplicationGatewayBackendHTTPSettings{
 					Etag: to.StringPtr("*"),
 					Name: &httpSettingsName,
@@ -636,7 +635,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 			backendPrefixHTTPSettingsChecker := func(appGW *network.ApplicationGatewayPropertiesFormat) {
 				expectedBackend := &ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend
-				httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), backendPort, ingress.Name)
+				httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), backendPort, ingress.Name)
 				httpSettings := &network.ApplicationGatewayBackendHTTPSettings{
 					Etag: to.StringPtr("*"),
 					Name: &httpSettingsName,

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -6,13 +6,12 @@
 package appgw
 
 import (
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
-
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
 func (builder *appGwConfigBuilder) BackendAddressPools(ingressList [](*v1beta1.Ingress)) (ConfigBuilder, error) {
@@ -38,7 +37,7 @@ func (builder *appGwConfigBuilder) BackendAddressPools(ingressList [](*v1beta1.I
 			}
 
 			if endpointsPortsSet.Contains(serviceBackendPair.BackendPort) {
-				addressPoolName := generateAddressPoolName(backendID.serviceFullName(), backendID.ServicePort.String(), serviceBackendPair.BackendPort)
+				addressPoolName := generateAddressPoolName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), serviceBackendPair.BackendPort)
 				// The same service might be referenced in multiple ingress resources, this might result in multiple `serviceBackendPairMap` having the same service key but different
 				// ingress resource. Thus, while generating the backend address pool, we should make sure that we are generating unique backend address pools.
 				addressPool, ok := addressPools[addressPoolName]

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -9,34 +9,34 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
 func (builder *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList [](*v1beta1.Ingress)) (ConfigBuilder, error) {
 	backendIDs := utils.NewUnorderedSet()
 	serviceBackendPairsMap := make(map[backendIdentifier](utils.UnorderedSet))
 
-	// find all ServiceName:ServicePort pairs from the ingress list
 	for _, ingress := range ingressList {
 		defIngressBackend := ingress.Spec.Backend
 		if defIngressBackend != nil {
-			backendIDs.Insert(generateBackendID(ingress, defIngressBackend))
+			backendIDs.Insert(generateBackendID(ingress, nil, nil, defIngressBackend))
 		}
-		for _, rule := range ingress.Spec.Rules {
+		for rule_idx := range ingress.Spec.Rules {
+			rule := &ingress.Spec.Rules[rule_idx]
 			if rule.HTTP == nil {
 				// skip no http rule
 				continue
 			}
-			for _, path := range rule.HTTP.Paths {
-				backendIDs.Insert(generateBackendID(ingress, &path.Backend))
+			for path_idx := range rule.HTTP.Paths {
+				path := &rule.HTTP.Paths[path_idx]
+				backendIDs.Insert(generateBackendID(ingress, rule, path, &path.Backend))
 			}
 		}
 	}
@@ -50,8 +50,8 @@ func (builder *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList [](
 		if service == nil {
 			glog.V(1).Infof("unable to get the service [%s]", backendID.serviceKey())
 			resolvedBackendPorts.Insert(serviceBackendPortPair{
-				ServicePort: backendID.ServicePort.IntVal,
-				BackendPort: backendID.ServicePort.IntVal,
+				ServicePort: backendID.Backend.ServicePort.IntVal,
+				BackendPort: backendID.Backend.ServicePort.IntVal,
 			})
 		} else {
 			for _, sp := range service.Spec.Ports {
@@ -61,9 +61,9 @@ func (builder *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList [](
 					// ignore UDP ports
 					continue
 				}
-				if fmt.Sprint(sp.Port) == backendID.ServicePort.String() ||
-					sp.Name == backendID.ServicePort.String() ||
-					sp.TargetPort.String() == backendID.ServicePort.String() {
+				if fmt.Sprint(sp.Port) == backendID.Backend.ServicePort.String() ||
+					sp.Name == backendID.Backend.ServicePort.String() ||
+					sp.TargetPort.String() == backendID.Backend.ServicePort.String() {
 					// matched a service port with a port from the service
 
 					if sp.TargetPort.String() == "" {
@@ -123,7 +123,7 @@ func (builder *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList [](
 		if serviceBackendPairs.Size() > 1 {
 			// more than one possible backend port exposed through ingress
 			glog.Warningf("service:port [%s:%s] has more than one service-backend port binding",
-				backendID.serviceKey(), backendID.ServicePort.String())
+				backendID.serviceKey(), backendID.Backend.ServicePort.String())
 			return builder, errors.New("more than one service-backend port binding is not allowed")
 		}
 
@@ -134,7 +134,7 @@ func (builder *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList [](
 
 		builder.serviceBackendPairMap[backendID] = uniquePair
 
-		httpSettingsName := generateHTTPSettingsName(backendID.serviceFullName(), backendID.ServicePort.String(), uniquePair.BackendPort, backendID.Ingress.Name)
+		httpSettingsName := generateHTTPSettingsName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), uniquePair.BackendPort, backendID.Ingress.Name)
 		httpSettingsPort := uniquePair.BackendPort
 		backendPathPrefix := to.StringPtr(annotations.BackendPathPrefix(backendID.Ingress))
 		httpSettings := network.ApplicationGatewayBackendHTTPSettings{

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -28,14 +28,14 @@ func (builder *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList [](
 		if defIngressBackend != nil {
 			backendIDs.Insert(generateBackendID(ingress, nil, nil, defIngressBackend))
 		}
-		for rule_idx := range ingress.Spec.Rules {
-			rule := &ingress.Spec.Rules[rule_idx]
+		for ruleIdx := range ingress.Spec.Rules {
+			rule := &ingress.Spec.Rules[ruleIdx]
 			if rule.HTTP == nil {
 				// skip no http rule
 				continue
 			}
-			for path_idx := range rule.HTTP.Paths {
-				path := &rule.HTTP.Paths[path_idx]
+			for pathIdx := range rule.HTTP.Paths {
+				path := &rule.HTTP.Paths[pathIdx]
 				backendIDs.Insert(generateBackendID(ingress, rule, path, &path.Backend))
 			}
 		}

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -6,11 +6,10 @@
 package appgw
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
-	"k8s.io/api/extensions/v1beta1"
-
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"k8s.io/api/extensions/v1beta1"
 )
 
 // ConfigBuilder is a builder for application gateway configuration
@@ -73,18 +72,17 @@ func (builder *appGwConfigBuilder) resolvePortName(portName string, backendID *b
 	return resolvedPorts
 }
 
-func generateBackendID(ingress *v1beta1.Ingress, backend *v1beta1.IngressBackend) backendIdentifier {
-	backendServiceName := backend.ServiceName
-	backendServicePort := backend.ServicePort
-	backendID := backendIdentifier{
+func generateBackendID(ingress *v1beta1.Ingress, rule *v1beta1.IngressRule, path *v1beta1.HTTPIngressPath, backend *v1beta1.IngressBackend) backendIdentifier {
+	return backendIdentifier{
 		serviceIdentifier: serviceIdentifier{
 			Namespace: ingress.Namespace,
-			Name:      backendServiceName,
+			Name:      backend.ServiceName,
 		},
-		ServicePort: backendServicePort,
-		Ingress:     ingress,
+		Ingress: ingress,
+		Rule:    rule,
+		Path:    path,
+		Backend: backend,
 	}
-	return backendID
 }
 
 func generateFrontendListenerID(rule *v1beta1.IngressRule,

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type backendIdentifier struct {
 	serviceIdentifier
-	ServicePort intstr.IntOrString
-	Ingress     *v1beta1.Ingress
+	Ingress *v1beta1.Ingress
+	Rule    *v1beta1.IngressRule
+	Path    *v1beta1.HTTPIngressPath
+	Backend *v1beta1.IngressBackend
 }
 
 type serviceBackendPortPair struct {

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -32,8 +32,8 @@ func (builder *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, rule *v1be
 		urlPathMap.PathRules = &[]network.ApplicationGatewayPathRule{}
 	}
 
-	for path_idx := range rule.HTTP.Paths {
-		path := &rule.HTTP.Paths[path_idx]
+	for pathIdx := range rule.HTTP.Paths {
+		path := &rule.HTTP.Paths[pathIdx]
 		backendID := generateBackendID(ingress, rule, path, &path.Backend)
 		backendPool := builder.backendPoolMap[backendID]
 		backendHTTPSettings := builder.backendHTTPSettingsMap[backendID]

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -32,8 +32,9 @@ func (builder *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, rule *v1be
 		urlPathMap.PathRules = &[]network.ApplicationGatewayPathRule{}
 	}
 
-	for _, path := range rule.HTTP.Paths {
-		backendID := generateBackendID(ingress, &path.Backend)
+	for path_idx := range rule.HTTP.Paths {
+		path := &rule.HTTP.Paths[path_idx]
+		backendID := generateBackendID(ingress, rule, path, &path.Backend)
 		backendPool := builder.backendPoolMap[backendID]
 		backendHTTPSettings := builder.backendHTTPSettingsMap[backendID]
 		if backendPool == nil || backendHTTPSettings == nil {
@@ -100,7 +101,7 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 
 		if defBackend != nil {
 			// has default backend
-			defaultBackendID := generateBackendID(ingress, defBackend)
+			defaultBackendID := generateBackendID(ingress, nil, nil, defBackend)
 
 			defaultHTTPSettings := builder.backendHTTPSettingsMap[defaultBackendID]
 			defaultAddressPool := builder.backendPoolMap[defaultBackendID]

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -81,9 +81,10 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 
 		var wildcardRule *v1beta1.IngressRule
 		wildcardRule = nil
-		for _, rule := range ingress.Spec.Rules {
+		for ruleIdx := range ingress.Spec.Rules {
+			rule := &ingress.Spec.Rules[ruleIdx]
 			if rule.HTTP != nil && len(rule.Host) == 0 {
-				wildcardRule = &rule
+				wildcardRule = rule
 			}
 		}
 
@@ -91,7 +92,8 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 		defBackend := ingress.Spec.Backend
 		if wildcardRule != nil {
 			// wildcard rule override the default backend
-			for _, path := range wildcardRule.HTTP.Paths {
+			for pathIdx := range wildcardRule.HTTP.Paths {
+				path := &wildcardRule.HTTP.Paths[pathIdx]
 				if path.Path == "" || path.Path == "/*" {
 					// look for default path
 					defBackend = &path.Backend
@@ -112,7 +114,8 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 			}
 		}
 
-		for _, rule := range ingress.Spec.Rules {
+		for ruleIdx := range ingress.Spec.Rules {
+			rule := &ingress.Spec.Rules[ruleIdx]
 			if rule.HTTP == nil {
 				// skip no http rule
 				continue
@@ -121,14 +124,14 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 			httpAvailable := false
 			httpsAvailable := false
 
-			listenerHTTPID := generateFrontendListenerID(&rule, network.HTTP, nil)
+			listenerHTTPID := generateFrontendListenerID(rule, network.HTTP, nil)
 			_, exist := builder.httpListenersMap[listenerHTTPID]
 			if exist {
 				httpAvailable = true
 			}
 
 			// check annotation for port override
-			listenerHTTPSID := generateFrontendListenerID(&rule, network.HTTPS, nil)
+			listenerHTTPSID := generateFrontendListenerID(rule, network.HTTPS, nil)
 			_, exist = builder.httpListenersMap[listenerHTTPSID]
 			if exist {
 				httpsAvailable = true
@@ -143,7 +146,7 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 						defaultAddressPoolID, defaultHTTPSettingsID)
 				}
 				// need to eliminate non-unique paths
-				urlPathMaps[listenerHTTPID] = builder.pathMaps(ingress, &rule,
+				urlPathMaps[listenerHTTPID] = builder.pathMaps(ingress, rule,
 					listenerHTTPID, urlPathMaps[listenerHTTPID],
 					defaultAddressPoolID, defaultHTTPSettingsID)
 			}
@@ -156,7 +159,7 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 						defaultAddressPoolID, defaultHTTPSettingsID)
 				}
 				// need to eliminate non-unique paths
-				urlPathMaps[listenerHTTPSID] = builder.pathMaps(ingress, &rule,
+				urlPathMaps[listenerHTTPSID] = builder.pathMaps(ingress, rule,
 					listenerHTTPSID, urlPathMaps[listenerHTTPSID],
 					defaultAddressPoolID, defaultHTTPSettingsID)
 			}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,7 +7,6 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"time"
 
@@ -93,10 +92,6 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 
 	// Replace the current appgw config with the generated one
 	appGw.ApplicationGatewayPropertiesFormat = configBuilder.Build()
-	appGwJson, err := json.MarshalIndent(appGw, "", "    ")
-	if err == nil {
-		glog.V(2).Infof("Application Gateway Config:\n %s", appGwJson)
-	}
 
 	glog.V(1).Info("BEGIN ApplicationGateway deployment")
 	defer glog.V(1).Info("END ApplicationGateway deployment")

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,15 +7,15 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"time"
 
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/eapache/channels"
 	"github.com/golang/glog"
-
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 )
 
 // AppGwIngressController configures the application gateway based on the ingress rules defined.
@@ -93,6 +93,10 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 
 	// Replace the current appgw config with the generated one
 	appGw.ApplicationGatewayPropertiesFormat = configBuilder.Build()
+	appGwJson, err := json.MarshalIndent(appGw, "", "    ")
+	if err == nil {
+		glog.V(2).Infof("Application Gateway Config:\n %s", appGwJson)
+	}
 
 	glog.V(1).Info("BEGIN ApplicationGateway deployment")
 	defer glog.V(1).Info("END ApplicationGateway deployment")


### PR DESCRIPTION
1) For loop ingresses/rules/paths with index to avoid making copies as we are using their addresses to create struct that are used as map keys.
2) Add IngressRule and IngressPath to backendIdentifier struct. Idea is to hold information relating a request routing rule (path to backend) in one struct and flatten ingress list.