### PR TITLE
Move pkg/k8scontext/event.go to pkg/events/events.go

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -6,10 +6,6 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
@@ -21,6 +17,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
 type appGWSettingsChecker struct {
@@ -369,7 +371,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		for {
 			select {
 			case obj := <-ctxt.UpdateChannel.Out():
-				event := obj.(k8scontext.Event)
+				event := obj.(events.Event)
 				// Check if we got an event of type secret.
 				if _, ok := event.Value.(*v1beta1.Ingress); ok {
 					return

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -11,15 +11,16 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/client-go/tools/record"
-
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/eapache/channels"
 	"github.com/golang/glog"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 )
 
 // AppGwIngressController configures the application gateway based on the ingress rules defined.
@@ -178,7 +179,7 @@ func (c *AppGwIngressController) Start() {
 	for {
 		select {
 		case obj := <-c.k8sUpdateChannel.Out():
-			event := obj.(k8scontext.Event)
+			event := obj.(events.Event)
 			c.eventQueue.Enqueue(event)
 		case <-c.stopChannel:
 			break

--- a/pkg/controller/eventqueue.go
+++ b/pkg/controller/eventqueue.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
@@ -35,7 +35,7 @@ type EventQueue struct {
 // configuration. CanSkip specifies if this event can be skipped if a previous
 // event is processed at a later time.
 type QueuedEvent struct {
-	Event     k8scontext.Event
+	Event     events.Event
 	Timestamp int64
 	CanSkip   bool
 }
@@ -56,7 +56,7 @@ func NewEventQueue(processor EventProcessor) *EventQueue {
 
 // EnqueueCanSkip adds an event with parameter el as payload. User can specify if
 // this event should be skippable by setting the boolean parameter skip.
-func (q *EventQueue) EnqueueCanSkip(el k8scontext.Event, skip bool) {
+func (q *EventQueue) EnqueueCanSkip(el events.Event, skip bool) {
 	if q.queue.ShuttingDown() {
 		// Queue is shutting down will not be able to enqueue this.
 		glog.Errorf("queue is shutting down, unable to enqueue event")
@@ -77,7 +77,7 @@ func (q *EventQueue) EnqueueCanSkip(el k8scontext.Event, skip bool) {
 }
 
 // Enqueue adds an non-skipable event with parameter el as payload.
-func (q *EventQueue) Enqueue(el k8scontext.Event) {
+func (q *EventQueue) Enqueue(el events.Event) {
 	q.EnqueueCanSkip(el, false)
 }
 

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
-package k8scontext
+package events
 
 // EventType represents the type of update for k8s resources
 type EventType int

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -5,7 +5,7 @@
 
 package events
 
-// EventType represents the type of update for k8s resources
+// EventType is the type of event we have received from Kubernetes
 type EventType int
 
 const (
@@ -17,7 +17,7 @@ const (
 	Delete
 )
 
-// Event type that contains the type of event and data related to this event
+// Event is the combined type and actual object we received from Kubernetes
 type Event struct {
 	Type  EventType
 	Value interface{}


### PR DESCRIPTION
This PR is a small chunk from https://github.com/Azure/application-gateway-kubernetes-ingress/pull/267

The move here is necessary to avoid a cyclical dependency && allow for reusability of the Event struct.