### PR TITLE
tests: Rename functions creating test fixtures so they start with new in lieu of make

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -154,7 +154,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		},
 	}
 
-	pod := makePodFixture(serviceName, ingressNS, backendName, backendPort)
+	pod := newPodFixture(serviceName, ingressNS, backendName, backendPort)
 
 	go_flag.Lookup("logtostderr").Value.Set("true")
 	go_flag.Set("v", "3")

--- a/pkg/appgw/certificates_test.go
+++ b/pkg/appgw/certificates_test.go
@@ -40,8 +40,8 @@ var _ = Describe("Testing function newHostToSecretMap", func() {
 	}
 
 	Context("Test fetching secrets from ingress with TLS spec", func() {
-		cb := makeConfigBuilderTestFixture(nil)
-		ingress := makeIngressFixture()
+		cb := newConfigBuilderFixture(nil)
+		ingress := newIngressFixture()
 
 		actualHostToSecretMap := cb.newHostToSecretMap(ingress)
 
@@ -67,8 +67,8 @@ var _ = Describe("Testing function newHostToSecretMap", func() {
 	})
 
 	Context("Test obtaining a single certificate for an existing host", func() {
-		cb := makeConfigBuilderTestFixture(nil)
-		ingress := makeIngressFixture()
+		cb := newConfigBuilderFixture(nil)
+		ingress := newIngressFixture()
 		hostnameSecretIDMap := cb.newHostToSecretMap(ingress)
 		actualSecret, actualSecretID := cb.getCertificate(ingress, host1, hostnameSecretIDMap)
 

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -22,19 +22,19 @@ func TestHealthProbes(t *testing.T) {
 
 var _ = Describe("configure App Gateway health probes", func() {
 	Context("create probes", func() {
-		cb := makeConfigBuilderTestFixture(nil)
+		cb := newConfigBuilderFixture(nil)
 
-		endpoints := makeEndpointsFixture()
+		endpoints := newEndpointsFixture()
 		_ = cb.k8sContext.Caches.Endpoints.Add(endpoints)
 
-		service := makeServiceFixture(*makeServicePorts()...)
+		service := newServiceFixture(*newServicePortsFixture()...)
 		_ = cb.k8sContext.Caches.Service.Add(service)
 
-		pod := makePodFixture(testFixturesServiceName, testFixturesNamespace, testFixturesContainerName, testFixturesContainerPort)
+		pod := newPodFixture(testFixturesServiceName, testFixturesNamespace, testFixturesContainerName, testFixturesContainerPort)
 		_ = cb.k8sContext.Caches.Pods.Add(pod)
 
 		ingressList := []*v1beta1.Ingress{
-			makeIngressFixture(),
+			newIngressFixture(),
 		}
 
 		// !! Action !!

--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -51,9 +51,9 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 	}
 
 	Context("ingress rules without certificates", func() {
-		certs := getCertsTestFixture()
-		cb := makeConfigBuilderTestFixture(&certs)
-		ingress := makeIngressFixture()
+		certs := newCertsFixture()
+		cb := newConfigBuilderFixture(&certs)
+		ingress := newIngressFixture()
 		ingressList := []*v1beta1.Ingress{ingress}
 		httpListenersAzureConfigMap := cb.getListenerConfigs(ingressList)
 
@@ -98,9 +98,9 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 	})
 
 	Context("ingress rules with certificates", func() {
-		certs := getCertsTestFixture()
-		cb := makeConfigBuilderTestFixture(&certs)
-		ingress := makeIngressFixture()
+		certs := newCertsFixture()
+		cb := newConfigBuilderFixture(&certs)
+		ingress := newIngressFixture()
 		ingressList := []*v1beta1.Ingress{ingress}
 		It("should have setup tests with some TLS certs", func() {
 			Ω(len(ingress.Spec.TLS)).Should(BeNumerically(">=", 2))
@@ -120,9 +120,9 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 	})
 
 	Context("with attached certificates", func() {
-		certs := getCertsTestFixture()
-		cb := makeConfigBuilderTestFixture(&certs)
-		ingress := makeIngressFixture()
+		certs := newCertsFixture()
+		cb := newConfigBuilderFixture(&certs)
+		ingress := newIngressFixture()
 		ingress.Annotations[annotations.SslRedirectKey] = "one/two/three"
 
 		// !! Action !!

--- a/pkg/appgw/test_fixtures.go
+++ b/pkg/appgw/test_fixtures.go
@@ -34,7 +34,7 @@ const (
 	testFixturesSelectorValue = "frontend"
 )
 
-func makeAppGwyConfigTestFixture() network.ApplicationGatewayPropertiesFormat {
+func newAppGwyConfigFixture() network.ApplicationGatewayPropertiesFormat {
 	feIPConfigs := []network.ApplicationGatewayFrontendIPConfiguration{
 		{
 			Name: to.StringPtr("xx3"),
@@ -54,7 +54,7 @@ func makeAppGwyConfigTestFixture() network.ApplicationGatewayPropertiesFormat {
 	}
 }
 
-func makeSecretStoreTestFixture(toAdd *map[string]interface{}) k8scontext.SecretsKeeper {
+func newSecretStoreFixture(toAdd *map[string]interface{}) k8scontext.SecretsKeeper {
 	c := cache.NewThreadSafeStore(cache.Indexers{}, cache.Indices{})
 	ingressKey := getResourceKey(testFixturesNamespace, testFixturesName)
 	c.Add(ingressKey, testFixturesHost)
@@ -77,9 +77,9 @@ func keyFunc(obj interface{}) (string, error) {
 	return fmt.Sprintf("%s/%s", testFixturesNamespace, testFixturesServiceName), nil
 }
 
-func makeConfigBuilderTestFixture(certs *map[string]interface{}) appGwConfigBuilder {
+func newConfigBuilderFixture(certs *map[string]interface{}) appGwConfigBuilder {
 	cb := appGwConfigBuilder{
-		appGwConfig:            makeAppGwyConfigTestFixture(),
+		appGwConfig:            newAppGwyConfigFixture(),
 		serviceBackendPairMap:  make(map[backendIdentifier]serviceBackendPortPair),
 		backendHTTPSettingsMap: make(map[backendIdentifier]*network.ApplicationGatewayBackendHTTPSettings),
 		backendPoolMap:         make(map[backendIdentifier]*network.ApplicationGatewayBackendAddressPool),
@@ -90,7 +90,7 @@ func makeConfigBuilderTestFixture(certs *map[string]interface{}) appGwConfigBuil
 				Service:   cache.NewStore(keyFunc),
 				Pods:      cache.NewStore(keyFunc),
 			},
-			CertificateSecretStore: makeSecretStoreTestFixture(certs),
+			CertificateSecretStore: newSecretStoreFixture(certs),
 		},
 		probesMap: make(map[backendIdentifier]*network.ApplicationGatewayProbe),
 	}
@@ -98,7 +98,7 @@ func makeConfigBuilderTestFixture(certs *map[string]interface{}) appGwConfigBuil
 	return cb
 }
 
-func getCertsTestFixture() map[string]interface{} {
+func newCertsFixture() map[string]interface{} {
 	toAdd := make(map[string]interface{})
 
 	secretsIdent := secretIdentifier{
@@ -114,7 +114,7 @@ func getCertsTestFixture() map[string]interface{} {
 	return toAdd
 }
 
-func makeIngressBackendFixture(serviceName string, port int32) *v1beta1.IngressBackend {
+func newIngressBackendFixture(serviceName string, port int32) *v1beta1.IngressBackend {
 	return &v1beta1.IngressBackend{
 		ServiceName: serviceName,
 		ServicePort: intstr.IntOrString{
@@ -123,7 +123,7 @@ func makeIngressBackendFixture(serviceName string, port int32) *v1beta1.IngressB
 	}
 }
 
-func makeIngressRuleFixture(host string, urlPath string, be v1beta1.IngressBackend) v1beta1.IngressRule {
+func newIngressRuleFixture(host string, urlPath string, be v1beta1.IngressBackend) v1beta1.IngressRule {
 	return v1beta1.IngressRule{
 		Host: host,
 		IngressRuleValue: v1beta1.IngressRuleValue{
@@ -139,15 +139,15 @@ func makeIngressRuleFixture(host string, urlPath string, be v1beta1.IngressBacke
 	}
 }
 
-func makeIngressFixture() *v1beta1.Ingress {
-	be80 := makeIngressBackendFixture(testFixturesServiceName, 80)
-	be443 := makeIngressBackendFixture(testFixturesServiceName, 443)
+func newIngressFixture() *v1beta1.Ingress {
+	be80 := newIngressBackendFixture(testFixturesServiceName, 80)
+	be443 := newIngressBackendFixture(testFixturesServiceName, 443)
 
 	return &v1beta1.Ingress{
 		Spec: v1beta1.IngressSpec{
 			Rules: []v1beta1.IngressRule{
-				makeIngressRuleFixture(testFixturesHost, testFixturesURLPath, *be80),
-				makeIngressRuleFixture(testFixturesHost, testFixturesURLPath, *be443),
+				newIngressRuleFixture(testFixturesHost, testFixturesURLPath, *be80),
+				newIngressRuleFixture(testFixturesHost, testFixturesURLPath, *be443),
 			},
 			TLS: []v1beta1.IngressTLS{
 				{
@@ -175,7 +175,7 @@ func makeIngressFixture() *v1beta1.Ingress {
 	}
 }
 
-func makeServicePorts() *[]v1.ServicePort {
+func newServicePortsFixture() *[]v1.ServicePort {
 	httpPort := v1.ServicePort{
 		// The name of this port within the service. This must be a DNS_LABEL.
 		// All ports within a ServiceSpec must have unique names. This maps to
@@ -239,7 +239,7 @@ func makeServicePorts() *[]v1.ServicePort {
 	}
 }
 
-func makeProbeFixture(containerName string) *v1.Probe {
+func newProbeFixture(containerName string) *v1.Probe {
 	return &v1.Probe{
 		TimeoutSeconds:   5,
 		FailureThreshold: 3,
@@ -258,7 +258,7 @@ func makeProbeFixture(containerName string) *v1.Probe {
 	}
 }
 
-func makePodFixture(serviceName string, ingressNamespace string, containerName string, containerPort int32) *v1.Pod {
+func newPodFixture(serviceName string, ingressNamespace string, containerName string, containerPort int32) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
@@ -278,14 +278,14 @@ func makePodFixture(serviceName string, ingressNamespace string, containerName s
 							ContainerPort: containerPort,
 						},
 					},
-					ReadinessProbe: makeProbeFixture(containerName),
+					ReadinessProbe: newProbeFixture(containerName),
 				},
 			},
 		},
 	}
 }
 
-func makeServiceFixture(servicePorts ...v1.ServicePort) *v1.Service {
+func newServiceFixture(servicePorts ...v1.ServicePort) *v1.Service {
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testFixturesServiceName,
@@ -307,7 +307,7 @@ func makeServiceFixture(servicePorts ...v1.ServicePort) *v1.Service {
 	}
 }
 
-func makeEndpointsFixture() *v1.Endpoints {
+func newEndpointsFixture() *v1.Endpoints {
 	return &v1.Endpoints{
 		Subsets: []v1.EndpointSubset{
 			{


### PR DESCRIPTION
Following up on a comment (https://github.com/Azure/application-gateway-kubernetes-ingress/pull/180#discussion_r284369840) - renaming all test fixture creators so they start with `new*` in lieu of `make*`

At some point we should move these functions in their own namespace and even further simplify the names.

No functional code changes in this PR.