### PR TITLE
Add more SSL Redirects tests and fix a bug

### DIFF
--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -155,7 +155,15 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 			Expect(azConfigMapKeys[0].FrontendPort).To(Equal(port443))
 
 			actualVal := httpListenersAzureConfigMap[azConfigMapKeys[0]]
-			Expect(actualVal).To(Equal(expectedListenerAzConfigSSL))
+			expectedListenerConfig := listenerAzConfig{
+				Protocol: "Https",
+				Secret: secretIdentifier{
+					Namespace: tests.Namespace,
+					Name:      tests.NameOfSecret,
+				},
+			}
+			Expect(actualVal).To(Equal(expectedListenerConfig))
+			Expect(actualVal.SslRedirectConfigurationName).To(Equal(""))
 		})
 	})
 })

--- a/pkg/appgw/redirects_test.go
+++ b/pkg/appgw/redirects_test.go
@@ -1,0 +1,142 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package appgw
+
+import (
+	"fmt"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+var _ = Describe("Test SSL Redirect Annotations", func() {
+
+	cb := newConfigBuilderFixture(nil)
+
+	listenerID1 := listenerIdentifier{
+		FrontendPort: 80,
+		HostName:     "bye.com",
+	}
+	listenerID2 := listenerIdentifier{
+		FrontendPort: 443,
+		HostName:     "bye.com",
+	}
+
+	expectedListenerConfigs := map[listenerIdentifier]listenerAzConfig{
+		listenerID1: {
+			Protocol: "Http",
+		},
+		listenerID2: {
+			Protocol: "Https",
+			Secret: secretIdentifier{
+				Namespace: tests.Namespace,
+				Name:      "--the-name-of-the-secret--",
+			},
+			SslRedirectConfigurationName: "sslr-" + tests.Namespace + "-" + tests.Name,
+		},
+	}
+
+	Context("Test RequestRoutingRules with TLS and with SSL Redirect Annotation", func() {
+		ingress := tests.NewIngressFixture()
+		ingressList := []*v1beta1.Ingress{ingress}
+		actualRedirects := cb.getRedirectConfigurations(ingressList)
+		expectedRedirect := n.ApplicationGatewayRedirectConfiguration{
+			ApplicationGatewayRedirectConfigurationPropertiesFormat: &n.ApplicationGatewayRedirectConfigurationPropertiesFormat{
+				RedirectType: "Permanent",
+				TargetListener: &n.SubResource{
+					ID: to.StringPtr("/subscriptions/--subscription--" +
+						"/resourceGroups/--resource-group--" +
+						"/providers/Microsoft.Network" +
+						"/applicationGateways/--app-gw-name--" +
+						"/httpListeners/fl-bye.com-443"),
+				},
+				TargetURL:           nil,
+				IncludePath:         to.BoolPtr(true),
+				IncludeQueryString:  to.BoolPtr(true),
+				RequestRoutingRules: nil,
+				URLPathMaps:         nil,
+				PathRules:           nil,
+			},
+			Name: to.StringPtr("sslr-" + tests.Namespace + "-" + tests.Name),
+			Etag: to.StringPtr("*"),
+			Type: nil,
+			ID:   nil,
+		}
+
+		_, actualListeners := cb.processIngressRules(ingress)
+
+		It("test was setup correctly", func() {
+			Expect(ingress.Spec.TLS).ToNot(BeNil())
+			Expect(ingress.Annotations[annotations.SslRedirectKey]).To(Equal("true"))
+		})
+
+		It("should have created correct ApplicationGatewayRedirectConfiguration struct", func() {
+			Expect(len(*actualRedirects)).To(Equal(1))
+			Expect(*actualRedirects).To(ContainElement(expectedRedirect))
+			Expect(len(actualListeners)).To(Equal(2))
+			Expect(actualListeners[listenerID1]).To(Equal(expectedListenerConfigs[listenerID1]))
+			Expect(actualListeners[listenerID2]).To(Equal(expectedListenerConfigs[listenerID2]))
+			Expect(actualListeners[listenerID2].SslRedirectConfigurationName).To(Equal("sslr-"+tests.Namespace+"-"+tests.Name), fmt.Sprintf("Actual: %+v", actualListeners))
+		})
+	})
+
+	Context("Test RequestRoutingRules without TLS but with SSL Redirect Annotation", func() {
+		ingress := tests.NewIngressFixture()
+		ingress.Spec.TLS = nil
+		ingressList := []*v1beta1.Ingress{ingress}
+		actualRedirects := cb.getRedirectConfigurations(ingressList)
+
+		// Run this to link the listeners and the redirect config
+		_, actualListeners := cb.processIngressRules(ingress)
+
+		It("test was setup correctly", func() {
+			Expect(ingress.Spec.TLS).To(BeNil())
+			Expect(ingress.Annotations[annotations.SslRedirectKey]).To(Equal("true"))
+		})
+
+		It("should have created correct ApplicationGatewayRedirectConfiguration struct", func() {
+			Expect(len(*actualRedirects)).To(Equal(0))
+			Expect(len(actualListeners)).To(Equal(1))
+			Expect(actualListeners[listenerID1]).To(Equal(expectedListenerConfigs[listenerID1]), fmt.Sprintf("Actual: %+v", actualListeners))
+			Expect(actualListeners[listenerID1].SslRedirectConfigurationName).To(Equal(""), fmt.Sprintf("Actual: %+v", actualListeners))
+		})
+	})
+
+	Context("Test RequestRoutingRules with TLS but without SSL Redirect Annotation", func() {
+		ingress := tests.NewIngressFixture()
+		delete(ingress.Annotations, annotations.SslRedirectKey)
+		ingressList := []*v1beta1.Ingress{ingress}
+		actualRedirects := cb.getRedirectConfigurations(ingressList)
+
+		// Run this to link the listeners and the redirect config
+		_, actualListeners := cb.processIngressRules(ingress)
+
+		It("test was setup correctly", func() {
+			Expect(ingress.Spec.TLS).ToNot(BeNil())
+			Expect(ingress.Annotations[annotations.SslRedirectKey]).To(Equal(""))
+		})
+
+		It("should have created correct ApplicationGatewayRedirectConfiguration struct", func() {
+			// Obviously there should be NO redirects since the annotation has been removed
+			Expect(len(*actualRedirects)).To(Equal(0))
+			Expect(len(actualListeners)).To(Equal(1))
+			expectedListenerConfig := listenerAzConfig{
+				Protocol: "Https",
+				Secret: secretIdentifier{
+					Namespace: tests.Namespace,
+					Name:      "--the-name-of-the-secret--",
+				},
+			}
+			Expect(actualListeners[listenerID2]).To(Equal(expectedListenerConfig), fmt.Sprintf("Actual: %+v", actualListeners))
+			Expect(actualListeners[listenerID2].SslRedirectConfigurationName).To(Equal(""), fmt.Sprintf("Actual: %+v", actualListeners))
+		})
+	})
+})


### PR DESCRIPTION
Adding comprehensive tests:
 - with TLS & with SSL Redirect Annotation
 - without TLS & with Annotation
 - with TLS & without Annotation

Fixes a bug where even without annotation we create a redirect.
This has not caused any issues since the unnecessary redirects have not been linked to routing rules.
