### PR TITLE
We need only one Ginkgo test launcher

### DIFF
--- a/pkg/appgw/certificates_test.go
+++ b/pkg/appgw/certificates_test.go
@@ -7,10 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestNewHostToSecretMap(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test newHostToSecretMap function")
-}
+// appgw_suite_test.go launches these Ginkgo tests
 
 var _ = Describe("Testing function newHostToSecretMap", func() {
 	const host1 = "ftp.contoso.com"

--- a/pkg/appgw/certificates_test.go
+++ b/pkg/appgw/certificates_test.go
@@ -1,8 +1,6 @@
 package appgw
 
 import (
-	"testing"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -10,10 +10,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 )
 
-func TestFrontendListeners(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test setting up SSL redirect annotations")
-}
+// appgw_suite_test.go launches these Ginkgo tests
 
 var _ = Describe("Process ingress rules and parse frontend listener configs", func() {
 

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -1,10 +1,8 @@
 package appgw
 
 import (
-	"github.com/Azure/go-autorest/autorest/to"
-	"testing"
-
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/extensions/v1beta1"

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -15,10 +15,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 )
 
-func TestHealthProbes(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test setting up App Gateway health probes")
-}
+// appgw_suite_test.go launches these Ginkgo tests
 
 var _ = Describe("configure App Gateway health probes", func() {
 	Context("create probes", func() {

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -6,8 +6,6 @@
 package appgw
 
 import (
-	"testing"
-
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"

--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -9,10 +9,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 )
 
-func TestIngressRules(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test parsing of ingress rules")
-}
+// appgw_suite_test.go launches these Ginkgo tests
 
 var _ = Describe("Process ingress rules, listeners, and ports", func() {
 	port80 := int32(80)

--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -1,8 +1,6 @@
 package appgw
 
 import (
-	"testing"
-
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pkg/appgw/internaltypes_test.go
+++ b/pkg/appgw/internaltypes_test.go
@@ -13,10 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestStringKeyGenerators(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test setting up App Gateway health probes")
-}
+// appgw_suite_test.go launches these Ginkgo test
 
 var _ = Describe("Test string key generators", func() {
 	veryLongString := "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZAB"

--- a/pkg/appgw/internaltypes_test.go
+++ b/pkg/appgw/internaltypes_test.go
@@ -7,7 +7,6 @@ package appgw
 
 import (
 	"fmt"
-	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
We don't need all these Ginkgo runners.
The following is sufficient for the entire package:
https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/pkg/appgw/appgw_suite_test.go#L10-L13
