### PR TITLE
Cleanup main.go & env_variables.go

### DIFF
--- a/cmd/appgw-ingress/env_variables.go
+++ b/cmd/appgw-ingress/env_variables.go
@@ -5,7 +5,11 @@
 
 package main
 
-import "os"
+import (
+	"os"
+
+	"github.com/golang/glog"
+)
 
 type envVariables struct {
 	SubscriptionID    string
@@ -15,12 +19,22 @@ type envVariables struct {
 	WatchNamespace    string
 }
 
-func newEnvVariables() envVariables {
-	return envVariables{
+func getEnvVars() envVariables {
+	env := envVariables{
 		SubscriptionID:    os.Getenv("APPGW_SUBSCRIPTION_ID"),
 		ResourceGroupName: os.Getenv("APPGW_RESOURCE_GROUP"),
 		AppGwName:         os.Getenv("APPGW_NAME"),
 		AuthLocation:      os.Getenv("AZURE_AUTH_LOCATION"),
 		WatchNamespace:    os.Getenv("KUBERNETES_WATCHNAMESPACE"),
 	}
+
+	if len(env.SubscriptionID) == 0 || len(env.ResourceGroupName) == 0 || len(env.AppGwName) == 0 || len(env.WatchNamespace) == 0 {
+		glog.Fatalf("Error while initializing values from environment. Please check helm configuration for missing values.")
+	}
+
+	if env.WatchNamespace == "" {
+		glog.Fatal("Error creating informers, namespace is not specified")
+	}
+
+	return env
 }


### PR DESCRIPTION
This merely rearranges sections of main.go and cleans up unnecessary constructs;

  - often times we use `glog.Fatalf("Error: %v", err.Error())`, which is unnecessary;  `glog.Fatal("Error:", err)` achieves the same
  - renamed `newEnvVariables` --> `getEnvVars` and moved validation there.
  - moved the waiting-on-Azure-auth block into its own func `waitForAzureAuth`
  - removed a few `for true {...}` -- `for {...}` does the same
  - replaced the last `for true { time.Sleep(1 * time.Minute) }` with an empty `select` -- the empty `select{}` will block indefinitely while yielding CPU, unlike `for` loops
  - removed the aliasing of the `flag` and `pflag`