### PR TITLE
controller: On failure to apply config - log (sanitized) config

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -131,6 +131,8 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 		// Reset cache
 		c.configCache = &[]byte{}
 		glog.Warningf("unable to send CreateOrUpdate request, error [%v]", err.Error())
+		configJSON, _ := c.dumpSanitizedJSON(&appGw)
+		glog.V(5).Info(string(configJSON))
 		return errors.New("unable to send CreateOrUpdate request")
 	}
 


### PR DESCRIPTION
On failure to apply config - let's dump the JSON.
The idea here is to provide a mechanism by which we can wipe sensitive data and then dump the JSON.
This PR proposes we delete `"sslCertificates"`, which I believe captures all keys that have sensitive information.
Logging at V5 should provide some additional protection from pumping too much noise into logs.
