### PR TITLE
glog: Flush before exiting main()

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -43,6 +43,8 @@ var (
 )
 
 func main() {
+	// Log output is buffered... Calling Flush before exiting guarantees all log output is written.
+	defer glog.Flush()
 	if err := flags.Parse(os.Args); err != nil {
 		glog.Fatalf("Error parsing command line arguments: %v", err.Error())
 	}


### PR DESCRIPTION
Let's call `glog.Flush()` to ensure we don't miss log lines.

Documentation: https://godoc.org/github.com/golang/glog