### PR TITLE
appgw_test: Add a PublicIPAddress to tests

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -409,6 +409,11 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 				Name: to.StringPtr("*"),
 				Etag: to.StringPtr("*"),
 				ID:   to.StringPtr("*"),
+				ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &network.SubResource{
+						ID: to.StringPtr("x/y/z"),
+					},
+				},
 			},
 		}
 	})


### PR DESCRIPTION
In https://github.com/Azure/application-gateway-kubernetes-ingress/pull/156 we are getting a test, which explicitly requires a PublicIP address.

This PR adds one to the tests.