### PR TITLE
Carving out the functions processing ingress rules into a separate file

### DIFF
--- a/pkg/appgw/certificates.go
+++ b/pkg/appgw/certificates.go
@@ -1,0 +1,115 @@
+package appgw
+
+import (
+	"encoding/base64"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+// getSslCertificates obtains all SSL Certificates for the given Ingress object.
+func (builder *appGwConfigBuilder) getSslCertificates(ingressList []*v1beta1.Ingress) *[]network.ApplicationGatewaySslCertificate {
+	secretIDCertificateMap := make(map[secretIdentifier]*string)
+
+	for _, ingress := range ingressList {
+		for k, v := range builder.getSecretToCertificateMap(ingress) {
+			secretIDCertificateMap[k] = v
+		}
+	}
+
+	var sslCertificates []network.ApplicationGatewaySslCertificate
+	for secretID, cert := range secretIDCertificateMap {
+		sslCertificates = append(sslCertificates, newCert(secretID, cert))
+	}
+	return &sslCertificates
+}
+
+func (builder *appGwConfigBuilder) getSecretToCertificateMap(ingress *v1beta1.Ingress) map[secretIdentifier]*string {
+	secretIDCertificateMap := make(map[secretIdentifier]*string)
+	for _, tls := range ingress.Spec.TLS {
+		if len(tls.SecretName) == 0 {
+			continue
+		}
+
+		tlsSecret := secretIdentifier{
+			Name:      tls.SecretName,
+			Namespace: ingress.Namespace,
+		}
+
+		// add hostname-tlsSecret mapping to a per-ingress map
+		if cert := builder.k8sContext.CertificateSecretStore.GetPfxCertificate(tlsSecret.secretKey()); cert != nil {
+			secretIDCertificateMap[tlsSecret] = to.StringPtr(base64.StdEncoding.EncodeToString(cert))
+		}
+	}
+	return secretIDCertificateMap
+}
+
+// TODO(draychev): Remove V1 when the old declaration of getCertificate(...) is removed from the code base
+func (builder *appGwConfigBuilder) getCertificate(ingress *v1beta1.Ingress, hostname string, hostnameSecretIDMap map[string]secretIdentifier) (*string, *secretIdentifier) {
+	if hostnameSecretIDMap == nil {
+		return nil, nil
+	}
+	secID, exists := hostnameSecretIDMap[hostname]
+	if !exists {
+		// check if wildcard exists
+		secID, exists = hostnameSecretIDMap[""]
+	}
+	if !exists {
+		// no wildcard or matched certificate
+		return nil, nil
+	}
+
+	cert, exists := builder.getSecretToCertificateMap(ingress)[secID]
+	if !exists {
+		// secret referred does not correspond to a certificate
+		return nil, nil
+	}
+	return cert, &secID
+}
+
+func (builder *appGwConfigBuilder) newHostToSecretMap(ingress *v1beta1.Ingress) map[string]secretIdentifier {
+	hostToSecretMap := make(map[string]secretIdentifier)
+	for _, tls := range ingress.Spec.TLS {
+		if len(tls.SecretName) == 0 {
+			continue
+		}
+
+		tlsSecret := secretIdentifier{
+			Name:      tls.SecretName,
+			Namespace: ingress.Namespace,
+		}
+
+		// add hostname-tlsSecret mapping to a per-ingress map
+		cert := builder.k8sContext.CertificateSecretStore.GetPfxCertificate(tlsSecret.secretKey())
+		if cert == nil {
+			continue
+		}
+
+		// default secret
+		if len(tls.Hosts) == 0 {
+			hostToSecretMap[""] = tlsSecret
+		}
+
+		for _, hostname := range tls.Hosts {
+			// default secret
+			if len(hostname) == 0 {
+				hostToSecretMap[""] = tlsSecret
+			} else {
+				hostToSecretMap[hostname] = tlsSecret
+			}
+		}
+	}
+	return hostToSecretMap
+}
+
+func newCert(secretID secretIdentifier, cert *string) network.ApplicationGatewaySslCertificate {
+	return network.ApplicationGatewaySslCertificate{
+		Etag: to.StringPtr("*"),
+		Name: to.StringPtr(secretID.secretFullName()),
+		ApplicationGatewaySslCertificatePropertiesFormat: &network.ApplicationGatewaySslCertificatePropertiesFormat{
+			Data:     cert,
+			Password: to.StringPtr("msazure"),
+		},
+	}
+}

--- a/pkg/appgw/certificates_test.go
+++ b/pkg/appgw/certificates_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Testing function newHostToSecretMap", func() {
 		cb := makeConfigBuilderTestFixture(nil)
 		ingress := makeIngressFixture()
 		hostnameSecretIDMap := cb.newHostToSecretMap(ingress)
-		actualSecret, actualSecretID := cb.getCertificateV1(ingress, host1, hostnameSecretIDMap)
+		actualSecret, actualSecretID := cb.getCertificate(ingress, host1, hostnameSecretIDMap)
 
 		It("should have generated the expected secret", func() {
 			Expect(*actualSecret).To(Equal("eHl6"))

--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -1,0 +1,16 @@
+package appgw
+
+import "k8s.io/api/extensions/v1beta1"
+
+func (builder *appGwConfigBuilder) getListenerConfigs(ingressList []*v1beta1.Ingress) map[frontendListenerIdentifier]*frontendListenerAzureConfig {
+	httpListenersAzureConfigMap := make(map[frontendListenerIdentifier]*frontendListenerAzureConfig)
+
+ 	for _, ingress := range ingressList {
+		_, _, configMap := builder.processIngressRules(ingress)
+		for k, v := range configMap {
+			httpListenersAzureConfigMap[k] = v
+		}
+	}
+
+ 	return httpListenersAzureConfigMap
+}

--- a/pkg/appgw/http_listeners.go
+++ b/pkg/appgw/http_listeners.go
@@ -15,28 +15,6 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
-func (builder *appGwConfigBuilder) getCertificate(ingressKey string, hostname string) (*string, *secretIdentifier) {
-	_, exists := builder.ingressKeyHostnameSecretIDMap[ingressKey]
-	if !exists {
-		return nil, nil
-	}
-	secID, exists := builder.ingressKeyHostnameSecretIDMap[ingressKey][hostname]
-	if !exists {
-		// check if wildcard exists
-		secID, exists = builder.ingressKeyHostnameSecretIDMap[ingressKey][""]
-	}
-	if !exists {
-		// no wildcard or matched certificate
-		return nil, nil
-	}
-	cert, exists := builder.secretIDCertificateMap[secID]
-	if !exists {
-		// secret referred does not correspond to a certificate
-		return nil, nil
-	}
-	return cert, &secID
-}
-
 func (builder *appGwConfigBuilder) HTTPListeners(ingressList [](*v1beta1.Ingress)) (ConfigBuilder, error) {
 	frontendListeners := utils.NewUnorderedSet()
 	frontendPortsSet := utils.NewUnorderedSet()
@@ -88,7 +66,7 @@ func (builder *appGwConfigBuilder) HTTPListeners(ingressList [](*v1beta1.Ingress
 			}
 
 			httpsAvailable := false
-			cert, secID := builder.getCertificate(ingressKey, rule.Host)
+			cert, secID := builder.getCertificate(ingress, rule.Host, hostnameSecretIDMap)
 			if cert != nil {
 				httpsAvailable = true
 			}

--- a/pkg/appgw/ingress_rules.go
+++ b/pkg/appgw/ingress_rules.go
@@ -1,0 +1,55 @@
+package appgw
+
+import (
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+// processIngressRules creates the sets of front end listeners and ports, and a map of azure config per listener for the given ingress.
+func (builder *appGwConfigBuilder) processIngressRules(ingress *v1beta1.Ingress) (utils.UnorderedSet, utils.UnorderedSet, map[frontendListenerIdentifier]*frontendListenerAzureConfig) {
+	frontendListeners := utils.NewUnorderedSet()
+	frontendPorts := utils.NewUnorderedSet()
+
+	ingressHostnameSecretIDMap := builder.newHostToSecretMap(ingress)
+	azListenerConfigs := make(map[frontendListenerIdentifier]*frontendListenerAzureConfig)
+
+	for _, rule := range ingress.Spec.Rules {
+		if rule.HTTP == nil {
+			// skip no http rule
+			continue
+		}
+
+		cert, secID := builder.getCertificate(ingress, rule.Host, ingressHostnameSecretIDMap)
+		httpsAvailable := cert != nil
+
+		// If a cert is a available it is implied that we should enable only HTTPS.
+		// TODO: Once we introduce an `ssl-redirect` annotation we should enable HTTP for HTTPS rules as well, with the correct SSL redirect configurations setup.
+		if httpsAvailable {
+			listenerIDHTTPS := generateFrontendListenerID(&rule, network.HTTPS, nil)
+			frontendListeners.Insert(listenerIDHTTPS)
+			frontendPorts.Insert(listenerIDHTTPS.FrontendPort)
+
+			felAzConfig := &frontendListenerAzureConfig{
+				Protocol:                     network.HTTPS,
+				Secret:                       *secID,
+				SslRedirectConfigurationName: generateSSLRedirectConfigurationName(ingress.Namespace, ingress.Name),
+			}
+			azListenerConfigs[listenerIDHTTPS] = felAzConfig
+
+		}
+
+		if annotations.IsSslRedirect(ingress) || !httpsAvailable {
+			// Enable HTTP only if HTTPS has not been specified or if an SSL-redirect annotation has been set to `true`.
+			listenerIDHTTP := generateFrontendListenerID(&rule, network.HTTP, nil)
+			frontendListeners.Insert(listenerIDHTTP)
+			frontendPorts.Insert(listenerIDHTTP.FrontendPort)
+			felAzConfig := &frontendListenerAzureConfig{
+				Protocol: network.HTTP,
+			}
+			azListenerConfigs[listenerIDHTTP] = felAzConfig
+		}
+	}
+	return frontendListeners, frontendPorts, azListenerConfigs
+}

--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -1,0 +1,165 @@
+package appgw
+
+import (
+	"testing"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+func TestIngressRules(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test parsing of ingress rules")
+}
+
+var _ = Describe("Process ingress rules, listeners, and ports", func() {
+	port80 := int32(80)
+	port443 := int32(443)
+
+	expectedListener80 := frontendListenerIdentifier{
+		FrontendPort: port80,
+		HostName:     testFixturesHost,
+	}
+
+	expectedListenerAzConfigNoSSL := frontendListenerAzureConfig{
+		Protocol: "Http",
+		Secret: secretIdentifier{
+			Namespace: "",
+			Name:      "",
+		},
+		SslRedirectConfigurationName: "",
+	}
+
+	expectedListener443 := frontendListenerIdentifier{
+		FrontendPort: 443,
+		HostName:     testFixturesHost,
+	}
+
+	expectedListenerAzConfigSSL := frontendListenerAzureConfig{
+		Protocol: "Https",
+		Secret: secretIdentifier{
+			Namespace: testFixturesNamespace,
+			Name:      testFixturesNameOfSecret,
+		},
+		SslRedirectConfigurationName: agPrefix + "-" +
+			testFixturesNamespace +
+			"-" +
+			testFixturesName +
+			"-sslr",
+	}
+
+	Context("ingress rules without certificates", func() {
+		certs := getCertsTestFixture()
+		cb := makeConfigBuilderTestFixture(&certs)
+		ingress := makeIngressFixture()
+		ingressList := []*v1beta1.Ingress{ingress}
+		httpListenersAzureConfigMap := cb.getListenerConfigs(ingressList)
+
+		// Ensure there are no certs
+		ingress.Spec.TLS = nil
+
+		// !! Action !!
+		frontendListeners, frontendPorts, _ := cb.processIngressRules(ingress)
+
+		// Verify front end listeners
+		It("should have correct count of frontend listeners", func() {
+			Expect(len(frontendPorts.ToSlice())).To(Equal(1))
+		})
+		It("should have a listener on port 80", func() {
+			actualListener := (frontendListeners.ToSlice()[0]).(frontendListenerIdentifier)
+			Expect(actualListener).To(Equal(expectedListener80))
+		})
+
+		// Verify front end ports
+		It("should have correct count of front end ports", func() {
+			Expect(len(frontendPorts.ToSlice())).To(Equal(1))
+		})
+
+		It("should have one port 80", func() {
+			actualPort := frontendPorts.ToSlice()[0]
+			Expect(actualPort).To(Equal(port80))
+		})
+
+		// check the request routing rules
+		It("should have no request routing rules", func() {
+			Expect(cb.appGwConfig.RequestRoutingRules).To(BeNil())
+		})
+
+		It("should construct the App Gateway listeners correctly without SSL", func() {
+			azConfigMapKeys := getMapKeys(&httpListenersAzureConfigMap)
+			Expect(len(azConfigMapKeys)).To(Equal(2))
+			Expect(azConfigMapKeys).To(ContainElement(expectedListener80))
+
+			actualVal := httpListenersAzureConfigMap[expectedListener80]
+			Expect(*actualVal).To(Equal(expectedListenerAzConfigNoSSL))
+		})
+	})
+
+	Context("ingress rules with certificates", func() {
+		certs := getCertsTestFixture()
+		cb := makeConfigBuilderTestFixture(&certs)
+		ingress := makeIngressFixture()
+		ingressList := []*v1beta1.Ingress{ingress}
+		httpListenersAzureConfigMap := cb.getListenerConfigs(ingressList)
+
+		It("should configure App Gateway listeners correctly with SSL", func() {
+			azConfigMapKeys := getMapKeys(&httpListenersAzureConfigMap)
+			Expect(len(azConfigMapKeys)).To(Equal(2))
+			Expect(azConfigMapKeys).To(ContainElement(expectedListener443))
+
+			actualVal := httpListenersAzureConfigMap[expectedListener443]
+			Expect(*actualVal).To(Equal(expectedListenerAzConfigSSL))
+		})
+	})
+
+	Context("with attached certificates", func() {
+		certs := getCertsTestFixture()
+		cb := makeConfigBuilderTestFixture(&certs)
+		ingress := makeIngressFixture()
+		ingress.Annotations[annotations.SslRedirectKey] = "one/two/three"
+
+		// !! Action !!
+		frontendListeners, frontendPorts, _ := cb.processIngressRules(ingress)
+
+		ingressList := []*v1beta1.Ingress{ingress}
+		httpListenersAzureConfigMap := cb.getListenerConfigs(ingressList)
+
+		It("should have correct number of front end listener", func() {
+			Expect(len(frontendListeners.ToSlice())).To(Equal(1))
+		})
+		It("should have correct number of front end ports", func() {
+			Expect(len(frontendPorts.ToSlice())).To(Equal(1))
+		})
+		It("should have a listener on port 443", func() {
+			actualListener := (frontendListeners.ToSlice()[0]).(frontendListenerIdentifier)
+			Expect(actualListener.FrontendPort).To(Equal(port443))
+		})
+		It("should have one port 443", func() {
+			actualPort := frontendPorts.ToSlice()[0]
+			Expect(actualPort).To(Equal(port443))
+		})
+
+		It("should have no request routing rules ", func() {
+			Expect(cb.appGwConfig.RequestRoutingRules).To(BeNil())
+		})
+
+		It("should configure App Gateway listeners correctly", func() {
+			azConfigMapKeys := getMapKeys(&httpListenersAzureConfigMap)
+			Expect(len(azConfigMapKeys)).To(Equal(1))
+			Expect(azConfigMapKeys[0].FrontendPort).To(Equal(port443))
+
+			actualVal := httpListenersAzureConfigMap[azConfigMapKeys[0]]
+			Expect(*actualVal).To(Equal(expectedListenerAzConfigSSL))
+		})
+	})
+})
+
+func getMapKeys(m *map[frontendListenerIdentifier]*frontendListenerAzureConfig) []frontendListenerIdentifier {
+	keys := make([]frontendListenerIdentifier, 0, len(*m))
+	for k := range *m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -102,6 +102,11 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 		cb := makeConfigBuilderTestFixture(&certs)
 		ingress := makeIngressFixture()
 		ingressList := []*v1beta1.Ingress{ingress}
+		It("should have setup tests with some TLS certs", func() {
+			Ω(len(ingress.Spec.TLS)).Should(BeNumerically(">=", 2))
+		})
+
+		// !! Action !!
 		httpListenersAzureConfigMap := cb.getListenerConfigs(ingressList)
 
 		It("should configure App Gateway listeners correctly with SSL", func() {


### PR DESCRIPTION
This PR is a chunk of the larger refactor from PR https://github.com/Azure/application-gateway-kubernetes-ingress/pull/156

In this PR:
  - we create a new file - `frontend_listeners.go` with function `getListenerConfigs`, which constructs listener config for App Gwy from the given list of Ingresses -- this file will be fleshed out in following commits including unit tests for `frontend_listeners`
  - we create new file `ingress_rules.go`, which introduces `processIngressRules`.  This function constructs the sets of front end listeners, ports and the corresponding Azure Config for these listeners.
  - with these changes we also all uses of the old version of `getCertificate` (and delete the code) to the new `getCertificate`, which was introduced with https://github.com/Azure/application-gateway-kubernetes-ingress/pull/172
  - tests