### PR TITLE
Simplify return types

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	defaultBackendAddressPoolChecker := func(appGW *network.ApplicationGatewayPropertiesFormat) {
 		expectedBackend := &ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend
 		addressPoolName := generateAddressPoolName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), backendPort)
-		addressPoolAddresses := [](network.ApplicationGatewayBackendAddress){{IPAddress: &endpoint1}, {IPAddress: &endpoint2}, {IPAddress: &endpoint3}}
+		addressPoolAddresses := []network.ApplicationGatewayBackendAddress{{IPAddress: &endpoint1}, {IPAddress: &endpoint2}, {IPAddress: &endpoint3}}
 
 		addressPool := &network.ApplicationGatewayBackendAddressPool{
 			Etag: to.StringPtr("*"),
@@ -291,11 +291,11 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 	testAGConfig := func(ingressList []*v1beta1.Ingress, settings appGwConfigSettings) {
 		// Add Health Probes.
-		configBuilder, err := configBuilder.HealthProbesCollection(ingressList)
+		err := configBuilder.HealthProbesCollection(ingressList)
 		Expect(err).Should(BeNil(), "Error in generating the Health Probes: %v", err)
 
 		// Add HTTP settings.
-		configBuilder, err = configBuilder.BackendHTTPSettingsCollection(ingressList)
+		err = configBuilder.BackendHTTPSettingsCollection(ingressList)
 		Expect(err).Should(BeNil(), "Error in generating the HTTP Settings: %v", err)
 
 		// Retrieve the implementation of the `ConfigBuilder` interface.
@@ -314,7 +314,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// Add backend address pools. We need the HTTP settings before we can add the backend address pools.
-		configBuilder, err = configBuilder.BackendAddressPools(ingressList)
+		err = configBuilder.BackendAddressPools(ingressList)
 		Expect(err).Should(BeNil(), "Error in generating the backend address pools: %v", err)
 
 		// Retrieve the implementation of the `ConfigBuilder` interface.
@@ -327,7 +327,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// Add the listeners. We need the backend address pools before we can add HTTP listeners.
-		configBuilder, err = configBuilder.Listeners(ingressList)
+		err = configBuilder.Listeners(ingressList)
 		Expect(err).Should(BeNil(), "Error in generating the HTTP listeners: %v", err)
 
 		// Retrieve the implementation of the `ConfigBuilder` interface.
@@ -340,7 +340,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// RequestRoutingRules depends on the previous operations
-		configBuilder, err = configBuilder.RequestRoutingRules(ingressList)
+		err = configBuilder.RequestRoutingRules(ingressList)
 		Expect(err).Should(BeNil(), "Error in generating the routing rules: %v", err)
 
 		// Retrieve the implementation of the `ConfigBuilder` interface.

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 )
 
-func (c *appGwConfigBuilder) BackendAddressPools(ingressList []*v1beta1.Ingress) (ConfigBuilder, error) {
+func (c *appGwConfigBuilder) BackendAddressPools(ingressList []*v1beta1.Ingress) error {
 	defaultPool := defaultBackendAddressPool()
 	addressPools := map[string]*n.ApplicationGatewayBackendAddressPool{
 		*defaultPool.Name: defaultPool,
@@ -30,7 +30,7 @@ func (c *appGwConfigBuilder) BackendAddressPools(ingressList []*v1beta1.Ingress)
 		}
 	}
 	c.appGwConfig.BackendAddressPools = getBackendPoolMapValues(&addressPools)
-	return c, nil
+	return nil
 }
 
 func getBackendPoolMapValues(m *map[string]*n.ApplicationGatewayBackendAddressPool) *[]n.ApplicationGatewayBackendAddressPool {

--- a/pkg/appgw/backendaddresspools_test.go
+++ b/pkg/appgw/backendaddresspools_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 			ing2,
 		}
 		cb := newConfigBuilderFixture(nil)
-		_, _ = cb.BackendAddressPools(ingressList)
+		_ = cb.BackendAddressPools(ingressList)
 
 		It("should contain correct number of backend address pools", func() {
 			Expect(len(*cb.appGwConfig.BackendAddressPools)).To(Equal(1))
@@ -65,7 +65,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 	Context("ensure unique IP addresses", func() {
 		ingressList := []*v1beta1.Ingress{newIngressFixture()}
 		cb := newConfigBuilderFixture(nil)
-		_, _ = cb.BackendAddressPools(ingressList)
+		_ = cb.BackendAddressPools(ingressList)
 		actualPool := newPool("pool-name", subset)
 		It("should contain unique addresses only", func() {
 			Expect(len(*actualPool.BackendAddresses)).To(Equal(4))
@@ -92,7 +92,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 	Context("ensure correct creation of ApplicationGatewayBackendAddress", func() {
 		ingressList := []*v1beta1.Ingress{newIngressFixture()}
 		cb := newConfigBuilderFixture(nil)
-		_, _ = cb.BackendAddressPools(ingressList)
+		_ = cb.BackendAddressPools(ingressList)
 
 		endpoints := newEndpointsFixture()
 		_ = cb.k8sContext.Caches.Endpoints.Add(endpoints)

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -23,7 +23,7 @@ const (
 	DefaultConnDrainTimeoutInSec = 30
 )
 
-func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList []*v1beta1.Ingress) (ConfigBuilder, error) {
+func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList []*v1beta1.Ingress) error {
 	backendIDs := make(map[backendIdentifier]interface{})
 	serviceBackendPairsMap := make(map[backendIdentifier]map[serviceBackendPortPair]interface{})
 
@@ -126,7 +126,7 @@ func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList []*v1beta
 	}
 
 	if len(unresolvedBackendID) > 0 {
-		return c, errors.New("unable to resolve backend port for some services")
+		return errors.New("unable to resolve backend port for some services")
 	}
 
 	probeID := c.appGwIdentifier.probeID(defaultProbeName)
@@ -142,7 +142,7 @@ func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList []*v1beta
 				backendID.serviceKey(), backendID.Backend.ServicePort.String())
 			c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, "PortResolutionError", logLine)
 			glog.Warning(logLine)
-			return c, errors.New("more than one service-backend port binding is not allowed")
+			return errors.New("more than one service-backend port binding is not allowed")
 		}
 
 		// At this point there will be only one pair
@@ -164,7 +164,7 @@ func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList []*v1beta
 
 	c.appGwConfig.BackendHTTPSettingsCollection = &backends
 
-	return c, nil
+	return nil
 }
 
 func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, port int32) network.ApplicationGatewayBackendHTTPSettings {

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -15,11 +15,11 @@ import (
 // ConfigBuilder is a builder for application gateway configuration
 type ConfigBuilder interface {
 	// builder pattern
-	BackendHTTPSettingsCollection(ingressList []*v1beta1.Ingress) (ConfigBuilder, error)
-	BackendAddressPools(ingressList []*v1beta1.Ingress) (ConfigBuilder, error)
-	Listeners(ingressList []*v1beta1.Ingress) (ConfigBuilder, error)
-	RequestRoutingRules(ingressList []*v1beta1.Ingress) (ConfigBuilder, error)
-	HealthProbesCollection(ingressList []*v1beta1.Ingress) (ConfigBuilder, error)
+	BackendHTTPSettingsCollection(ingressList []*v1beta1.Ingress) error
+	BackendAddressPools(ingressList []*v1beta1.Ingress) error
+	Listeners(ingressList []*v1beta1.Ingress) error
+	RequestRoutingRules(ingressList []*v1beta1.Ingress) error
+	HealthProbesCollection(ingressList []*v1beta1.Ingress) error
 	Build() *network.ApplicationGatewayPropertiesFormat
 }
 

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (c *appGwConfigBuilder) HealthProbesCollection(ingressList []*v1beta1.Ingress) (ConfigBuilder, error) {
+func (c *appGwConfigBuilder) HealthProbesCollection(ingressList []*v1beta1.Ingress) error {
 	backendIDs := make(map[backendIdentifier]interface{})
 	healthProbeCollection := make(map[string]network.ApplicationGatewayProbe)
 
@@ -71,7 +71,7 @@ func (c *appGwConfigBuilder) HealthProbesCollection(ingressList []*v1beta1.Ingre
 	}
 
 	c.appGwConfig.Probes = &probes
-	return c, nil
+	return nil
 }
 
 func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *network.ApplicationGatewayProbe {

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -33,7 +33,7 @@ var _ = Describe("configure App Gateway health probes", func() {
 		}
 
 		// !! Action !!
-		_, _ = cb.HealthProbesCollection(ingressList)
+		_ = cb.HealthProbesCollection(ingressList)
 		actual := cb.appGwConfig.Probes
 
 		// We expect our health probe configurator to have arrived at this final setup
@@ -122,7 +122,7 @@ var _ = Describe("configure App Gateway health probes", func() {
 		}
 
 		// !! Action !!
-		_, _ = cb.HealthProbesCollection(ingressList)
+		_ = cb.HealthProbesCollection(ingressList)
 		actual := cb.appGwConfig.Probes
 
 		// We expect our health probe configurator to have arrived at this final setup

--- a/pkg/appgw/http_listeners.go
+++ b/pkg/appgw/http_listeners.go
@@ -7,7 +7,7 @@ package appgw
 
 import "k8s.io/api/extensions/v1beta1"
 
-func (c *appGwConfigBuilder) Listeners(ingressList []*v1beta1.Ingress) (ConfigBuilder, error) {
+func (c *appGwConfigBuilder) Listeners(ingressList []*v1beta1.Ingress) error {
 	c.appGwConfig.SslCertificates = c.getSslCertificates(ingressList)
 	c.appGwConfig.FrontendPorts = c.getFrontendPorts(ingressList)
 	c.appGwConfig.HTTPListeners, _ = c.getListeners(ingressList)
@@ -17,5 +17,5 @@ func (c *appGwConfigBuilder) Listeners(ingressList []*v1beta1.Ingress) (ConfigBu
 	// in the RequestRoutingRules step, which must be executed after Listeners.
 	c.appGwConfig.RedirectConfigurations = c.getRedirectConfigurations(ingressList)
 
-	return c, nil
+	return nil
 }

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -76,7 +76,7 @@ func (c *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, rule *v1beta1.In
 	return urlPathMap
 }
 
-func (c *appGwConfigBuilder) RequestRoutingRules(ingressList []*v1beta1.Ingress) (ConfigBuilder, error) {
+func (c *appGwConfigBuilder) RequestRoutingRules(ingressList []*v1beta1.Ingress) error {
 	_, httpListenersMap := c.getListeners(ingressList)
 	urlPathMaps := make(map[listenerIdentifier]*network.ApplicationGatewayURLPathMap)
 	for _, ingress := range ingressList {
@@ -239,7 +239,7 @@ func (c *appGwConfigBuilder) RequestRoutingRules(ingressList []*v1beta1.Ingress)
 
 	c.appGwConfig.RequestRoutingRules = &requestRoutingRules
 	c.appGwConfig.URLPathMaps = &urlPathMapFiltered
-	return c, nil
+	return nil
 }
 
 func (c *appGwConfigBuilder) getSslRedirectConfigResourceReference(ingress *v1beta1.Ingress) *network.SubResource {

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 
 		ingressList := []*v1beta1.Ingress{&ingress}
 
-		_, _ = configBuilder.RequestRoutingRules(ingressList)
+		_ = configBuilder.RequestRoutingRules(ingressList)
 
 		It("should have correct RequestRoutingRules", func() {
 			Expect(len(*configBuilder.appGwConfig.RequestRoutingRules)).To(Equal(1))

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -73,21 +73,21 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	ingressList := c.k8sContext.GetHTTPIngressList()
 
 	// The following operations need to be in sequence
-	configBuilder, err = configBuilder.HealthProbesCollection(ingressList)
+	err = configBuilder.HealthProbesCollection(ingressList)
 	if err != nil {
 		glog.Errorf("unable to generate Health Probes, error [%v]", err.Error())
 		return errors.New("unable to generate health probes")
 	}
 
 	// The following operations need to be in sequence
-	configBuilder, err = configBuilder.BackendHTTPSettingsCollection(ingressList)
+	err = configBuilder.BackendHTTPSettingsCollection(ingressList)
 	if err != nil {
 		glog.Errorf("unable to generate backend http settings, error [%v]", err.Error())
 		return errors.New("unable to generate backend http settings")
 	}
 
 	// BackendAddressPools depend on BackendHTTPSettings
-	configBuilder, err = configBuilder.BackendAddressPools(ingressList)
+	err = configBuilder.BackendAddressPools(ingressList)
 	if err != nil {
 		glog.Errorf("unable to generate backend address pools, error [%v]", err.Error())
 		return errors.New("unable to generate backend address pools")
@@ -97,14 +97,14 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	// This also creates redirection configuration (if TLS is configured and Ingress is annotated).
 	// This configuration must be attached to request routing rules, which are created in the steps below.
 	// The order of operations matters.
-	configBuilder, err = configBuilder.Listeners(ingressList)
+	err = configBuilder.Listeners(ingressList)
 	if err != nil {
 		glog.Errorf("unable to generate frontend listeners, error [%v]", err.Error())
 		return errors.New("unable to generate frontend listeners")
 	}
 
 	// SSL redirection configurations created elsewhere will be attached to the appropriate rule in this step.
-	configBuilder, err = configBuilder.RequestRoutingRules(ingressList)
+	err = configBuilder.RequestRoutingRules(ingressList)
 	if err != nil {
 		glog.Errorf("unable to generate request routing rules, error [%v]", err.Error())
 		return errors.New("unable to generate request routing rules")


### PR DESCRIPTION
In all these cases below in is unnecessary to return `ConfigBuilder` since the function returning it already mutated the receiver and the changes are available to its peers.

The goal of this change is to:
 - simplify functions' signatures
 - remove the illusion that each function returning `ConfigBuilder` is without side-effects returning a copy of the struct.