### PR TITLE
feat: use Private IP with routing rules

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -106,7 +106,7 @@ func main() {
 	// Run fatal validations
 	appGw, _ := appGwClient.Get(context.Background(), env.ResourceGroupName, env.AppGwName)
 	if err := appgw.FatalValidateOnExistingConfig(recorder, appGw.ApplicationGatewayPropertiesFormat, env); err != nil {
-		glog.Fatal("Got a fatal validation error on existing Application Gateway config. Please update Application Gateway or the controller's helm config.", err)
+		glog.Fatal("Got a fatal validation error on existing Application Gateway config. Please update Application Gateway or the controller's helm config. Error:", err)
 	}
 
 	k8sContext := k8scontext.NewContext(kubeClient, namespaces, *resyncPeriod)

--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -15,3 +15,4 @@ data:
   APPGW_RESOURCE_GROUP:  {{ required "A valid appgw entry is required!" .Values.appgw.resourceGroup }}
   APPGW_NAME:            {{ required "A valid appgw entry is required!" .Values.appgw.name }}
   KUBERNETES_WATCHNAMESPACE:  {{ required "A valid kubernetes watch namespace is required!" .Values.kubernetes.watchNamespace }}
+  USE_PRIVATE_IP: "{{ .Values.ipConfiguration.usePrivateIP }}"

--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -15,4 +15,4 @@ data:
   APPGW_RESOURCE_GROUP:  {{ required "A valid appgw entry is required!" .Values.appgw.resourceGroup }}
   APPGW_NAME:            {{ required "A valid appgw entry is required!" .Values.appgw.name }}
   KUBERNETES_WATCHNAMESPACE:  {{ required "A valid kubernetes watch namespace is required!" .Values.kubernetes.watchNamespace }}
-  USE_PRIVATE_IP: "{{ .Values.ipConfiguration.usePrivateIP }}"
+  USE_PRIVATE_IP: "{{ .Values.appgw.usePrivateIP }}"

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -18,6 +18,7 @@ kubernetes:
 #   subscriptionId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 #   resourceGroup: myResourceGroup
 #   name: myApplicationGateway
+#   usePrivateIP: true 
 
 ################################################################################
 # Specify the authentication with Azure Resource Manager
@@ -45,9 +46,3 @@ kubernetes:
 # Specify if the cluster is RBAC enabled or not
 # aksClusterConfiguration:
 #     apiServerAddress: <>
-
-################################################################################
-# Specify ip configuration related information for the gateway.
-# For using private Ip with the gateway, use usePrivateIP
-# ipConfiguration:
-#  usePrivateIP: true 

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -45,3 +45,9 @@ kubernetes:
 # Specify if the cluster is RBAC enabled or not
 # aksClusterConfiguration:
 #     apiServerAddress: <>
+
+################################################################################
+# Specify ip configuration related information for the gateway.
+# For using private Ip with the gateway, use usePrivateIP
+# ipConfiguration:
+#  usePrivateIP: true 

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
@@ -129,6 +130,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	serviceList := []*v1.Service{
 		service,
 	}
+
+	envVariables := environment.GetFakeEnv()
 
 	// Ideally we should be creating the `pods` resource instead of the `endpoints` resource
 	// and allowing the k8s API server to create the `endpoints` resource which we end up consuming.
@@ -335,7 +338,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// Add the listeners. We need the backend address pools before we can add HTTP listeners.
-		err = configBuilder.Listeners(ingressList)
+		err = configBuilder.Listeners(ingressList, envVariables)
 		Expect(err).Should(BeNil(), "Error in generating the HTTP listeners: %v", err)
 
 		// Get a pointer to the modified ApplicationGatewayPropertiesFormat
@@ -348,7 +351,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// RequestRoutingRules depends on the previous operations
-		err = configBuilder.RequestRoutingRules(ingressList, serviceList)
+		err = configBuilder.RequestRoutingRules(ingressList, serviceList, envVariables)
 		Expect(err).Should(BeNil(), "Error in generating the routing rules: %v", err)
 
 		// Get a pointer to the modified ApplicationGatewayPropertiesFormat

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -20,8 +20,8 @@ type ConfigBuilder interface {
 	// builder pattern
 	BackendHTTPSettingsCollection(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
 	BackendAddressPools(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
-	Listeners(ingressList []*v1beta1.Ingress) error
-	RequestRoutingRules(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
+	Listeners(ingressList []*v1beta1.Ingress, envVariables environment.EnvVariables) error
+	RequestRoutingRules(ingressList []*v1beta1.Ingress, serviceList []*v1.Service, envVariables environment.EnvVariables) error
 	HealthProbesCollection(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
 	GetApplicationGatewayPropertiesFormatPtr() *network.ApplicationGatewayPropertiesFormat
 	PreBuildValidate(envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error

--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -7,8 +7,10 @@ package appgw
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -17,14 +19,14 @@ import (
 )
 
 // getListeners constructs the unique set of App Gateway HTTP listeners across all ingresses.
-func (c *appGwConfigBuilder) getListeners(ingressList []*v1beta1.Ingress) (*[]n.ApplicationGatewayHTTPListener, map[listenerIdentifier]*n.ApplicationGatewayHTTPListener) {
+func (c *appGwConfigBuilder) getListeners(ingressList []*v1beta1.Ingress, envVariables environment.EnvVariables) (*[]n.ApplicationGatewayHTTPListener, map[listenerIdentifier]*n.ApplicationGatewayHTTPListener) {
 	// TODO(draychev): this is for compatibility w/ RequestRoutingRules and should be removed ASAP
 	legacyMap := make(map[listenerIdentifier]*n.ApplicationGatewayHTTPListener)
 
 	var listeners []n.ApplicationGatewayHTTPListener
 
 	for listenerID, config := range c.getListenerConfigs(ingressList) {
-		listener := c.newListener(listenerID, config.Protocol)
+		listener := c.newListener(listenerID, config.Protocol, envVariables)
 		if config.Protocol == n.HTTPS {
 			sslCertificateID := c.appGwIdentifier.sslCertificateID(config.Secret.secretFullName())
 			listener.SslCertificate = resourceRef(sslCertificateID)
@@ -61,7 +63,7 @@ func (c *appGwConfigBuilder) getListenerConfigs(ingressList []*v1beta1.Ingress) 
 	return allListeners
 }
 
-func (c *appGwConfigBuilder) newListener(listener listenerIdentifier, protocol n.ApplicationGatewayProtocol) n.ApplicationGatewayHTTPListener {
+func (c *appGwConfigBuilder) newListener(listener listenerIdentifier, protocol n.ApplicationGatewayProtocol, envVariables environment.EnvVariables) n.ApplicationGatewayHTTPListener {
 	frontendPortName := generateFrontendPortName(listener.FrontendPort)
 	frontendPortID := c.appGwIdentifier.frontendPortID(frontendPortName)
 
@@ -70,7 +72,7 @@ func (c *appGwConfigBuilder) newListener(listener listenerIdentifier, protocol n
 		Name: to.StringPtr(generateListenerName(listener)),
 		ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
 			// TODO: expose this to external configuration
-			FrontendIPConfiguration: resourceRef(*c.getPublicIPID()),
+			FrontendIPConfiguration: resourceRef(*c.getIPConfigurationID(envVariables)),
 			FrontendPort:            resourceRef(frontendPortID),
 			Protocol:                protocol,
 			HostName:                &listener.HostName,
@@ -78,8 +80,8 @@ func (c *appGwConfigBuilder) newListener(listener listenerIdentifier, protocol n
 	}
 }
 
-func (c *appGwConfigBuilder) getPublicIPID() *string {
-	var publicIPID *string
+func (c *appGwConfigBuilder) getIPConfigurationID(envVariables environment.EnvVariables) *string {
+	var ipID *string
 	var jsonConfigs []string
 	for _, ip := range *c.appGwConfig.FrontendIPConfigurations {
 		// Collect the JSON IP configs for debug purposes.
@@ -88,21 +90,23 @@ func (c *appGwConfigBuilder) getPublicIPID() *string {
 		} else {
 			jsonConfigs = append(jsonConfigs, string(jsonConf))
 		}
-		// Either PublicIPAddress is nil or PrivateIPAddress; never both present never both nil;
-		if ip.ApplicationGatewayFrontendIPConfigurationPropertiesFormat != nil && ip.PublicIPAddress != nil {
-			publicIPID = ip.ID
+
+		if usePrivateIP, _ := strconv.ParseBool(envVariables.UsePrivateIP); usePrivateIP {
+			if ip.ApplicationGatewayFrontendIPConfigurationPropertiesFormat != nil && ip.PrivateIPAddress != nil {
+				ipID = ip.ID
+			}
+		} else {
+			if ip.ApplicationGatewayFrontendIPConfigurationPropertiesFormat != nil && ip.PublicIPAddress != nil {
+				ipID = ip.ID
+			}
 		}
 	}
 
-	if publicIPID == nil {
-		// App Gateway will always have a Public IP address.
-		// In the case where somehow it does not have one - it may be appropriate to crash.
+	if ipID == nil {
+		// This should not happen as we are performing validation on frontIpConfiguration to make sure if have the required IP.
 		ips := strings.Join(jsonConfigs, ", ")
-
-		// Will call os.Exit(255)
-		// TODO(draychev): glog.Fatal does not expose stack trace.
-		glog.Fatal("HTTP Listener was not able to find a Public IP address for App Gateway. Available IPs:", ips)
+		glog.Error("HTTP Listener was not able to find a Public IP address for App Gateway. Available IPs:", ips)
 	}
 
-	return publicIPID
+	return ipID
 }

--- a/pkg/appgw/http_listeners.go
+++ b/pkg/appgw/http_listeners.go
@@ -6,13 +6,14 @@
 package appgw
 
 import (
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"k8s.io/api/extensions/v1beta1"
 )
 
-func (c *appGwConfigBuilder) Listeners(ingressList []*v1beta1.Ingress) error {
+func (c *appGwConfigBuilder) Listeners(ingressList []*v1beta1.Ingress, envVariables environment.EnvVariables) error {
 	c.appGwConfig.SslCertificates = c.getSslCertificates(ingressList)
 	c.appGwConfig.FrontendPorts = c.getFrontendPorts(ingressList)
-	c.appGwConfig.HTTPListeners, _ = c.getListeners(ingressList)
+	c.appGwConfig.HTTPListeners, _ = c.getListeners(ingressList, envVariables)
 
 	// App Gateway Rules can be configured to redirect HTTP traffic to HTTPS URLs.
 	// In this step here we create the redirection configurations. These configs are attached to request routing rules

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -79,8 +80,8 @@ func (c *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, serviceList []*v
 	return urlPathMap
 }
 
-func (c *appGwConfigBuilder) RequestRoutingRules(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error {
-	_, httpListenersMap := c.getListeners(ingressList)
+func (c *appGwConfigBuilder) RequestRoutingRules(ingressList []*v1beta1.Ingress, serviceList []*v1.Service, envVariables environment.EnvVariables) error {
+	_, httpListenersMap := c.getListeners(ingressList, envVariables)
 	urlPathMaps := make(map[listenerIdentifier]*network.ApplicationGatewayURLPathMap)
 	backendPools := c.newBackendPoolMap(ingressList, serviceList)
 	_, backendHTTPSettingsMap, _, _ := c.getBackendsAndSettingsMap(ingressList, serviceList)

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -6,6 +6,7 @@
 package appgw
 
 import (
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
@@ -138,7 +139,8 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 
 		ingressList := []*v1beta1.Ingress{&ingress}
 		serviceList := []*v1.Service{tests.NewServiceFixture()}
-		_ = configBuilder.RequestRoutingRules(ingressList, serviceList)
+		envVariables := environment.GetFakeEnv()
+		_ = configBuilder.RequestRoutingRules(ingressList, serviceList, envVariables)
 
 		It("should have correct RequestRoutingRules", func() {
 			Expect(len(*configBuilder.appGwConfig.RequestRoutingRules)).To(Equal(1))

--- a/pkg/appgw/test_fixtures.go
+++ b/pkg/appgw/test_fixtures.go
@@ -7,6 +7,7 @@ package appgw
 
 import (
 	"fmt"
+
 	"k8s.io/client-go/tools/record"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
@@ -19,7 +20,7 @@ import (
 func newAppGwyConfigFixture() network.ApplicationGatewayPropertiesFormat {
 	feIPConfigs := []network.ApplicationGatewayFrontendIPConfiguration{
 		{
-			// Private IP
+			// Public IP
 			Name: to.StringPtr("xx3"),
 			Etag: to.StringPtr("xx2"),
 			Type: to.StringPtr("xx1"),
@@ -32,11 +33,11 @@ func newAppGwyConfigFixture() network.ApplicationGatewayPropertiesFormat {
 			},
 		},
 		{
-			// Public IP
+			// Private IP
 			Name: to.StringPtr("yy3"),
 			Etag: to.StringPtr("yy2"),
 			Type: to.StringPtr("yy1"),
-			ID:   to.StringPtr("yy4"),
+			ID:   to.StringPtr(tests.IPID2),
 			ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
 				PrivateIPAddress: to.StringPtr("abc"),
 				PublicIPAddress:  nil,

--- a/pkg/appgw/validators.go
+++ b/pkg/appgw/validators.go
@@ -8,6 +8,7 @@ package appgw
 import (
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
@@ -22,6 +23,8 @@ const (
 	errKeyEitherDefaults = "either-defaults"
 	errKeyNoBorR         = "no-backend-or-redirect"
 	errKeyEitherBorR     = "either-backend-or-redirect"
+	errKeyNoPrivateIP    = "no-private-ip"
+	errKeyNoPublicIP     = "no-public-ip"
 )
 
 var validationErrors = map[string]error{
@@ -29,6 +32,8 @@ var validationErrors = map[string]error{
 	errKeyEitherDefaults: errors.New("URL Path Map must have either DefaultRedirectConfiguration or (DefaultBackendAddressPool + DefaultBackendHTTPSettings) but not both"),
 	errKeyNoBorR:         errors.New("A valid path rule must have one of RedirectConfiguration or (BackendAddressPool + BackendHTTPSettings)"),
 	errKeyEitherBorR:     errors.New("A Path Rule must have either RedirectConfiguration or (BackendAddressPool + BackendHTTPSettings) but not both"),
+	errKeyNoPrivateIP:    errors.New("A Private IP must be present in the Application Gateway FrontendIPConfiguration if the controller is configured to UsePrivateIP for routing rules"),
+	errKeyNoPublicIP:     errors.New("A Public IP must be present in the Application Gateway FrontendIPConfiguration"),
 }
 
 func validateServiceDefinition(eventRecorder record.EventRecorder, config *n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error {
@@ -104,10 +109,34 @@ func validateURLPathMaps(eventRecorder record.EventRecorder, config *n.Applicati
 	return nil
 }
 
+func validateFrontendIPConfiguration(eventRecorder record.EventRecorder, config *n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables) error {
+	privateIPPresent := false
+	publicIPPresent := false
+	for _, ip := range *config.FrontendIPConfigurations {
+		if ip.ApplicationGatewayFrontendIPConfigurationPropertiesFormat != nil && ip.PrivateIPAddress != nil {
+			privateIPPresent = true
+		} else if ip.ApplicationGatewayFrontendIPConfigurationPropertiesFormat != nil && ip.PublicIPAddress != nil {
+			publicIPPresent = true
+		}
+	}
+
+	if usePrivateIP, _ := strconv.ParseBool(envVariables.UsePrivateIP); usePrivateIP && !privateIPPresent {
+		return validationErrors[errKeyNoPrivateIP]
+	}
+
+	if !publicIPPresent {
+		return validationErrors[errKeyNoPublicIP]
+	}
+
+	return nil
+}
+
 // FatalValidateOnExistingConfig validates the existing configuration is valid for the specified setting of the controller.
 func FatalValidateOnExistingConfig(eventRecorder record.EventRecorder, config *n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables) error {
 
-	validators := []func(eventRecorder record.EventRecorder, config *network.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables) error{}
+	validators := []func(eventRecorder record.EventRecorder, config *network.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables) error{
+		validateFrontendIPConfiguration,
+	}
 
 	for _, fn := range validators {
 		if err := fn(eventRecorder, config, envVariables); err != nil {

--- a/pkg/appgw/validators.go
+++ b/pkg/appgw/validators.go
@@ -113,11 +113,10 @@ func validateFrontendIPConfiguration(eventRecorder record.EventRecorder, config 
 	privateIPPresent := false
 	publicIPPresent := false
 	for _, ip := range *config.FrontendIPConfigurations {
-		if ip.ApplicationGatewayFrontendIPConfigurationPropertiesFormat != nil && ip.PrivateIPAddress != nil {
-			privateIPPresent = true
-		} else if ip.ApplicationGatewayFrontendIPConfigurationPropertiesFormat != nil && ip.PublicIPAddress != nil {
-			publicIPPresent = true
-		}
+		privateIPPresent = privateIPPresent ||
+			(ip.ApplicationGatewayFrontendIPConfigurationPropertiesFormat != nil && ip.PrivateIPAddress != nil)
+		publicIPPresent = publicIPPresent ||
+			(ip.ApplicationGatewayFrontendIPConfigurationPropertiesFormat != nil && ip.PublicIPAddress != nil)
 	}
 
 	if usePrivateIP, _ := strconv.ParseBool(envVariables.UsePrivateIP); usePrivateIP && !privateIPPresent {

--- a/pkg/appgw/validators_test.go
+++ b/pkg/appgw/validators_test.go
@@ -7,6 +7,7 @@ package appgw
 
 import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
@@ -106,6 +107,83 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 			config.URLPathMaps = &[]n.ApplicationGatewayURLPathMap{pathMap}
 			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
 			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("test validateFrontendIPConfiguration", func() {
+		eventRecorder := record.NewFakeRecorder(100)
+		envVariables := environment.GetFakeEnv()
+
+		publicIPConf := n.ApplicationGatewayFrontendIPConfiguration{
+			// Public IP
+			Name: to.StringPtr("xx3"),
+			Etag: to.StringPtr("xx2"),
+			Type: to.StringPtr("xx1"),
+			ID:   to.StringPtr(tests.IPID1),
+			ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &n.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+				PrivateIPAddress: nil,
+				PublicIPAddress: &n.SubResource{
+					ID: to.StringPtr("xyz"),
+				},
+			},
+		}
+
+		privateIPConf := n.ApplicationGatewayFrontendIPConfiguration{
+			// Private IP
+			Name: to.StringPtr("yy3"),
+			Etag: to.StringPtr("yy2"),
+			Type: to.StringPtr("yy1"),
+			ID:   to.StringPtr(tests.IPID2),
+			ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &n.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+				PrivateIPAddress: to.StringPtr("abc"),
+				PublicIPAddress:  nil,
+			},
+		}
+
+		config := n.ApplicationGatewayPropertiesFormat{
+			FrontendIPConfigurations: &[]n.ApplicationGatewayFrontendIPConfiguration{},
+		}
+
+		It("should error out when Ip Configuration is empty.", func() {
+			config.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{}
+			err := validateFrontendIPConfiguration(eventRecorder, &config, envVariables)
+			Expect(err).To(Equal(validationErrors[errKeyNoPublicIP]))
+		})
+
+		It("should not error out when Ip Configuration is contains 1 PublicIP and UsePrivateIP is false.", func() {
+			config.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{publicIPConf}
+			err := validateFrontendIPConfiguration(eventRecorder, &config, envVariables)
+			Expect(err).To(BeNil())
+		})
+
+		It("should not error out when Ip Configuration is contains both PublicIP & PrivateIP and UsePrivateIP is false.", func() {
+			config.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{publicIPConf, privateIPConf}
+			err := validateFrontendIPConfiguration(eventRecorder, &config, envVariables)
+			Expect(err).To(BeNil())
+		})
+
+		It("should not error out when Ip Configuration is contains both PublicIP & PrivateIP and UsePrivateIP is true.", func() {
+			envVariablesNew := environment.GetFakeEnv()
+			envVariablesNew.UsePrivateIP = "true"
+			Expect(envVariablesNew.UsePrivateIP).To(Equal("true"))
+			config.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{publicIPConf, privateIPConf}
+			err := validateFrontendIPConfiguration(eventRecorder, &config, envVariablesNew)
+			Expect(err).To(BeNil())
+		})
+
+		It("should error out when Ip Configuration is contains 1 PublicIP and UsePrivateIP is true.", func() {
+			envVariablesNew := environment.GetFakeEnv()
+			envVariablesNew.UsePrivateIP = "true"
+			Expect(envVariablesNew.UsePrivateIP).To(Equal("true"))
+			config.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{publicIPConf}
+			err := validateFrontendIPConfiguration(eventRecorder, &config, envVariablesNew)
+			Expect(err).To(Equal(validationErrors[errKeyNoPrivateIP]))
+		})
+
+		It("should error out when Ip Configuration is doesn't contain public IP.", func() {
+			config.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{privateIPConf}
+			err := validateFrontendIPConfiguration(eventRecorder, &config, envVariables)
+			Expect(err).To(Equal(validationErrors[errKeyNoPublicIP]))
 		})
 	})
 })

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -114,14 +114,14 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	// This also creates redirection configuration (if TLS is configured and Ingress is annotated).
 	// This configuration must be attached to request routing rules, which are created in the steps below.
 	// The order of operations matters.
-	err = configBuilder.Listeners(ingressList)
+	err = configBuilder.Listeners(ingressList, envVariables)
 	if err != nil {
 		glog.Errorf("unable to generate frontend listeners, error [%v]", err.Error())
 		return errors.New("unable to generate frontend listeners")
 	}
 
 	// SSL redirection configurations created elsewhere will be attached to the appropriate rule in this step.
-	err = configBuilder.RequestRoutingRules(ingressList, serviceList)
+	err = configBuilder.RequestRoutingRules(ingressList, serviceList, envVariables)
 	if err != nil {
 		glog.Errorf("unable to generate request routing rules, error [%v]", err.Error())
 		return errors.New("unable to generate request routing rules")

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -8,11 +8,12 @@ package tests
 import (
 	"fmt"
 
+	"io/ioutil"
+
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
-	"io/ioutil"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,7 @@ const (
 	ResourceGroup = "--resource-group--"
 	AppGwName     = "--app-gw-name--"
 	IPID1         = "--front-end-ip-id-1--"
+	IPID2         = "--front-end-ip-id-2--"
 )
 
 // GetIngress creates an Ingress test fixture.


### PR DESCRIPTION
This PR adds support to allow Ingress Controller to use private IP with the Application Gateway.

To enable using Private IP, modify the `helm` config by adding
```yaml
appgw:
    subscriptionId: <subscriptionId>
    resourceGroup: <resourceGroupName>
    name: <applicationGatewayName>
    usePrivateIP: true

armAuth:
     type: aadPodIdentity
     identityResourceID: <identityResourceId>
     identityClientID:  <identityClientId>

kubernetes:
     watchNamespace: <namespace>
rbac:
     enabled: false
aksClusterConfiguration:
     apiServerAddress: <aks-api-server-address>

```

This will make the ingress controller look for private ip when assigning the ip configuration for the listener.

Another solution to this could have been:
```yaml
appgw.ingress.kubernetes.io/use-private-ip: true
```
We are not implementing this one since Application Gateway doesn't support listeners with different FrontendIPConfigurations (Public/Private) on the same port. It would be hard to resolve conflicts when two ingress want to deploy on same port but one is public and one is private.
In order to avoid conflicting scenarios when configuring ingress, this setting has been kept at the controller configuration level.