### PR TITLE
BackendHTTPSettings: Ensure unique names

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -212,9 +212,9 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// Test the default backend HTTP settings.
-		Expect((*appGW.BackendHTTPSettingsCollection)[0]).To(Equal(defaultBackendHTTPSettings(appGwIdentifier.probeID(defaultProbeName))))
+		Expect(*appGW.BackendHTTPSettingsCollection).To(ContainElement(defaultBackendHTTPSettings(appGwIdentifier.probeID(defaultProbeName))))
 		// Test the ingress backend HTTP setting that we installed.
-		Expect((*appGW.BackendHTTPSettingsCollection)[1]).To(Equal(*httpSettings))
+		Expect(*appGW.BackendHTTPSettingsCollection).To(ContainElement(*httpSettings))
 	}
 
 	defaultBackendAddressPoolChecker := func(appGW *network.ApplicationGatewayPropertiesFormat) {

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -116,8 +116,9 @@ func (builder *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList [](
 	}
 
 	probeID := builder.appGwIdentifier.probeID(defaultProbeName)
-	httpSettingsCollection := make([](network.ApplicationGatewayBackendHTTPSettings), 0)
-	httpSettingsCollection = append(httpSettingsCollection, defaultBackendHTTPSettings(probeID))
+	httpSettingsCollection := make(map[string]network.ApplicationGatewayBackendHTTPSettings)
+	defaultBackend := defaultBackendHTTPSettings(probeID)
+	httpSettingsCollection[*defaultBackend.Name] = defaultBackend
 
 	// enforce single pair relationship between service port and backend port
 	for backendID, serviceBackendPairs := range serviceBackendPairsMap {
@@ -152,11 +153,16 @@ func (builder *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList [](
 			},
 		}
 		// other settings should come from annotations
-		httpSettingsCollection = append(httpSettingsCollection, httpSettings)
+		httpSettingsCollection[*httpSettings.Name] = httpSettings
 		builder.backendHTTPSettingsMap[backendID] = &httpSettings
 	}
 
-	builder.appGwConfig.BackendHTTPSettingsCollection = &httpSettingsCollection
+	backends := make([]network.ApplicationGatewayBackendHTTPSettings, 0)
+	for _, backend := range httpSettingsCollection {
+		backends = append(backends, backend)
+	}
+
+	builder.appGwConfig.BackendHTTPSettingsCollection = &backends
 
 	return builder, nil
 }


### PR DESCRIPTION
This change uses a map in lieu of a slice to ensure that we do not generate `BackendHTTPSettings` with the duplicate names.
When this happens ARM responds w/ the following error: 
```bash
W0528 18:16:17.978860   13648 controller.go:118] unable to send CreateOrUpdate request, error [network.ApplicationGatewaysClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidRequestFormat" Message="Cannot parse the request." Details=[{"code":"DuplicateResourceName","message":"Resource /subscriptions//resourceGroups//providers/Microsoft.Network/applicationGateways/ has two child resources with the same name (bp-default-websocket-service-80-8888-websocket-ingress)."}]]
```

One can get into such state w/ the following Ingress definition. (The use of duplicate backends is intentional and one should probably avoid this; but nevertheless this is valid YAML and a valid K8s Ingress): 

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: websocket-ingress
  annotations:
    kubernetes.io/ingress.class: azure/application-gateway
    appgw.ingress.kubernetes.io/ssl-redirect: "true"
spec:
  tls:
   - hosts:
     - ws.mis.li
     secretName: testsecret-tls
  rules:
    - host: ws.mis.li
      http:
        paths:
          - backend:
              serviceName: websocket-service
              servicePort: 80

    - host: x.mis.li
      http:
        paths:
          - path: /
            backend:
              serviceName: websocket-service
              servicePort: 80

    - host: y.mis.li
      http:
        paths:
          - path: /
            backend:
              serviceName: web-service
              servicePort: 80
```