### PR TITLE
annotations: adding annotations for backendhttpsettings

### DIFF
--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -21,6 +21,18 @@ const (
 	// Null means no path will be prefixed. Default value is null.
 	BackendPathPrefixKey = ApplicationGatewayPrefix + "/backend-path-prefix"
 
+	// CookieBasedAffinityKey defines the key to enable/disable cookie based affinity.
+	CookieBasedAffinityKey = ApplicationGatewayPrefix + "/cookie-based-affinity"
+
+	// RequestTimeoutKey defines the request timeout to the backend.
+	RequestTimeoutKey = ApplicationGatewayPrefix + "/request-timeout"
+
+	// ConnectionDrainingKey defines defines the key to enable/disable connection draining.
+	ConnectionDrainingKey = ApplicationGatewayPrefix + "/connection-draining"
+
+	// ConnectionDrainingTimeoutKey defines the drain timeout for the backends.
+	ConnectionDrainingTimeoutKey = ApplicationGatewayPrefix + "/connection-draining-timeout"
+
 	// SslRedirectKey defines the key for defining with SSL redirect should be turned on for an HTTP endpoint.
 	SslRedirectKey = ApplicationGatewayPrefix + "/ssl-redirect"
 
@@ -52,6 +64,26 @@ func IsSslRedirect(ing *v1beta1.Ingress) (bool, error) {
 // BackendPathPrefix override path
 func BackendPathPrefix(ing *v1beta1.Ingress) (string, error) {
 	return parseString(ing, BackendPathPrefixKey)
+}
+
+// RequestTimeout provides value for request timeout on the backend connection
+func RequestTimeout(ing *v1beta1.Ingress) (int32, error) {
+	return parseInt32(ing, RequestTimeoutKey)
+}
+
+// IsConnectionDraining provides whether connection draining is enabled or not.
+func IsConnectionDraining(ing *v1beta1.Ingress) (bool, error) {
+	return parseBool(ing, CookieBasedAffinityKey)
+}
+
+// ConnectionDrainingTimeout provides value for draining timeout for backends.
+func ConnectionDrainingTimeout(ing *v1beta1.Ingress) (int32, error) {
+	return parseInt32(ing, ConnectionDrainingTimeoutKey)
+}
+
+// IsCookieBasedAffinity for HTTP end points.
+func IsCookieBasedAffinity(ing *v1beta1.Ingress) (bool, error) {
+	return parseBool(ing, CookieBasedAffinityKey)
 }
 
 func parseBool(ing *v1beta1.Ingress, name string) (bool, error) {

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -21,13 +21,13 @@ const (
 	// Null means no path will be prefixed. Default value is null.
 	BackendPathPrefixKey = ApplicationGatewayPrefix + "/backend-path-prefix"
 
-	// CookieBasedAffinityKey defines the key to enable/disable cookie based affinity.
+	// CookieBasedAffinityKey defines the key to enable/disable cookie based affinity for client connection.
 	CookieBasedAffinityKey = ApplicationGatewayPrefix + "/cookie-based-affinity"
 
 	// RequestTimeoutKey defines the request timeout to the backend.
 	RequestTimeoutKey = ApplicationGatewayPrefix + "/request-timeout"
 
-	// ConnectionDrainingKey defines defines the key to enable/disable connection draining.
+	// ConnectionDrainingKey defines the key to enable/disable connection draining.
 	ConnectionDrainingKey = ApplicationGatewayPrefix + "/connection-draining"
 
 	// ConnectionDrainingTimeoutKey defines the drain timeout for the backends.
@@ -81,7 +81,7 @@ func ConnectionDrainingTimeout(ing *v1beta1.Ingress) (int32, error) {
 	return parseInt32(ing, ConnectionDrainingTimeoutKey)
 }
 
-// IsCookieBasedAffinity for HTTP end points.
+// IsCookieBasedAffinity provides value to enable/disable cookie based affinity for client connection.
 func IsCookieBasedAffinity(ing *v1beta1.Ingress) (bool, error) {
 	return parseBool(ing, CookieBasedAffinityKey)
 }
@@ -115,7 +115,7 @@ func parseInt32(ing *v1beta1.Ingress, name string) (int32, error) {
 			int32Val := int32(intVal)
 			return int32Val, nil
 		}
-		return 0, err
+		return 0, errors.NewInvalidAnnotationContent(name, val)
 	}
 
 	return 0, errors.ErrMissingAnnotations

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -79,7 +79,7 @@ func TestParseInt32Invalid(t *testing.T) {
 	value := "20asd"
 	ingress.Annotations[key] = value
 	parsedVal, err := parseInt32(&ingress, key)
-	if errors.IsInvalidContent(err) {
+	if !errors.IsInvalidContent(err) {
 		t.Error(fmt.Sprintf(Error, err, parsedVal, err))
 	}
 }

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -19,6 +19,7 @@ import (
 )
 
 const (
+	// DefaultConnDrainTimeoutInSec provides default value for ConnectionDrainTimeout
 	DefaultConnDrainTimeoutInSec = 30
 )
 

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -188,8 +188,8 @@ func (builder *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentif
 		httpSettings.Path = to.StringPtr(pathPrefix)
 	}
 
-	IsConnDrain, err := annotations.IsConnectionDraining(backendID.Ingress)
-	if err == nil && IsConnDrain {
+	isConnDrain, err := annotations.IsConnectionDraining(backendID.Ingress)
+	if err == nil && isConnDrain {
 		httpSettings.ConnectionDraining = &network.ApplicationGatewayConnectionDraining{
 			Enabled: to.BoolPtr(true),
 		}

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -183,32 +183,27 @@ func (builder *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentif
 		},
 	}
 
-	pathPrefix, err := annotations.BackendPathPrefix(backendID.Ingress)
-	if err == nil {
+	if pathPrefix, err := annotations.BackendPathPrefix(backendID.Ingress); err == nil {
 		httpSettings.Path = to.StringPtr(pathPrefix)
 	}
 
-	isConnDrain, err := annotations.IsConnectionDraining(backendID.Ingress)
-	if err == nil && isConnDrain {
+	if isConnDrain, err := annotations.IsConnectionDraining(backendID.Ingress); err == nil && isConnDrain {
 		httpSettings.ConnectionDraining = &network.ApplicationGatewayConnectionDraining{
 			Enabled: to.BoolPtr(true),
 		}
 
-		connDrainTimeout, err := annotations.ConnectionDrainingTimeout(backendID.Ingress)
-		if err == nil {
+		if connDrainTimeout, err := annotations.ConnectionDrainingTimeout(backendID.Ingress); err == nil {
 			httpSettings.ConnectionDraining.DrainTimeoutInSec = to.Int32Ptr(connDrainTimeout)
 		} else {
 			httpSettings.ConnectionDraining.DrainTimeoutInSec = to.Int32Ptr(DefaultConnDrainTimeoutInSec)
 		}
 	}
 
-	affinity, err := annotations.IsCookieBasedAffinity(backendID.Ingress)
-	if err == nil && affinity {
+	if affinity, err := annotations.IsCookieBasedAffinity(backendID.Ingress); err == nil && affinity {
 		httpSettings.CookieBasedAffinity = network.Enabled
 	}
 
-	reqTimeout, err := annotations.RequestTimeout(backendID.Ingress)
-	if err == nil {
+	if reqTimeout, err := annotations.RequestTimeout(backendID.Ingress); err == nil {
 		httpSettings.RequestTimeout = to.Int32Ptr(reqTimeout)
 	}
 

--- a/pkg/appgw/ingress_rules.go
+++ b/pkg/appgw/ingress_rules.go
@@ -38,8 +38,7 @@ func (builder *appGwConfigBuilder) processIngressRules(ingress *v1beta1.Ingress)
 		}
 
 		// Enable HTTP only if HTTPS is not configured OR if ingress annotated with 'ssl-redirect'
-		sslRedirect, _ := annotations.IsSslRedirect(ingress)
-		if sslRedirect || !httpsAvailable {
+		if sslRedirect, _ := annotations.IsSslRedirect(ingress); sslRedirect || !httpsAvailable {
 			listenerID := generateListenerID(&rule, network.HTTP, nil)
 			frontendPorts[listenerID.FrontendPort] = nil
 			felAzConfig := listenerAzConfig{

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -155,8 +155,7 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 					defaultAddressPoolID, defaultHTTPSettingsID)
 
 				// If ingress is annotated with "ssl-redirect" - setup redirection configuration.
-				sslRedirect, _ := annotations.IsSslRedirect(ingress)
-				if sslRedirect {
+				if sslRedirect, _ := annotations.IsSslRedirect(ingress); sslRedirect {
 					builder.modifyPathRulesForRedirection(ingress, urlPathMaps[listenerHTTPID])
 				}
 			}


### PR DESCRIPTION
This PR adds annotations to modify http settings related to the backend connections.

| Annotation | Values | Default | BackendHttpSettings property |
| -- | -- | -- | -- |
| appgw.ingress.kubernetes.io/connection-draining | `bool` | `false` | ConnectionDraining.Enabled |
| appgw.ingress.kubernetes.io/connection-draining-timeout | `int32` | `30` | ConnectionDraining.DrainTimeoutInSec |
| appgw.ingress.kubernetes.io/cookie-based-affinity | `bool` | `false` | CookieBasedAffinity |
| appgw.ingress.kubernetes.io/request-timeout | `int32` | `30` | RequestTimeout |

Will add tests/documentation in following PRs.