### PR TITLE
Ensure isMap and isSlice return false when checking nil

### DIFF
--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -64,11 +64,11 @@ func (c AppGwIngressController) dumpSanitizedJSON(appGw *network.ApplicationGate
 }
 
 func isMap(v interface{}) bool {
-	return reflect.ValueOf(v).Type().Kind() == reflect.Map
+	return v != nil && reflect.ValueOf(v).Type().Kind() == reflect.Map
 }
 
 func isSlice(v interface{}) bool {
-	return reflect.ValueOf(v).Type().Kind() == reflect.Slice
+	return v != nil && reflect.ValueOf(v).Type().Kind() == reflect.Slice
 }
 
 // deleteKey recursively deletes the given key from the map. This is NOT cap sensitive.

--- a/pkg/controller/helpers_test.go
+++ b/pkg/controller/helpers_test.go
@@ -86,4 +86,27 @@ var _ = Describe("configure App Gateway", func() {
 		})
 	})
 
+	Context("ensure isMap works as expected", func() {
+		It("should deal with nil values", func() {
+			Expect(isMap(nil)).To(BeFalse())
+		})
+		It("should return true when passed a map", func() {
+			Expect(isMap(make(map[string]interface{}))).To(BeTrue())
+		})
+		It("should return false when passed a slice", func() {
+			Expect(isMap(make([]string, 100))).To(BeFalse())
+		})
+	})
+
+	Context("ensure isSlice works as expected", func() {
+		It("should deal with nil values", func() {
+			Expect(isSlice(nil)).To(BeFalse())
+		})
+		It("should return true when passed a slice", func() {
+			Expect(isSlice(make([]string, 100))).To(BeTrue())
+		})
+		It("should return false when passed a map", func() {
+			Expect(isSlice(make(map[string]interface{}))).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
`isMap` and `isSlice` could be passed an empty interface and need to deal with these cases