### PR TITLE
Remove unnecessary memory allocations when making slices

### DIFF
--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -45,7 +45,7 @@ func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList [](*v1bet
 		}
 	}
 
-	unresolvedBackendID := make([]backendIdentifier, 0)
+	var unresolvedBackendID []backendIdentifier
 	for backendID := range backendIDs {
 		resolvedBackendPorts := make(map[serviceBackendPortPair]interface{})
 
@@ -157,7 +157,7 @@ func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList [](*v1bet
 		c.backendHTTPSettingsMap[backendID] = &httpSettings
 	}
 
-	backends := make([]network.ApplicationGatewayBackendHTTPSettings, 0)
+	var backends []network.ApplicationGatewayBackendHTTPSettings
 	for _, backend := range httpSettingsCollection {
 		backends = append(backends, backend)
 	}

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -157,7 +157,7 @@ func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList []*v1beta
 		c.backendHTTPSettingsMap[backendID] = &httpSettings
 	}
 
-	var backends []network.ApplicationGatewayBackendHTTPSettings
+	backends := make([]network.ApplicationGatewayBackendHTTPSettings, 0, len(httpSettingsCollection))
 	for _, backend := range httpSettingsCollection {
 		backends = append(backends, backend)
 	}

--- a/pkg/appgw/configbuilder_debug.go
+++ b/pkg/appgw/configbuilder_debug.go
@@ -16,7 +16,7 @@ func printEndpoints(endpoints v1.Endpoints) {
 	fmt.Printf("Endpoint [%s]\n", endpoints.Name)
 	for _, subset := range endpoints.Subsets {
 		ports := subset.Ports
-		var tmp []string
+		tmp := make([]string, 0, len(ports))
 		for _, port := range ports {
 			tmp = append(tmp, port.Name)
 		}

--- a/pkg/appgw/configbuilder_debug.go
+++ b/pkg/appgw/configbuilder_debug.go
@@ -16,7 +16,7 @@ func printEndpoints(endpoints v1.Endpoints) {
 	fmt.Printf("Endpoint [%s]\n", endpoints.Name)
 	for _, subset := range endpoints.Subsets {
 		ports := subset.Ports
-		tmp := make([]string, 0)
+		var tmp []string
 		for _, port := range ports {
 			tmp = append(tmp, port.Name)
 		}

--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -70,7 +70,7 @@ func (c *appGwConfigBuilder) newListener(listener listenerIdentifier, protocol n
 
 func (c *appGwConfigBuilder) getPublicIPID() *string {
 	var publicIPID *string
-	jsonConfigs := make([]string, 0)
+	var jsonConfigs []string
 	for _, ip := range *c.appGwConfig.FrontendIPConfigurations {
 		// Collect the JSON IP configs for debug purposes.
 		if jsonConf, err := ip.MarshalJSON(); err != nil {

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -65,7 +65,7 @@ func (c *appGwConfigBuilder) HealthProbesCollection(ingressList []*v1beta1.Ingre
 
 	glog.Infof("[health-probes] Will create %d App Gateway probes.", len(healthProbeCollection))
 
-	var probes []network.ApplicationGatewayProbe
+	probes := make([]network.ApplicationGatewayProbe, 0, len(healthProbeCollection))
 	for _, probe := range healthProbeCollection {
 		probes = append(probes, probe)
 	}

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -65,7 +65,7 @@ func (c *appGwConfigBuilder) HealthProbesCollection(ingressList [](*v1beta1.Ingr
 
 	glog.Infof("[health-probes] Will create %d App Gateway probes.", len(healthProbeCollection))
 
-	probes := make([]network.ApplicationGatewayProbe, 0)
+	var probes []network.ApplicationGatewayProbe
 	for _, probe := range healthProbeCollection {
 		probes = append(probes, probe)
 	}

--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -132,8 +132,9 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 			Expect(len(frontendPorts)).To(Equal(1))
 		})
 		It("should have a listener on port 443", func() {
-			var ports []int32
-			for _, listener := range getMapKeys(&frontendListeners) {
+			listeners := getMapKeys(&frontendListeners)
+			ports := make([]int32, 0, len(listeners))
+			for _, listener := range listeners {
 				ports = append(ports, listener.FrontendPort)
 			}
 			Expect(ports).To(ContainElement(port443))
@@ -159,7 +160,7 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 })
 
 func getMapKeys(m *map[listenerIdentifier]listenerAzConfig) []listenerIdentifier {
-	var keys []listenerIdentifier
+	keys := make([]listenerIdentifier, 0, len(*m))
 	for k := range *m {
 		keys = append(keys, k)
 	}
@@ -167,7 +168,7 @@ func getMapKeys(m *map[listenerIdentifier]listenerAzConfig) []listenerIdentifier
 }
 
 func getInt32MapKeys(m *map[int32]interface{}) []int32 {
-	var keys []int32
+	keys := make([]int32, 0, len(*m))
 	for k := range *m {
 		keys = append(keys, k)
 	}

--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 			Expect(len(frontendPorts)).To(Equal(1))
 		})
 		It("should have a listener on port 443", func() {
-			ports := make([]int32, 0)
+			var ports []int32
 			for _, listener := range getMapKeys(&frontendListeners) {
 				ports = append(ports, listener.FrontendPort)
 			}
@@ -159,7 +159,7 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 })
 
 func getMapKeys(m *map[listenerIdentifier]listenerAzConfig) []listenerIdentifier {
-	keys := make([]listenerIdentifier, 0, len(*m))
+	var keys []listenerIdentifier
 	for k := range *m {
 		keys = append(keys, k)
 	}
@@ -167,7 +167,7 @@ func getMapKeys(m *map[listenerIdentifier]listenerAzConfig) []listenerIdentifier
 }
 
 func getInt32MapKeys(m *map[int32]interface{}) []int32 {
-	keys := make([]int32, 0, len(*m))
+	var keys []int32
 	for k := range *m {
 		keys = append(keys, k)
 	}

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -297,7 +297,7 @@ func (c *Context) Run() {
 // GetHTTPIngressList returns a list of all the ingresses for HTTP from cache.
 func (c *Context) GetHTTPIngressList() []*v1beta1.Ingress {
 	ingressListInterface := c.Caches.Ingress.List()
-	ingressList := make([]*v1beta1.Ingress, 0)
+	var ingressList []*v1beta1.Ingress
 	for _, ingressInterface := range ingressListInterface {
 		ingress := ingressInterface.(*v1beta1.Ingress)
 
@@ -359,7 +359,7 @@ func (c *Context) GetPodsByServiceSelector(selector map[string]string) []*v1.Pod
 		selectorSet.Add(k + ":" + v)
 	}
 
-	podList := make([]*v1.Pod, 0)
+	var podList []*v1.Pod
 	for _, podInterface := range c.Caches.Pods.List() {
 		pod := podInterface.(*v1.Pod)
 		podLabelSet := mapset.NewSet()

--- a/pkg/utils/threadsafemultimap.go
+++ b/pkg/utils/threadsafemultimap.go
@@ -7,7 +7,7 @@ package utils
 
 import (
 	"sync"
-	
+
 	"github.com/deckarep/golang-set"
 )
 


### PR DESCRIPTION
There are multiple ways to make a slice, but they are not all equal.
Overall the performance loss is negligent given N in our case.
And yet - let's practice efficient and idiomatic Go.  (This mainly a reminder for myself as I'm fixing some of the unnecessary `make`s that I added)

Here is an interesting read on the topic: https://blog.golang.org/slices