### PR TITLE
controller: Wipe cache if updating ARM fails

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -122,6 +122,8 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	// Initiate deployment
 	appGwFuture, err := c.appGwClient.CreateOrUpdate(ctx, c.appGwIdentifier.ResourceGroup, c.appGwIdentifier.AppGwName, appGw)
 	if err != nil {
+		// Reset cache
+		c.configCache = &[]byte{}
 		glog.Warningf("unable to send CreateOrUpdate request, error [%v]", err.Error())
 		return errors.New("unable to send CreateOrUpdate request")
 	}
@@ -131,6 +133,8 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	glog.V(1).Infof("deployment took %+v", time.Now().Sub(deploymentStart).String())
 
 	if err != nil {
+		// Reset cache
+		c.configCache = &[]byte{}
 		glog.Warningf("unable to deploy ApplicationGateway, error [%v]", err.Error())
 		return errors.New("unable to deploy ApplicationGateway")
 	}


### PR DESCRIPTION
If we run into an error while applying App Gwy config, reset the cache so it could be re-constructed and re-applied next time around.