### PR TITLE
Sort urlPathmapFiltered

### DIFF
--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -243,7 +243,7 @@ func (c *appGwConfigBuilder) RequestRoutingRules(ingressList []*v1beta1.Ingress)
 	sort.Sort(sorter.ByRequestRoutingRuleName(requestRoutingRules))
 	c.appGwConfig.RequestRoutingRules = &requestRoutingRules
 
-	sort.Sort(sorter.ByRequestRoutingRuleName(requestRoutingRules))
+	sort.Sort(sorter.ByPathMap(urlPathMapFiltered))
 	c.appGwConfig.URLPathMaps = &urlPathMapFiltered
 
 	return nil


### PR DESCRIPTION
Fixing a bug, which leaves `urlPathMapFiltered` unsorted