### PR TITLE
rules: Handle slash path

### DIFF
--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -47,7 +47,7 @@ func (builder *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, rule *v1be
 		backendPoolSubResource := network.SubResource{ID: to.StringPtr(builder.appGwIdentifier.addressPoolID(*backendPool.Name))}
 		backendHTTPSettingsSubResource := network.SubResource{ID: to.StringPtr(builder.appGwIdentifier.httpSettingsID(*backendHTTPSettings.Name))}
 
-		if len(path.Path) == 0 || path.Path == "/*" {
+		if len(path.Path) == 0 || path.Path == "/*" || path.Path == "/" {
 			// this backend should be a default backend, catches all traffic
 			// check if it is a host-specific default backend
 			if rule.Host == listenerID.HostName {
@@ -97,7 +97,7 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 			// wildcard rule override the default backend
 			for pathIdx := range wildcardRule.HTTP.Paths {
 				path := &wildcardRule.HTTP.Paths[pathIdx]
-				if path.Path == "" || path.Path == "/*" {
+				if path.Path == "" || path.Path == "/*" || path.Path == "/" {
 					// look for default path
 					defBackend = &path.Backend
 				}


### PR DESCRIPTION
@marceldiass pointed out that in certain Ingress configs we run into an error and cannot apply App Gwy config to ARM.

Looking at the YAML that could result in this error - it is a valid scenario.

Here is the ARM error as it is surfaced in the Ingress pod's logs:
```sh
W0528 18:27:53.847420   14709 controller.go:118] unable to send CreateOrUpdate request, error [network.ApplicationGatewaysClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="ApplicationGatewayPathRulePathShouldHaveNonEmptyMatchValue" Message="Path / should have a nonempty match value followed by '/'  in PathRule /subscriptions/d664a618-e0fd-447e-a2cf-e0ca50ef6456/resourceGroups/derayche-rg-X/providers/Microsoft.Network/applicationGateways/applicationgateway85a7/urlPathMaps/url-x.mis.li-80/pathRules/k8s-0." Details=[]]
```

The Ingress YAML:
```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: websocket-ingress
  annotations:
    kubernetes.io/ingress.class: azure/application-gateway
    appgw.ingress.kubernetes.io/ssl-redirect: "true"
spec:
  rules:
    - host: ws.mis.li
      http:
        paths:
          - path: /
            backend:
              serviceName: websocket-service
              servicePort: 80
```