### PR TITLE
[RFC] Create AzureIngressManagedListener CRD

### DIFF
--- a/crd/AzureIngressManagedListener.yaml
+++ b/crd/AzureIngressManagedListener.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureingressmanagedlisteners.appgw.ingress.k8s.io
+spec:
+  group: appgw.ingress.k8s.io
+  version: v1
+  names:
+    kind: AzureIngressManagedListener
+    plural: azureingressmanagedlisteners
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            host:
+              description: "(optional) Hostname of the listener"
+              type: string
+            port:
+              description: "Port number of the listener (required)"
+              type: integer
+            path:
+              description: "(optional) URL path, for which the Ingress Controller is allowed to mutate Application Gateway configuration"
+              type: string
+          required:
+            - port

--- a/crd/sampleAzureIngressManagedListener.yaml
+++ b/crd/sampleAzureIngressManagedListener.yaml
@@ -1,0 +1,19 @@
+apiVersion: "appgw.ingress.k8s.io/v1"
+kind: AzureIngressManagedListener
+metadata:
+  name: ingress1-managed-listener
+spec:
+  host: "www.contoso.com"
+  port: 80
+  path: "/bar/*"
+
+---
+
+apiVersion: "appgw.ingress.k8s.io/v1"
+kind: AzureIngressManagedListener
+metadata:
+  name: ingress2-managed-listener
+spec:
+  host: "ftp.contoso.com"
+  port: 8080
+  path: "/foo/*"


### PR DESCRIPTION
Create a new Kubernetes custom resource definition ([CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)) `AzureIngressManagedListener`, which will define a top level parent of the resources our Ingress Controller is allowed to mutate.

The `AzureIngressManagedListener` objects will be created by the AKS administrator.

A sample YAML creating new instances of this resource would have the following shape:
```yaml
apiVersion: "appgw.ingress.k8s.io/v1"
kind: AzureIngressManagedListener
metadata:
  name: ingress1-managed-listener
spec:
  host: "www.contoso.com"
  port: 80
  path: "/bar/*
```

AKS administrator would make multiple `AzureIngressManagedListener` objects in order to control multiple ports/hosts/URLs.