### PR TITLE
health_probes: Removing the use of UnorderedSet

### DIFF
--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -19,6 +19,7 @@ import (
 
 func (builder *appGwConfigBuilder) HealthProbesCollection(ingressList [](*v1beta1.Ingress)) (ConfigBuilder, error) {
 	backendIDs := make(map[backendIdentifier]interface{})
+
 	healthProbeCollection := make(map[string]network.ApplicationGatewayProbe)
 
 	for _, ingress := range ingressList {


### PR DESCRIPTION
Much like in https://github.com/Azure/application-gateway-kubernetes-ingress/pull/210 with this PR we remove the use of `UnorderedSet`

The goal is to simplify by using plain old maps and remove unnecessary type assertions.