### PR TITLE
appgw_test: No guarantees on the order of Backend HTTP Settings

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -497,14 +497,14 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 				}
 
 				// Test the default backend HTTP settings.
-				Expect((*appGW.BackendHTTPSettingsCollection)[0]).To(Equal(defaultBackendHTTPSettings(appGwIdentifier.probeID(defaultProbeName))))
+				Expect((*appGW.BackendHTTPSettingsCollection)).To(ContainElement(defaultBackendHTTPSettings(appGwIdentifier.probeID(defaultProbeName))))
 				// Test the ingress backend HTTP setting that we installed.
-				Expect((*appGW.BackendHTTPSettingsCollection)[1]).To(Equal(*httpSettings))
+				Expect((*appGW.BackendHTTPSettingsCollection)).To(ContainElement(*httpSettings))
 			}
 
 			EmptyBackendAddressPoolChecker := func(appGW *network.ApplicationGatewayPropertiesFormat) {
 				// Test the default backend address pool.
-				Expect((*appGW.BackendAddressPools)[0]).To(Equal(defaultBackendAddressPool()))
+				Expect((*appGW.BackendAddressPools)).To(ContainElement(defaultBackendAddressPool()))
 			}
 
 			testAGConfig(ingressList, appGwConfigSettings{


### PR DESCRIPTION
We don't have guarantees on the order of the elements here in this test.
Also, unless I misunderstand how App Gateway v2 works, the order of Backend HTTP settings does not matter.

This test has been flaking once in a while; to stop this - we will check membership instead of position and equality.