### PR TITLE
Fixing a bug with SSL redirects

### DIFF
--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -129,15 +129,13 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 			httpsAvailable := false
 
 			listenerHTTPID := generateListenerID(rule, network.HTTP, nil)
-			_, exist := httpListenersMap[listenerHTTPID]
-			if exist {
+			if _, exist := httpListenersMap[listenerHTTPID]; exist {
 				httpAvailable = true
 			}
 
 			// check annotation for port override
 			listenerHTTPSID := generateListenerID(rule, network.HTTPS, nil)
-			_, exist = httpListenersMap[listenerHTTPSID]
-			if exist {
+			if _, exist := httpListenersMap[listenerHTTPSID]; exist {
 				httpsAvailable = true
 			}
 
@@ -154,8 +152,8 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 					listenerHTTPID, urlPathMaps[listenerHTTPID],
 					defaultAddressPoolID, defaultHTTPSettingsID)
 
-				// If ingress is annotated with "ssl-redirect" - setup redirection configuration.
-				if sslRedirect, _ := annotations.IsSslRedirect(ingress); sslRedirect {
+				// If ingress is annotated with "ssl-redirect" and we have TLS - setup redirection configuration.
+				if sslRedirect, _ := annotations.IsSslRedirect(ingress); sslRedirect && httpsAvailable {
 					builder.modifyPathRulesForRedirection(ingress, urlPathMaps[listenerHTTPID])
 				}
 			}
@@ -192,8 +190,8 @@ func (builder *appGwConfigBuilder) RequestRoutingRules(ingressList [](*v1beta1.I
 		}
 	}
 
-	urlPathMapFiltered := []network.ApplicationGatewayURLPathMap{}
-	requestRoutingRules := []network.ApplicationGatewayRequestRoutingRule{}
+	var urlPathMapFiltered []network.ApplicationGatewayURLPathMap
+	var requestRoutingRules []network.ApplicationGatewayRequestRoutingRule
 	for listenerID, urlPathMap := range urlPathMaps {
 		requestRoutingRuleName := generateRequestRoutingRuleName(listenerID)
 		httpListener := httpListenersMap[listenerID]


### PR DESCRIPTION
Using the following ingress:
```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: websocket-ingress
  annotations:
    kubernetes.io/ingress.class: azure/application-gateway
    appgw.ingress.kubernetes.io/ssl-redirect: "true"
spec:
  tls:
   - hosts:
     - ws.mis.li
     secretName: testsecret-tls
  rules:
  - http:
      paths:
      - path: /
        backend:
          serviceName: websocket-service
          servicePort: 80
```

ran into this error:
```sh
W0531 14:57:33.448468    2809 controller.go:133] unable to send CreateOrUpdate request, error [network.ApplicationGatewaysClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidResourceReference" Message="Resource /subscriptions/.../resourceGroups/derayche-rg-X/providers/Microsoft.Network/applicationGateways/.../redirectConfigurations/sslr-default-websocket-ingress referenced by resource /subscriptions/.../resourceGroups/derayche-rg-X/providers/Microsoft.Network/applicationGateways/.../requestRoutingRules/rr-80 was not found. Please make sure that the referenced resource exists, and that both resources are in the same region." Details=[]]
```

We have to ensure that we have a) SSL annotation and b) HTTPS enabled to then reference the `sslr-` resource