### PR TITLE
chore: Split Validation into FatalValidateOnExistingConfig, PreBuildValidate, PostBuildValidate

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -100,9 +100,16 @@ func main() {
 	namespaces := getNamespacesToWatch(env.WatchNamespace)
 	validateNamespaces(namespaces, kubeClient) // side-effect: will panic on non-existent namespace
 	glog.Info("Ingress Controller will observe the following namespaces:", strings.Join(namespaces, ","))
-	k8sContext := k8scontext.NewContext(kubeClient, namespaces, *resyncPeriod)
 
 	recorder := getEventRecorder(kubeClient)
+
+	// Run fatal validations
+	appGw, _ := appGwClient.Get(context.Background(), env.ResourceGroupName, env.AppGwName)
+	if err := appgw.FatalValidateOnExistingConfig(recorder, appGw.ApplicationGatewayPropertiesFormat, env); err != nil {
+		glog.Fatal("Got a fatal validation error on existing Application Gateway config. Please update Application Gateway or the controller's helm config.", err)
+	}
+
+	k8sContext := k8scontext.NewContext(kubeClient, namespaces, *resyncPeriod)
 
 	go controller.NewAppGwIngressController(appGwClient, appGwIdentifier, k8sContext, recorder).Start()
 	select {}

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -307,7 +307,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		Expect(err).Should(BeNil(), "Error in generating the HTTP Settings: %v", err)
 
 		// Retrieve the implementation of the `ConfigBuilder` interface.
-		appGW, _ := configBuilder.Build(ingressList, serviceList)
+		appGW := configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 		// We will have a default HTTP setting that gets added, and an HTTP setting corresponding to port `backendPort`
 		Expect(len(*appGW.BackendHTTPSettingsCollection)).To(Equal(settings.backendHTTPSettingsCollection.total), "Did not find expected number of backend HTTP settings")
 
@@ -326,7 +326,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		Expect(err).Should(BeNil(), "Error in generating the backend address pools: %v", err)
 
 		// Retrieve the implementation of the `ConfigBuilder` interface.
-		appGW, _ = configBuilder.Build(ingressList, serviceList)
+		appGW = configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 		// We will have a default backend address pool that gets added, and a backend pool corresponding to our service.
 		Expect(len(*appGW.BackendAddressPools)).To(Equal(settings.backendAddressPools.total), "Did not find expected number of backend address pool.")
 
@@ -339,7 +339,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		Expect(err).Should(BeNil(), "Error in generating the HTTP listeners: %v", err)
 
 		// Retrieve the implementation of the `ConfigBuilder` interface.
-		appGW, _ = configBuilder.Build(ingressList, serviceList)
+		appGW = configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 		// Ingress allows listeners on port 80 or port 443. Therefore in this particular case we would have only a single listener
 		Expect(len(*appGW.HTTPListeners)).To(Equal(settings.listeners.total), "Did not find expected number of HTTP listeners")
 
@@ -352,7 +352,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		Expect(err).Should(BeNil(), "Error in generating the routing rules: %v", err)
 
 		// Retrieve the implementation of the `ConfigBuilder` interface.
-		appGW, _ = configBuilder.Build(ingressList, serviceList)
+		appGW = configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 		Expect(len(*appGW.RequestRoutingRules)).To(Equal(settings.requestRoutingRules.total),
 			fmt.Sprintf("Expected %d request routing rules; Got %d", settings.requestRoutingRules.total, len(*appGW.RequestRoutingRules)))
 

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -306,7 +306,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		err = configBuilder.BackendHTTPSettingsCollection(ingressList, serviceList)
 		Expect(err).Should(BeNil(), "Error in generating the HTTP Settings: %v", err)
 
-		// Get pointer the modified ApplicationGatewayPropertiesFormat
+		// Get a pointer to the modified ApplicationGatewayPropertiesFormat
 		appGW := configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 		// We will have a default HTTP setting that gets added, and an HTTP setting corresponding to port `backendPort`
 		Expect(len(*appGW.BackendHTTPSettingsCollection)).To(Equal(settings.backendHTTPSettingsCollection.total), "Did not find expected number of backend HTTP settings")
@@ -325,7 +325,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		err = configBuilder.BackendAddressPools(ingressList, serviceList)
 		Expect(err).Should(BeNil(), "Error in generating the backend address pools: %v", err)
 
-		// Get pointer the modified ApplicationGatewayPropertiesFormat
+		// Get a pointer to the modified ApplicationGatewayPropertiesFormat
 		appGW = configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 		// We will have a default backend address pool that gets added, and a backend pool corresponding to our service.
 		Expect(len(*appGW.BackendAddressPools)).To(Equal(settings.backendAddressPools.total), "Did not find expected number of backend address pool.")
@@ -338,7 +338,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		err = configBuilder.Listeners(ingressList)
 		Expect(err).Should(BeNil(), "Error in generating the HTTP listeners: %v", err)
 
-		// Get pointer the modified ApplicationGatewayPropertiesFormat
+		// Get a pointer to the modified ApplicationGatewayPropertiesFormat
 		appGW = configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 		// Ingress allows listeners on port 80 or port 443. Therefore in this particular case we would have only a single listener
 		Expect(len(*appGW.HTTPListeners)).To(Equal(settings.listeners.total), "Did not find expected number of HTTP listeners")
@@ -351,7 +351,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		err = configBuilder.RequestRoutingRules(ingressList, serviceList)
 		Expect(err).Should(BeNil(), "Error in generating the routing rules: %v", err)
 
-		// Get pointer the modified ApplicationGatewayPropertiesFormat
+		// Get a pointer to the modified ApplicationGatewayPropertiesFormat
 		appGW = configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 		Expect(len(*appGW.RequestRoutingRules)).To(Equal(settings.requestRoutingRules.total),
 			fmt.Sprintf("Expected %d request routing rules; Got %d", settings.requestRoutingRules.total, len(*appGW.RequestRoutingRules)))

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -306,7 +306,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		err = configBuilder.BackendHTTPSettingsCollection(ingressList, serviceList)
 		Expect(err).Should(BeNil(), "Error in generating the HTTP Settings: %v", err)
 
-		// Retrieve the implementation of the `ConfigBuilder` interface.
+		// Get pointer the modified ApplicationGatewayPropertiesFormat
 		appGW := configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 		// We will have a default HTTP setting that gets added, and an HTTP setting corresponding to port `backendPort`
 		Expect(len(*appGW.BackendHTTPSettingsCollection)).To(Equal(settings.backendHTTPSettingsCollection.total), "Did not find expected number of backend HTTP settings")
@@ -325,7 +325,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		err = configBuilder.BackendAddressPools(ingressList, serviceList)
 		Expect(err).Should(BeNil(), "Error in generating the backend address pools: %v", err)
 
-		// Retrieve the implementation of the `ConfigBuilder` interface.
+		// Get pointer the modified ApplicationGatewayPropertiesFormat
 		appGW = configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 		// We will have a default backend address pool that gets added, and a backend pool corresponding to our service.
 		Expect(len(*appGW.BackendAddressPools)).To(Equal(settings.backendAddressPools.total), "Did not find expected number of backend address pool.")
@@ -338,7 +338,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		err = configBuilder.Listeners(ingressList)
 		Expect(err).Should(BeNil(), "Error in generating the HTTP listeners: %v", err)
 
-		// Retrieve the implementation of the `ConfigBuilder` interface.
+		// Get pointer the modified ApplicationGatewayPropertiesFormat
 		appGW = configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 		// Ingress allows listeners on port 80 or port 443. Therefore in this particular case we would have only a single listener
 		Expect(len(*appGW.HTTPListeners)).To(Equal(settings.listeners.total), "Did not find expected number of HTTP listeners")
@@ -351,7 +351,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		err = configBuilder.RequestRoutingRules(ingressList, serviceList)
 		Expect(err).Should(BeNil(), "Error in generating the routing rules: %v", err)
 
-		// Retrieve the implementation of the `ConfigBuilder` interface.
+		// Get pointer the modified ApplicationGatewayPropertiesFormat
 		appGW = configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 		Expect(len(*appGW.RequestRoutingRules)).To(Equal(settings.requestRoutingRules.total),
 			fmt.Sprintf("Expected %d request routing rules; Got %d", settings.requestRoutingRules.total, len(*appGW.RequestRoutingRules)))

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -6,6 +6,7 @@
 package appgw
 
 import (
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/golang/glog"
@@ -22,7 +23,9 @@ type ConfigBuilder interface {
 	Listeners(ingressList []*v1beta1.Ingress) error
 	RequestRoutingRules(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
 	HealthProbesCollection(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
-	Build(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) (*network.ApplicationGatewayPropertiesFormat, error)
+	GetApplicationGatewayPropertiesFormatPtr() *network.ApplicationGatewayPropertiesFormat
+	PreBuildValidate(envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
+	PostBuildValidate(envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
 }
 
 type appGwConfigBuilder struct {
@@ -96,20 +99,34 @@ func generateListenerID(rule *v1beta1.IngressRule,
 }
 
 // Build generates the ApplicationGatewayPropertiesFormat for azure resource manager
-func (c *appGwConfigBuilder) Build(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) (*network.ApplicationGatewayPropertiesFormat, error) {
-	return &c.appGwConfig, c.Validate(ingressList, serviceList)
+func (c *appGwConfigBuilder) GetApplicationGatewayPropertiesFormatPtr() *network.ApplicationGatewayPropertiesFormat {
+	return &c.appGwConfig
 }
 
 // Validate runs all the validators on the config constructed to ensure it complies with App Gateway requirements.
-func (c *appGwConfigBuilder) Validate(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error {
+func (c *appGwConfigBuilder) PreBuildValidate(envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error {
 
-	validators := []func(eventRecorder record.EventRecorder, config *network.ApplicationGatewayPropertiesFormat, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error{
-		validateURLPathMaps,
+	validators := []func(eventRecorder record.EventRecorder, config *network.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error{
 		validateServiceDefinition,
 	}
 
 	for _, fn := range validators {
-		if err := fn(c.recorder, &c.appGwConfig, ingressList, serviceList); err != nil {
+		if err := fn(c.recorder, &c.appGwConfig, envVariables, ingressList, serviceList); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *appGwConfigBuilder) PostBuildValidate(envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error {
+
+	validators := []func(eventRecorder record.EventRecorder, config *network.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error{
+		validateURLPathMaps,
+	}
+
+	for _, fn := range validators {
+		if err := fn(c.recorder, &c.appGwConfig, envVariables, ingressList, serviceList); err != nil {
 			return err
 		}
 	}

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -98,12 +98,12 @@ func generateListenerID(rule *v1beta1.IngressRule,
 	return listenerID
 }
 
-// Build generates the ApplicationGatewayPropertiesFormat for azure resource manager
+// GetApplicationGatewayPropertiesFormatPtr gets a pointer to updated ApplicationGatewayPropertiesFormat.
 func (c *appGwConfigBuilder) GetApplicationGatewayPropertiesFormatPtr() *network.ApplicationGatewayPropertiesFormat {
 	return &c.appGwConfig
 }
 
-// Validate runs all the validators on the config constructed to ensure it complies with App Gateway requirements.
+// PreBuildValidate runs all the validators that suggest misconfiguration in Kubernetes resources.
 func (c *appGwConfigBuilder) PreBuildValidate(envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error {
 
 	validators := []func(eventRecorder record.EventRecorder, config *network.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error{
@@ -119,6 +119,7 @@ func (c *appGwConfigBuilder) PreBuildValidate(envVariables environment.EnvVariab
 	return nil
 }
 
+// PostBuildValidate runs all the validators on the config constructed to ensure it complies with App Gateway requirements.
 func (c *appGwConfigBuilder) PostBuildValidate(envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error {
 
 	validators := []func(eventRecorder record.EventRecorder, config *network.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error{

--- a/pkg/appgw/validators_test.go
+++ b/pkg/appgw/validators_test.go
@@ -6,6 +6,7 @@
 package appgw
 
 import (
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
@@ -23,13 +24,14 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 		eventRecorder := record.NewFakeRecorder(100)
 		ingressList := []*v1beta1.Ingress{}
 		serviceList := []*v1.Service{}
+		envVariables := environment.GetFakeEnv()
 
 		config := n.ApplicationGatewayPropertiesFormat{
 			URLPathMaps: &[]n.ApplicationGatewayURLPathMap{},
 		}
 
 		It("", func() {
-			err := validateURLPathMaps(eventRecorder, &config, ingressList, serviceList)
+			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
 			Expect(err).To(BeNil())
 		})
 
@@ -43,7 +45,7 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 				},
 			}
 			config.URLPathMaps = &[]n.ApplicationGatewayURLPathMap{pathMap}
-			err := validateURLPathMaps(eventRecorder, &config, ingressList, serviceList)
+			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
 			Expect(err).ToNot(BeNil())
 			Expect(err).To(Equal(validationErrors[errKeyNoDefaults]))
 		})
@@ -58,7 +60,7 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 				},
 			}
 			config.URLPathMaps = &[]n.ApplicationGatewayURLPathMap{pathMap}
-			err := validateURLPathMaps(eventRecorder, &config, ingressList, serviceList)
+			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
 			Expect(err).ToNot(BeNil())
 			Expect(err).To(Equal(validationErrors[errKeyEitherDefaults]))
 		})
@@ -73,7 +75,7 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 				},
 			}
 			config.URLPathMaps = &[]n.ApplicationGatewayURLPathMap{pathMap}
-			err := validateURLPathMaps(eventRecorder, &config, ingressList, serviceList)
+			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
 			Expect(err).ToNot(BeNil())
 			Expect(err).To(Equal(validationErrors[errKeyNoDefaults]))
 		})
@@ -88,7 +90,7 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 				},
 			}
 			config.URLPathMaps = &[]n.ApplicationGatewayURLPathMap{pathMap}
-			err := validateURLPathMaps(eventRecorder, &config, ingressList, serviceList)
+			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
 			Expect(err).To(BeNil())
 		})
 
@@ -102,7 +104,7 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 				},
 			}
 			config.URLPathMaps = &[]n.ApplicationGatewayURLPathMap{pathMap}
-			err := validateURLPathMaps(eventRecorder, &config, ingressList, serviceList)
+			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
 			Expect(err).To(BeNil())
 		})
 	})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
@@ -70,9 +71,21 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	// Create a configbuilder based on current appgw config
 	configBuilder := appgw.NewConfigBuilder(c.k8sContext, &c.appGwIdentifier, appGw.ApplicationGatewayPropertiesFormat, c.recorder)
 
+	// Get environment variables. Some environment variables can affect our config generation.
+	envVariables := environment.GetEnv()
+
 	// Get all the ingresses and services
 	ingressList := c.k8sContext.GetHTTPIngressList()
 	serviceList := c.k8sContext.GetServiceList()
+
+	if err := appgw.FatalValidateOnExistingConfig(c.recorder, appGw.ApplicationGatewayPropertiesFormat, envVariables); err != nil {
+		glog.Error("Got a fatal validation error on existing Application Gateway config. Will retry getting Application Gateway until error is resolved:", err)
+		return err
+	}
+
+	if err = configBuilder.PreBuildValidate(envVariables, ingressList, serviceList); err != nil {
+		glog.Error("ConfigBuilder PostBuildValidate returned error:", err)
+	}
 
 	// The following operations need to be in sequence
 	err = configBuilder.HealthProbesCollection(ingressList, serviceList)
@@ -112,10 +125,12 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 		return errors.New("unable to generate request routing rules")
 	}
 
-	// Replace the current appgw config with the generated one
-	if appGw.ApplicationGatewayPropertiesFormat, err = configBuilder.Build(ingressList, serviceList); err != nil {
-		glog.Error("ConfigBuilder failed to create Application Gateway config:", err)
+	if err = configBuilder.PostBuildValidate(envVariables, ingressList, serviceList); err != nil {
+		glog.Error("ConfigBuilder PostBuildValidate returned error:", err)
 	}
+
+	// Replace the current appgw config with the generated one
+	appGw.ApplicationGatewayPropertiesFormat = configBuilder.GetApplicationGatewayPropertiesFormatPtr()
 
 	addTags(&appGw)
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -78,11 +78,13 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	ingressList := c.k8sContext.GetHTTPIngressList()
 	serviceList := c.k8sContext.GetServiceList()
 
+	// Run fatal validations on the existing config of the Application Gateway.
 	if err := appgw.FatalValidateOnExistingConfig(c.recorder, appGw.ApplicationGatewayPropertiesFormat, envVariables); err != nil {
 		glog.Error("Got a fatal validation error on existing Application Gateway config. Will retry getting Application Gateway until error is resolved:", err)
 		return err
 	}
 
+	// Run validations on the Kubernetes resources which can suggest misconfiguration.
 	if err = configBuilder.PreBuildValidate(envVariables, ingressList, serviceList); err != nil {
 		glog.Error("ConfigBuilder PostBuildValidate returned error:", err)
 	}
@@ -125,6 +127,7 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 		return errors.New("unable to generate request routing rules")
 	}
 
+	// Run post validations to report errors in the config generation.
 	if err = configBuilder.PostBuildValidate(envVariables, ingressList, serviceList); err != nil {
 		glog.Error("ConfigBuilder PostBuildValidate returned error:", err)
 	}


### PR DESCRIPTION
This PR divides the validate into three parts:
1) `FatalValidateOnExistingConfig`: These are validations which cause either the controller to crash or retry the event until the Application Gateway config is corrected or controller is redeployed with a new helm-config.
2) `PreBuildValidate`: These are validation error that suggest misconfiguration on k8s side like missing service, etc. But they don't prevent us from generating a config.
3) `PostBuildValidate`: These are errors which suggest that our generated application gateway config is invalid. These are fatal and will caught by `ARM`.