### PR TITLE
feat: Add aad-pod-identity to helm

### DIFF
--- a/helm/ingress-azure/requirements.yaml
+++ b/helm/ingress-azure/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: aad-pod-identity
+    version: 0.1.0
+    repository: https://raw.githubusercontent.com/Azure/aad-pod-identity/master/charts/

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -41,3 +41,7 @@ kubernetes:
 # Specify if the cluster is RBAC enabled or not
 # rbac:
 #     enabled: false # true/false
+
+aad-pod-identity:
+  azureIdentity:
+    enabled: false


### PR DESCRIPTION
This PR adds aad-pod-identity as a requirement for appgw ingress controller helm.