### PR TITLE
appgw: Carving out frontend ports related functions in separate files

### DIFF
--- a/pkg/appgw/frontend_ports.go
+++ b/pkg/appgw/frontend_ports.go
@@ -1,0 +1,36 @@
+package appgw
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+func (builder *appGwConfigBuilder) getFrontendPorts(ingressList []*v1beta1.Ingress) *[]network.ApplicationGatewayFrontendPort {
+	allPorts := make(map[int32]interface{})
+	for _, ingress := range ingressList {
+		fePorts, _ := builder.processIngressRules(ingress)
+		for _, port := range fePorts.ToSlice() {
+			allPorts[port.(int32)] = nil
+		}
+	}
+
+	// fallback to default listener as placeholder if no listener is available
+	if len(allPorts) == 0 {
+		port := defaultFrontendListenerIdentifier().FrontendPort
+		allPorts[port] = nil
+	}
+
+	var frontendPorts []network.ApplicationGatewayFrontendPort
+	for port := range allPorts {
+		frontendPortName := generateFrontendPortName(port)
+		frontendPorts = append(frontendPorts, network.ApplicationGatewayFrontendPort{
+			Etag: to.StringPtr("*"),
+			Name: &frontendPortName,
+			ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
+				Port: to.Int32Ptr(port),
+			},
+		})
+	}
+	return &frontendPorts
+}

--- a/pkg/appgw/frontend_ports_test.go
+++ b/pkg/appgw/frontend_ports_test.go
@@ -1,0 +1,57 @@
+package appgw
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+// appgw_suite_test.go launches these Ginkgo tests
+
+var _ = Describe("Process ingress rules", func() {
+	Context("with many frontend ports", func() {
+		certs := newCertsFixture()
+		cb := newConfigBuilderFixture(&certs)
+
+		ingressList := []*v1beta1.Ingress{
+			newIngressFixture(),
+			newIngressFixture(),
+		}
+
+		ports := cb.getFrontendPorts(ingressList)
+
+		It("should have correct count of ports", func() {
+			Expect(len(*ports)).To(Equal(2))
+		})
+
+		It("should have port 80", func() {
+			expected := network.ApplicationGatewayFrontendPort{
+				ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
+					Port:              to.Int32Ptr(80),
+					ProvisioningState: nil,
+				},
+				Name: to.StringPtr("fp-80"),
+				Etag: to.StringPtr("*"),
+				Type: nil,
+				ID:   nil,
+			}
+			Expect(*ports).To(ContainElement(expected))
+		})
+
+		It("should have port 443", func() {
+			expected := network.ApplicationGatewayFrontendPort{
+				ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
+					Port:              to.Int32Ptr(443),
+					ProvisioningState: nil,
+				},
+				Name: to.StringPtr("fp-443"),
+				Etag: to.StringPtr("*"),
+				Type: nil,
+				ID:   nil,
+			}
+			Expect(*ports).To(ContainElement(expected))
+		})
+	})
+})


### PR DESCRIPTION
Two of the files from PR https://github.com/Azure/application-gateway-kubernetes-ingress/pull/156

This should make reviewing https://github.com/Azure/application-gateway-kubernetes-ingress/pull/156 easier.

This PR introduces a function called `getFrontendPorts()` which when given a list of K8s Ingresses, returns a list of `ApplicationGatewayFrontendPort` to be created / applied.