### PR TITLE
Update cache separately from comparing cache with current config

### DIFF
--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 										Backend: v1beta1.IngressBackend{
 											ServiceName: "websocket-service",
 											ServicePort: intstr.IntOrString{
-												Type: intstr.Int,
+												Type:   intstr.Int,
 												IntVal: 80,
 											},
 										},
@@ -127,7 +127,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					annotations.IngressClassKey: annotations.ApplicationGatewayIngressClass,
-					annotations.SslRedirectKey: "true",
+					annotations.SslRedirectKey:  "true",
 				},
 				Namespace: testFixturesNamespace,
 				Name:      testFixturesName,
@@ -136,7 +136,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 
 		ingressList := []*v1beta1.Ingress{&ingress}
 
-		_, _= configBuilder.RequestRoutingRules(ingressList)
+		_, _ = configBuilder.RequestRoutingRules(ingressList)
 
 		It("should have correct RequestRoutingRules", func() {
 			Expect(len(*configBuilder.appGwConfig.RequestRoutingRules)).To(Equal(1))
@@ -157,15 +157,15 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 						ID: to.StringPtr("/subscriptions/--subscription--/resourceGroups/--resource-group--" +
 							"/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-80"),
 					},
-					URLPathMap: nil,
-					RewriteRuleSet: nil,
+					URLPathMap:            nil,
+					RewriteRuleSet:        nil,
 					RedirectConfiguration: nil,
-					ProvisioningState: nil,
+					ProvisioningState:     nil,
 				},
 				Name: to.StringPtr("rr-80"),
 				Etag: to.StringPtr("*"),
 				Type: nil,
-				ID: nil,
+				ID:   nil,
 			}
 			Expect(*configBuilder.appGwConfig.RequestRoutingRules).To(ContainElement(expected))
 		})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -45,7 +45,6 @@ func NewAppGwIngressController(appGwClient network.ApplicationGatewaysClient, ap
 		appGwIdentifier:  appGwIdentifier,
 		k8sContext:       k8sContext,
 		k8sUpdateChannel: k8sContext.UpdateChannel,
-		configCache:      &[]byte{},
 		recorder:         recorder,
 	}
 
@@ -117,7 +116,7 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	addTags(&appGw)
 
 	if c.configIsSame(&appGw) {
-		glog.Infoln("Config has NOT changed! No need to connect to ARM.")
+		glog.Infoln("cache: Config has NOT changed! No need to connect to ARM.")
 		return nil
 	}
 
@@ -129,23 +128,25 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	appGwFuture, err := c.appGwClient.CreateOrUpdate(ctx, c.appGwIdentifier.ResourceGroup, c.appGwIdentifier.AppGwName, appGw)
 	if err != nil {
 		// Reset cache
-		c.configCache = &[]byte{}
+		c.configCache = nil
 		glog.Warningf("unable to send CreateOrUpdate request, error [%v]", err.Error())
 		configJSON, _ := c.dumpSanitizedJSON(&appGw)
 		glog.V(5).Info(string(configJSON))
 		return errors.New("unable to send CreateOrUpdate request")
 	}
-
 	// Wait until deployment finshes and save the error message
 	err = appGwFuture.WaitForCompletionRef(ctx, c.appGwClient.BaseClient.Client)
 	glog.V(1).Infof("deployment took %+v", time.Now().Sub(deploymentStart).String())
 
 	if err != nil {
 		// Reset cache
-		c.configCache = &[]byte{}
+		c.configCache = nil
 		glog.Warningf("unable to deploy ApplicationGateway, error [%v]", err.Error())
 		return errors.New("unable to deploy ApplicationGateway")
 	}
+
+	glog.Info("cache: Updated with latest applied config.")
+	c.updateCache(&appGw)
 
 	return nil
 }

--- a/pkg/controller/helpers_test.go
+++ b/pkg/controller/helpers_test.go
@@ -76,11 +76,10 @@ var _ = Describe("configure App Gateway", func() {
 				Name: to.StringPtr("something"),
 			}
 
-			c := AppGwIngressController{
-				configCache: &[]byte{},
-			}
+			c := AppGwIngressController{}
 
 			Expect(c.configIsSame(&client)).To(BeFalse())
+			c.updateCache(&client)
 			Expect(c.configIsSame(&client)).To(BeTrue())
 			Expect(string(*c.configCache)).To(Equal(`{"name":"something"}`))
 		})


### PR DESCRIPTION
There are a few issues that I'd like to fix with the config cache:

 1. no need to pre-allocate a byte array for that - we can start with none memory allocated
 2. cleaning the cache should be as simple as setting it to a nil pointer
 3. most importantly - I'd like to separate comparing config w/ cache and updating the cache -- these should have never been put together