### PR TITLE
Carve out annotation parsing and add errors package, carved out backend https settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/onsi/gomega v1.5.0
 	github.com/openzipkin/zipkin-go v0.1.3 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/spf13/pflag v1.0.3
 	golang.org/x/sys v0.0.0-20190307162637-572b51eaf722 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,7 @@ github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTm
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -1,7 +1,16 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
 package annotations
 
 import (
+	"strconv"
+
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/errors"
 )
 
 const (
@@ -24,26 +33,58 @@ const (
 	ApplicationGatewayIngressClass = "azure/application-gateway"
 )
 
-// BackendPathPrefix override path
-func BackendPathPrefix(ing *v1beta1.Ingress) string {
-	val, _ := ing.Annotations[BackendPathPrefixKey]
-	return val
-}
-
 // IngressClass ingress class
-func IngressClass(ing *v1beta1.Ingress) string {
-	val, _ := ing.Annotations[IngressClassKey]
-	return val
+func IngressClass(ing *v1beta1.Ingress) (string, error) {
+	return parseString(ing, IngressClassKey)
 }
 
 // IsApplicationGatewayIngress checks if the Ingress resource can be handled by the Application Gateway ingress controller.
-func IsApplicationGatewayIngress(ing *v1beta1.Ingress) bool {
-	controllerName := ing.Annotations[IngressClassKey]
-	return controllerName == ApplicationGatewayIngressClass
+func IsApplicationGatewayIngress(ing *v1beta1.Ingress) (bool, error) {
+	controllerName, err := parseString(ing, IngressClassKey)
+	return controllerName == ApplicationGatewayIngressClass, err
 }
 
 // IsSslRedirect for HTTP end points.
-func IsSslRedirect(ing *v1beta1.Ingress) bool {
-	val, ok := ing.Annotations[SslRedirectKey]
-	return ok && val == "true"
+func IsSslRedirect(ing *v1beta1.Ingress) (bool, error) {
+	return parseBool(ing, SslRedirectKey)
+}
+
+// BackendPathPrefix override path
+func BackendPathPrefix(ing *v1beta1.Ingress) (string, error) {
+	return parseString(ing, BackendPathPrefixKey)
+}
+
+func parseBool(ing *v1beta1.Ingress, name string) (bool, error) {
+	val, ok := ing.Annotations[name]
+	if ok {
+		boolVal, err := strconv.ParseBool(val)
+		if err != nil {
+			return false, errors.NewInvalidAnnotationContent(name, val)
+		}
+		return boolVal, nil
+	}
+	return false, errors.ErrMissingAnnotations
+}
+
+func parseString(ing *v1beta1.Ingress, name string) (string, error) {
+	val, ok := ing.Annotations[name]
+	if ok {
+		return val, nil
+	}
+
+	return "", errors.ErrMissingAnnotations
+}
+
+func parseInt32(ing *v1beta1.Ingress, name string) (int32, error) {
+	val, ok := ing.Annotations[name]
+	if ok {
+		intVal, err := strconv.Atoi(val)
+		if err == nil {
+			int32Val := int32(intVal)
+			return int32Val, nil
+		}
+		return 0, err
+	}
+
+	return 0, errors.ErrMissingAnnotations
 }

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -106,7 +106,7 @@ func TestParseString(t *testing.T) {
 func TestParseStringMissingKey(t *testing.T) {
 	key := "key"
 	delete(ingress.Annotations, key)
-	_, err := parseString(&ingress, key)
+	parsedVal, err := parseString(&ingress, key)
 	if !errors.IsMissingAnnotations(err) {
 		t.Error(fmt.Sprintf(Error, errors.ErrMissingAnnotations, parsedVal, err))
 	}

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -22,7 +22,7 @@ var ingress = v1beta1.Ingress{
 
 const (
 	NoError = "Expected to return %s and no error. Returned %v and %s."
-	Error = "Expected to return error %s. Returned %v and %s."
+	Error   = "Expected to return error %s. Returned %v and %s."
 )
 
 func TestParseBoolTrue(t *testing.T) {

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -21,8 +21,8 @@ var ingress = v1beta1.Ingress{
 }
 
 const (
-	NoError = "Expected to return %s and no error. Returned %v and %s."
-	Error   = "Expected to return error %s. Returned %v and %s."
+	NoError = "Expected to return %s and no error. Returned %v and %v."
+	Error   = "Expected to return error %s. Returned %v and %v."
 )
 
 func TestParseBoolTrue(t *testing.T) {
@@ -69,7 +69,7 @@ func TestParseInt32(t *testing.T) {
 	value := "20"
 	ingress.Annotations[key] = value
 	parsedVal, err := parseInt32(&ingress, key)
-	if err != nil || string(parsedVal) != value {
+	if err != nil || fmt.Sprint(parsedVal) != value {
 		t.Error(fmt.Sprintf(NoError, value, parsedVal, err))
 	}
 }

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/errors"
 	"k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,24 +20,89 @@ var ingress = v1beta1.Ingress{
 	},
 }
 
-func TestIsSslRedirectYes(t *testing.T) {
-	redirectKey := "true"
-	ingress.Annotations[SslRedirectKey] = redirectKey
-	if !IsSslRedirect(&ingress) {
-		t.Error(fmt.Sprintf("IsSslRedirect is expected to return true since %s = %s", SslRedirectKey, redirectKey))
+func TestParseBoolTrue(t *testing.T) {
+	key := "key"
+	value := "true"
+	ingress.Annotations[key] = value
+	parsedVal, err := parseBool(&ingress, key)
+	if !parsedVal || err != nil {
+		t.Error(fmt.Sprintf("parseBool is expected to return true since %s = %s", key, value))
 	}
 }
 
-func TestIsSslRedirectNo(t *testing.T) {
-	redirectKey := "nope"
-	ingress.Annotations[SslRedirectKey] = redirectKey
-	if IsSslRedirect(&ingress) {
-		t.Error(fmt.Sprintf("IsSslRedirect is expected to return false since %s = %s", SslRedirectKey, redirectKey))
+func TestParseBoolFalse(t *testing.T) {
+	key := "key"
+	value := "false"
+	ingress.Annotations[key] = value
+	parsedVal, err := parseBool(&ingress, key)
+	if parsedVal || err != nil {
+		t.Error(fmt.Sprintf("parseBool is expected to return false since %s = %s", key, value))
 	}
 }
-func TestIsSslRedirectMissingKey(t *testing.T) {
-	delete(ingress.Annotations, SslRedirectKey)
-	if IsSslRedirect(&ingress) {
-		t.Error(fmt.Sprintf("IsSslRedirect is expected to return false since there is no %s annotation", SslRedirectKey))
+
+func TestParseBoolInvalid(t *testing.T) {
+	key := "key"
+	value := "nope"
+	ingress.Annotations[key] = value
+	parsedVal, err := parseBool(&ingress, key)
+	if !errors.IsInvalidContent(err) || parsedVal {
+		t.Error(fmt.Sprintf("parseBool is expected to return false since %s = %s", key, value))
+	}
+}
+
+func TestParseBoolMissingKey(t *testing.T) {
+	key := "key"
+	delete(ingress.Annotations, key)
+	_, err := parseBool(&ingress, key)
+	if !errors.IsMissingAnnotations(err) {
+		t.Error(fmt.Sprintf("key is expected to return false since there is no %s annotation", key))
+	}
+}
+
+func TestParseInt32(t *testing.T) {
+	key := "key"
+	value := "20"
+	ingress.Annotations[key] = value
+	parsedVal, err := parseInt32(&ingress, key)
+	if err != nil && string(parsedVal) != value {
+		t.Error(fmt.Sprintf("key retuned %d since %s = %s", parsedVal, key, value))
+	}
+}
+
+func TestParseInt32Invalid(t *testing.T) {
+	key := "key"
+	value := "20asd"
+	ingress.Annotations[key] = value
+	parsedVal, err := parseInt32(&ingress, key)
+	if errors.IsInvalidContent(err) {
+		t.Error(fmt.Sprintf("key retuned %d since %s = %s", parsedVal, key, value))
+	}
+}
+
+func TestParseInt32MissingKey(t *testing.T) {
+	key := "key"
+	delete(ingress.Annotations, key)
+	_, err := parseInt32(&ingress, key)
+	if !errors.IsMissingAnnotations(err) {
+		t.Error(fmt.Sprintf("key is expected to return false since there is no %s annotation", key))
+	}
+}
+
+func TestParseString(t *testing.T) {
+	key := "key"
+	value := "/path"
+	ingress.Annotations[key] = value
+	parsedVal, _ := parseString(&ingress, key)
+	if parsedVal != value {
+		t.Error(fmt.Sprintf("parseString retuned %s since %s = %s", parsedVal, key, value))
+	}
+}
+
+func TestParseStringMissingKey(t *testing.T) {
+	key := "key"
+	delete(ingress.Annotations, key)
+	_, err := parseString(&ingress, key)
+	if !errors.IsMissingAnnotations(err) {
+		t.Error(fmt.Sprintf("key is expected to return false since there is no %s annotation", key))
 	}
 }

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -207,7 +207,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &network.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 				Protocol: network.HTTP,
 				Port:     &backendPort,
-				Path:     to.StringPtr(""),
+				Path:     nil,
+				HostName: nil,
 				Probe:    resourceRef(probeID),
 			},
 		}
@@ -492,7 +493,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 					ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &network.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 						Protocol: network.HTTP,
 						Port:     &servicePort,
-						Path:     to.StringPtr(""),
+						Path:     nil,
 						Probe:    resourceRef(appGwIdentifier.probeID(defaultProbeName)),
 					},
 				}
@@ -715,6 +716,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 						Port:     &backendPort,
 						Path:     to.StringPtr("/test"),
 						Probe:    resourceRef(probeID),
+						HostName: nil,
 					},
 				}
 

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -86,8 +86,9 @@ func (builder *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifi
 		probe.Host = to.StringPtr(backendID.Rule.Host)
 	}
 
-	if len(annotations.BackendPathPrefix(backendID.Ingress)) != 0 {
-		probe.Path = to.StringPtr(annotations.BackendPathPrefix(backendID.Ingress))
+	pathPrefix, err := annotations.BackendPathPrefix(backendID.Ingress)
+	if err == nil {
+		probe.Path = to.StringPtr(pathPrefix)
 	} else if backendID.Path != nil && len(backendID.Path.Path) != 0 {
 		probe.Path = to.StringPtr(backendID.Path.Path)
 	}

--- a/pkg/appgw/ingress_rules.go
+++ b/pkg/appgw/ingress_rules.go
@@ -38,7 +38,8 @@ func (builder *appGwConfigBuilder) processIngressRules(ingress *v1beta1.Ingress)
 		}
 
 		// Enable HTTP only if HTTPS is not configured OR if ingress annotated with 'ssl-redirect'
-		if annotations.IsSslRedirect(ingress) || !httpsAvailable {
+		sslRedirect, _ := annotations.IsSslRedirect(ingress)
+		if sslRedirect || !httpsAvailable {
 			listenerID := generateListenerID(&rule, network.HTTP, nil)
 			frontendPorts[listenerID.FrontendPort] = nil
 			felAzConfig := listenerAzConfig{

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -6,8 +6,9 @@
 package appgw
 
 import (
-	"github.com/golang/glog"
 	"strconv"
+
+	"github.com/golang/glog"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
@@ -154,7 +155,8 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 					defaultAddressPoolID, defaultHTTPSettingsID)
 
 				// If ingress is annotated with "ssl-redirect" - setup redirection configuration.
-				if annotations.IsSslRedirect(ingress) {
+				sslRedirect, _ := annotations.IsSslRedirect(ingress)
+				if sslRedirect {
 					builder.modifyPathRulesForRedirection(ingress, urlPathMaps[listenerHTTPID])
 				}
 			}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// ErrMissingAnnotations the ingress rule does not contain annotations
+	// This is an error only when annotations are being parsed
+	ErrMissingAnnotations = errors.New("ingress rule without annotations")
+)
+
+// IsMissingAnnotations checks if the err is an error which
+// indicates the ingress does not contain annotations
+func IsMissingAnnotations(e error) bool {
+	return e == ErrMissingAnnotations
+}
+
+// NewInvalidAnnotationContent returns a new InvalidContent error
+func NewInvalidAnnotationContent(name string, val interface{}) error {
+	return InvalidContent{
+		Name: fmt.Sprintf("the annotation %v does not contain a valid value (%v)", name, val),
+	}
+}
+
+// InvalidContent error
+type InvalidContent struct {
+	Name string
+}
+
+func (e InvalidContent) Error() string {
+	return e.Name
+}
+
+// IsInvalidContent checks if the err is an error which
+// indicates an annotations value is not valid
+func IsInvalidContent(e error) bool {
+	_, ok := e.(InvalidContent)
+	return ok
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import "testing"
+
+func TestIsMissingAnnotations(t *testing.T) {
+	if !IsMissingAnnotations(ErrMissingAnnotations) {
+		t.Error("expected true")
+	}
+}
+
+func TestInvalidContent(t *testing.T) {
+	if IsInvalidContent(ErrMissingAnnotations) {
+		t.Error("expected false")
+	}
+	err := NewInvalidAnnotationContent("demo", "")
+	if !IsInvalidContent(err) {
+		t.Error("expected true")
+	}
+	if IsInvalidContent(nil) {
+		t.Error("expected false")
+	}
+}

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -424,5 +424,6 @@ func (c *Context) Stop() {
 }
 
 func isIngressApplicationGateway(ingress *v1beta1.Ingress) bool {
-	return annotations.IsApplicationGatewayIngress(ingress)
+	val, _ := annotations.IsApplicationGatewayIngress(ingress)
+	return val
 }

--- a/vendor/github.com/pkg/errors/.gitignore
+++ b/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.3
+  - 1.5.4
+  - 1.6.2
+  - 1.7.1
+  - tip
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,269 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// and the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required the errors.WithStack and errors.WithMessage
+// functions destructure errors.Wrap into its component operations of annotating
+// an error with a stack trace and an a message, respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// causer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// stackTracer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is call, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,178 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -125,6 +125,8 @@ github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
+# github.com/pkg/errors v0.8.0
+github.com/pkg/errors
 # github.com/spf13/pflag v1.0.3
 github.com/spf13/pflag
 # go.opencensus.io v0.18.1-0.20181204023538-aab39bd6a98b


### PR DESCRIPTION
This PR takes out the parsing for string/bool/int32 to separate functions so that annotations just have to provide key and get the value. It will also returns errors like missing value/invalid content which can be used for validation later.
Also, carved out the backendhttpsettings obj creation.