### PR TITLE
All generated prop names must be <= 80 characters and be unique

### DIFF
--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -68,27 +68,27 @@ func governor(val string) string {
 }
 
 func (s serviceIdentifier) serviceFullName() string {
-	return fmt.Sprintf("%v-%v", s.Namespace, s.Name)
+	return governor(fmt.Sprintf("%v-%v", s.Namespace, s.Name))
 }
 
 func (s serviceIdentifier) serviceKey() string {
-	return fmt.Sprintf("%v/%v", s.Namespace, s.Name)
+	return governor(fmt.Sprintf("%v/%v", s.Namespace, s.Name))
 }
 
 func (s secretIdentifier) secretKey() string {
-	return fmt.Sprintf("%v/%v", s.Namespace, s.Name)
+	return governor(fmt.Sprintf("%v/%v", s.Namespace, s.Name))
 }
 
 func (s secretIdentifier) secretFullName() string {
-	return fmt.Sprintf("%v-%v", s.Namespace, s.Name)
+	return governor(fmt.Sprintf("%v-%v", s.Namespace, s.Name))
 }
 
 func getResourceKey(namespace, name string) string {
-	return fmt.Sprintf("%v/%v", namespace, name)
+	return governor(fmt.Sprintf("%v/%v", namespace, name))
 }
 
 func generateHTTPSettingsName(serviceName string, servicePort string, backendPortNo int32, ingress string) string {
-	return fmt.Sprintf("%s-%v-%v-bp-%v-%s", agPrefix, serviceName, servicePort, backendPortNo, ingress)
+	return governor(fmt.Sprintf("%s-%v-%v-bp-%v-%s", agPrefix, serviceName, servicePort, backendPortNo, ingress))
 }
 
 func generateProbeName(serviceName string, servicePort string, ingress string) string {
@@ -96,27 +96,27 @@ func generateProbeName(serviceName string, servicePort string, ingress string) s
 }
 
 func generateAddressPoolName(serviceName string, servicePort string, backendPortNo int32) string {
-	return fmt.Sprintf("%s-%v-%v-bp-%v-pool", agPrefix, serviceName, servicePort, backendPortNo)
+	return governor(fmt.Sprintf("%s-%v-%v-bp-%v-pool", agPrefix, serviceName, servicePort, backendPortNo))
 }
 
 func generateFrontendPortName(port int32) string {
-	return fmt.Sprintf("%s-fp-%v", agPrefix, port)
+	return governor(fmt.Sprintf("%s-fp-%v", agPrefix, port))
 }
 
 func generateHTTPListenerName(frontendListenerID frontendListenerIdentifier) string {
-	return fmt.Sprintf("%s-%v-%v-fl", agPrefix, frontendListenerID.HostName, frontendListenerID.FrontendPort)
+	return governor(fmt.Sprintf("%s-%v-%v-fl", agPrefix, frontendListenerID.HostName, frontendListenerID.FrontendPort))
 }
 
 func generateURLPathMapName(frontendListenerID frontendListenerIdentifier) string {
-	return fmt.Sprintf("%s-%v-%v-url", agPrefix, frontendListenerID.HostName, frontendListenerID.FrontendPort)
+	return governor(fmt.Sprintf("%s-%v-%v-url", agPrefix, frontendListenerID.HostName, frontendListenerID.FrontendPort))
 }
 
 func generateRequestRoutingRuleName(frontendListenerID frontendListenerIdentifier) string {
-	return fmt.Sprintf("%s-%v-%v-rr", agPrefix, frontendListenerID.HostName, frontendListenerID.FrontendPort)
+	return governor(fmt.Sprintf("%s-%v-%v-rr", agPrefix, frontendListenerID.HostName, frontendListenerID.FrontendPort))
 }
 
 func generateSSLRedirectConfigurationName(namespace, ingress string) string {
-	return fmt.Sprintf("%s-%s-%s-sslr", agPrefix, namespace, ingress)
+	return governor(fmt.Sprintf("%s-%s-%s-sslr", agPrefix, namespace, ingress))
 }
 
 const defaultBackendHTTPSettingsName = agPrefix + "-defaulthttpsetting"

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -68,19 +68,19 @@ func governor(val string) string {
 }
 
 func (s serviceIdentifier) serviceFullName() string {
-	return governor(fmt.Sprintf("%v-%v", s.Namespace, s.Name))
+	return fmt.Sprintf("%v-%v", s.Namespace, s.Name)
 }
 
 func (s serviceIdentifier) serviceKey() string {
-	return governor(fmt.Sprintf("%v/%v", s.Namespace, s.Name))
+	return fmt.Sprintf("%v/%v", s.Namespace, s.Name)
 }
 
 func (s secretIdentifier) secretKey() string {
-	return governor(fmt.Sprintf("%v/%v", s.Namespace, s.Name))
+	return fmt.Sprintf("%v/%v", s.Namespace, s.Name)
 }
 
 func (s secretIdentifier) secretFullName() string {
-	return governor(fmt.Sprintf("%v-%v", s.Namespace, s.Name))
+	return fmt.Sprintf("%v-%v", s.Namespace, s.Name)
 }
 
 func getResourceKey(namespace, name string) string {

--- a/pkg/appgw/internaltypes_test.go
+++ b/pkg/appgw/internaltypes_test.go
@@ -124,4 +124,41 @@ var _ = Describe("Test string key generators", func() {
 			Expect(actual).To(Equal(expected), fmt.Sprintf("Expected name: %s", expected))
 		})
 	})
+	Context("test string key generator too long", func() {
+		It("preserves keys of length 80 characters or less", func() {
+			namespace := "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZAB"
+			// ensure this is setup correctly
+			Ω(len(namespace)).Should(BeNumerically("==", 80))
+			name := namespace
+			serviceName := namespace
+			servicePort := namespace
+			backendPortNo := int32(8888)
+			ingress := namespace
+			port := int32(88)
+			felID := frontendListenerIdentifier{
+				FrontendPort: port,
+				HostName:     namespace,
+			}
+			names := []string{
+				getResourceKey(namespace, name),
+				generateHTTPSettingsName(serviceName, servicePort, backendPortNo, ingress),
+				generateProbeName(serviceName, servicePort, ingress),
+				generateAddressPoolName(serviceName, servicePort, backendPortNo),
+				generateFrontendPortName(port),
+				generateHTTPListenerName(felID),
+				generateURLPathMapName(felID),
+				generateRequestRoutingRuleName(felID),
+				generateSSLRedirectConfigurationName(namespace, ingress),
+			}
+			Expect(len(names)).To(Equal(9))
+
+			// Ensure the strings are unique
+			nameSet := make(map[string]interface{})
+			for _, name := range names {
+				Ω(len(name)).Should(BeNumerically("<=", 80))
+				nameSet[name] = nil
+			}
+			Expect(len(nameSet)).To(Equal(len(names)))
+		})
+	})
 })

--- a/pkg/appgw/internaltypes_test.go
+++ b/pkg/appgw/internaltypes_test.go
@@ -84,8 +84,8 @@ var _ = Describe("Test string key generators", func() {
 		})
 	})
 
-	Context("test string key generator too long", func() {
-		It("preserves keys of length 80 characters or less", func() {
+	Context("test string key generator with long strings", func() {
+		It("should create correct keys when these are over 80 characters long", func() {
 			actual := governor("this-is-the-key")
 			expected := "this-is-the-key"
 			Expect(actual).To(Equal(expected), fmt.Sprintf("Expected name: %s", expected))
@@ -124,41 +124,43 @@ var _ = Describe("Test string key generators", func() {
 			Expect(actual).To(Equal(expected), fmt.Sprintf("Expected name: %s", expected))
 		})
 	})
-	Context("test string key generator too long", func() {
-		It("preserves keys of length 80 characters or less", func() {
-			veryLongString := "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZAB"
+	Context("test string key generator with very long strings", func() {
+		veryLongString := "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZAB"
+		namespace := veryLongString
+		name := veryLongString
+		serviceName := veryLongString
+		servicePort := veryLongString
+		backendPortNo := int32(8888)
+		ingress := veryLongString
+		port := int32(88)
+		felID := frontendListenerIdentifier{
+			FrontendPort: port,
+			HostName:     namespace,
+		}
+		names := []string{
+			getResourceKey(namespace, name),
+			generateHTTPSettingsName(serviceName, servicePort, backendPortNo, ingress),
+			generateProbeName(serviceName, servicePort, ingress),
+			generateAddressPoolName(serviceName, servicePort, backendPortNo),
+			generateFrontendPortName(port),
+			generateHTTPListenerName(felID),
+			generateURLPathMapName(felID),
+			generateRequestRoutingRuleName(felID),
+			generateSSLRedirectConfigurationName(namespace, ingress),
+		}
+		It("ensure test is setup correctly", func(){
 			// ensure this is setup correctly
 			Ω(len(veryLongString)).Should(BeNumerically(">=", 80))
-			namespace := veryLongString
-			name := veryLongString
-			serviceName := veryLongString
-			servicePort := veryLongString
-			backendPortNo := int32(8888)
-			ingress := veryLongString
-			port := int32(88)
-			felID := frontendListenerIdentifier{
-				FrontendPort: port,
-				HostName:     namespace,
-			}
-			names := []string{
-				getResourceKey(namespace, name),
-				generateHTTPSettingsName(serviceName, servicePort, backendPortNo, ingress),
-				generateProbeName(serviceName, servicePort, ingress),
-				generateAddressPoolName(serviceName, servicePort, backendPortNo),
-				generateFrontendPortName(port),
-				generateHTTPListenerName(felID),
-				generateURLPathMapName(felID),
-				generateRequestRoutingRuleName(felID),
-				generateSSLRedirectConfigurationName(namespace, ingress),
-			}
 			Expect(len(names)).To(Equal(9))
-
+		})
+		It("should ensure that all names generated are no longer than 80 characters and are unique", func() {
 			// Ensure the strings are unique
 			nameSet := make(map[string]interface{})
 			for _, name := range names {
 				Ω(len(name)).Should(BeNumerically("<=", 80))
 				nameSet[name] = nil
 			}
+			// Uniqueness test
 			Expect(len(nameSet)).To(Equal(len(names)))
 		})
 	})

--- a/pkg/appgw/internaltypes_test.go
+++ b/pkg/appgw/internaltypes_test.go
@@ -126,14 +126,15 @@ var _ = Describe("Test string key generators", func() {
 	})
 	Context("test string key generator too long", func() {
 		It("preserves keys of length 80 characters or less", func() {
-			namespace := "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZAB"
+			veryLongString := "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZAB"
 			// ensure this is setup correctly
-			Ω(len(namespace)).Should(BeNumerically("==", 80))
-			name := namespace
-			serviceName := namespace
-			servicePort := namespace
+			Ω(len(veryLongString)).Should(BeNumerically(">=", 80))
+			namespace := veryLongString
+			name := veryLongString
+			serviceName := veryLongString
+			servicePort := veryLongString
 			backendPortNo := int32(8888)
-			ingress := namespace
+			ingress := veryLongString
 			port := int32(88)
 			felID := frontendListenerIdentifier{
 				FrontendPort: port,


### PR DESCRIPTION
Applying the new `governor` function to all property name generators.
Also ensuring with a unit test that the output of these functions is unique.