### PR TITLE
Updating documentation to remove the constraint on Autoscale-disabled App Gateway; Fixes #245

### DIFF
--- a/docs/install-existing.md
+++ b/docs/install-existing.md
@@ -10,9 +10,9 @@ The Application Gateway Ingress controller runs as pod within the AKS cluster. I
 
 In order to install the ingress controller on AKS we use [Helm](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm).
 
-## Assumptions
-* An existing [Azure Application Gateway v2](https://docs.microsoft.com/en-us/azure/application-gateway/create-zone-redundant) with manual scaling configured (not set to AutoScale).
-* An existing Azure Kubernetes Service cluster with Advanced Networking enabled.
+## Prerequisites
+* An existing [Azure Application Gateway v2](https://docs.microsoft.com/en-us/azure/application-gateway/create-zone-redundant).
+* An existing Azure Kubernetes Service cluster with [Advanced Networking](https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni) enabled.
 * The [aad-pod-identity](https://github.com/Azure/aad-pod-identity) service is installed on the AKS cluster.
 
 ## Setting up Authentication with Azure Resource Manager

--- a/docs/install-existing.md
+++ b/docs/install-existing.md
@@ -1,5 +1,5 @@
 # Table of Contents
-- [Assumptions](#assumptions)
+- [Prerequisites](#prerequisites)
 - [Setting up Authentication with Azure Resource Manager (ARM)](#setting-up-authentication-with-azure-resource-manager)
     * [Setting up aad-pod-identity](#setting-up-aad-pod-identity)
         + [Create Azure Identity on ARM](#create-azure-identity-on-arm)


### PR DESCRIPTION
In December 2018 when we used an older version of the underlying SDK we had to ensure we don't accidentally disable autoscale. So this blurb was added to the documentation.
As we discovered in https://github.com/Azure/application-gateway-kubernetes-ingress/issues/245 - this is no longer the case.

AGIC can work with Auto-scale enabled App Gateways as well.