### PR TITLE
[RFC] Use k8scontext.KubernetesResources to pass common arguments around

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -300,7 +300,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	}
 
 	testAGConfig := func(ingressList []*v1beta1.Ingress, serviceList []*v1.Service, settings appGwConfigSettings) {
-		kr := &k8scontext.KubernetesResources{
+		kr := &KubernetesResources{
 			IngressList:  ingressList,
 			ServiceList:  serviceList,
 			EnvVariables: environment.GetFakeEnv(),

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -300,17 +300,17 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	}
 
 	testAGConfig := func(ingressList []*v1beta1.Ingress, serviceList []*v1.Service, settings appGwConfigSettings) {
-		cbCxt := &ConfigBuilderContext{
+		cbCtx := &ConfigBuilderContext{
 			IngressList:  ingressList,
 			ServiceList:  serviceList,
 			EnvVariables: environment.GetFakeEnv(),
 		}
 		// Add Health Probes.
-		err := configBuilder.HealthProbesCollection(cbCxt)
+		err := configBuilder.HealthProbesCollection(cbCtx)
 		Expect(err).Should(BeNil(), "Error in generating the Health Probes: %v", err)
 
 		// Add HTTP settings.
-		err = configBuilder.BackendHTTPSettingsCollection(cbCxt)
+		err = configBuilder.BackendHTTPSettingsCollection(cbCtx)
 		Expect(err).Should(BeNil(), "Error in generating the HTTP Settings: %v", err)
 
 		// Get a pointer to the modified ApplicationGatewayPropertiesFormat
@@ -329,7 +329,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// Add backend address pools. We need the HTTP settings before we can add the backend address pools.
-		err = configBuilder.BackendAddressPools(cbCxt)
+		err = configBuilder.BackendAddressPools(cbCtx)
 		Expect(err).Should(BeNil(), "Error in generating the backend address pools: %v", err)
 
 		// Get a pointer to the modified ApplicationGatewayPropertiesFormat
@@ -342,7 +342,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// Add the listeners. We need the backend address pools before we can add HTTP listeners.
-		err = configBuilder.Listeners(cbCxt)
+		err = configBuilder.Listeners(cbCtx)
 		Expect(err).Should(BeNil(), "Error in generating the HTTP listeners: %v", err)
 
 		// Get a pointer to the modified ApplicationGatewayPropertiesFormat
@@ -355,7 +355,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// RequestRoutingRules depends on the previous operations
-		err = configBuilder.RequestRoutingRules(cbCxt)
+		err = configBuilder.RequestRoutingRules(cbCtx)
 		Expect(err).Should(BeNil(), "Error in generating the routing rules: %v", err)
 
 		// Get a pointer to the modified ApplicationGatewayPropertiesFormat

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -300,17 +300,17 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	}
 
 	testAGConfig := func(ingressList []*v1beta1.Ingress, serviceList []*v1.Service, settings appGwConfigSettings) {
-		kr := &KubernetesResources{
+		cbCxt := &ConfigBuilderContext{
 			IngressList:  ingressList,
 			ServiceList:  serviceList,
 			EnvVariables: environment.GetFakeEnv(),
 		}
 		// Add Health Probes.
-		err := configBuilder.HealthProbesCollection(kr)
+		err := configBuilder.HealthProbesCollection(cbCxt)
 		Expect(err).Should(BeNil(), "Error in generating the Health Probes: %v", err)
 
 		// Add HTTP settings.
-		err = configBuilder.BackendHTTPSettingsCollection(kr)
+		err = configBuilder.BackendHTTPSettingsCollection(cbCxt)
 		Expect(err).Should(BeNil(), "Error in generating the HTTP Settings: %v", err)
 
 		// Get a pointer to the modified ApplicationGatewayPropertiesFormat
@@ -329,7 +329,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// Add backend address pools. We need the HTTP settings before we can add the backend address pools.
-		err = configBuilder.BackendAddressPools(kr)
+		err = configBuilder.BackendAddressPools(cbCxt)
 		Expect(err).Should(BeNil(), "Error in generating the backend address pools: %v", err)
 
 		// Get a pointer to the modified ApplicationGatewayPropertiesFormat
@@ -342,7 +342,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// Add the listeners. We need the backend address pools before we can add HTTP listeners.
-		err = configBuilder.Listeners(kr)
+		err = configBuilder.Listeners(cbCxt)
 		Expect(err).Should(BeNil(), "Error in generating the HTTP listeners: %v", err)
 
 		// Get a pointer to the modified ApplicationGatewayPropertiesFormat
@@ -355,7 +355,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// RequestRoutingRules depends on the previous operations
-		err = configBuilder.RequestRoutingRules(kr)
+		err = configBuilder.RequestRoutingRules(cbCxt)
 		Expect(err).Should(BeNil(), "Error in generating the routing rules: %v", err)
 
 		// Get a pointer to the modified ApplicationGatewayPropertiesFormat

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -15,7 +15,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 )
 
@@ -35,7 +34,7 @@ func (c *appGwConfigBuilder) newBackendPoolMap(ingressList []*v1beta1.Ingress, s
 	return backendPoolMap
 }
 
-func (c *appGwConfigBuilder) BackendAddressPools(kr *k8scontext.KubernetesResources) error {
+func (c *appGwConfigBuilder) BackendAddressPools(kr *KubernetesResources) error {
 	defaultPool := defaultBackendAddressPool()
 	addressPools := map[string]*n.ApplicationGatewayBackendAddressPool{
 		*defaultPool.Name: defaultPool,

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -34,12 +34,12 @@ func (c *appGwConfigBuilder) newBackendPoolMap(ingressList []*v1beta1.Ingress, s
 	return backendPoolMap
 }
 
-func (c *appGwConfigBuilder) BackendAddressPools(kr *ConfigBuilderContext) error {
+func (c *appGwConfigBuilder) BackendAddressPools(cbCtx *ConfigBuilderContext) error {
 	defaultPool := defaultBackendAddressPool()
 	addressPools := map[string]*n.ApplicationGatewayBackendAddressPool{
 		*defaultPool.Name: defaultPool,
 	}
-	_, _, serviceBackendPairMap, _ := c.getBackendsAndSettingsMap(kr.IngressList, kr.ServiceList)
+	_, _, serviceBackendPairMap, _ := c.getBackendsAndSettingsMap(cbCtx.IngressList, cbCtx.ServiceList)
 	for backendID, serviceBackendPair := range serviceBackendPairMap {
 		if pool := c.getBackendAddressPool(backendID, serviceBackendPair, addressPools); pool != nil {
 			addressPools[*pool.Name] = pool

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -34,7 +34,7 @@ func (c *appGwConfigBuilder) newBackendPoolMap(ingressList []*v1beta1.Ingress, s
 	return backendPoolMap
 }
 
-func (c *appGwConfigBuilder) BackendAddressPools(kr *KubernetesResources) error {
+func (c *appGwConfigBuilder) BackendAddressPools(kr *ConfigBuilderContext) error {
 	defaultPool := defaultBackendAddressPool()
 	addressPools := map[string]*n.ApplicationGatewayBackendAddressPool{
 		*defaultPool.Name: defaultPool,

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -9,12 +9,14 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 )
 
 func (c *appGwConfigBuilder) newBackendPoolMap(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) map[backendIdentifier]*n.ApplicationGatewayBackendAddressPool {
@@ -33,12 +35,12 @@ func (c *appGwConfigBuilder) newBackendPoolMap(ingressList []*v1beta1.Ingress, s
 	return backendPoolMap
 }
 
-func (c *appGwConfigBuilder) BackendAddressPools(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error {
+func (c *appGwConfigBuilder) BackendAddressPools(kr *k8scontext.KubernetesResources) error {
 	defaultPool := defaultBackendAddressPool()
 	addressPools := map[string]*n.ApplicationGatewayBackendAddressPool{
 		*defaultPool.Name: defaultPool,
 	}
-	_, _, serviceBackendPairMap, _ := c.getBackendsAndSettingsMap(ingressList, serviceList)
+	_, _, serviceBackendPairMap, _ := c.getBackendsAndSettingsMap(kr.IngressList, kr.ServiceList)
 	for backendID, serviceBackendPair := range serviceBackendPairMap {
 		if pool := c.getBackendAddressPool(backendID, serviceBackendPair, addressPools); pool != nil {
 			addressPools[*pool.Name] = pool

--- a/pkg/appgw/backendaddresspools_test.go
+++ b/pkg/appgw/backendaddresspools_test.go
@@ -6,13 +6,15 @@
 package appgw
 
 import (
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
 // appgw_suite_test.go launches these Ginkgo tests
@@ -48,7 +50,11 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		serviceList := []*v1.Service{
 			tests.NewServiceFixture(),
 		}
-		_ = cb.BackendAddressPools(cb.k8sContext.GetHTTPIngressList(), serviceList)
+		kr := &k8scontext.KubernetesResources{
+			IngressList: cb.k8sContext.GetHTTPIngressList(),
+			ServiceList: serviceList,
+		}
+		_ = cb.BackendAddressPools(kr)
 
 		It("should contain correct number of backend address pools", func() {
 			Expect(len(*cb.appGwConfig.BackendAddressPools)).To(Equal(1))
@@ -78,7 +84,11 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		for _, ingress := range ingressList {
 			_ = cb.k8sContext.Caches.Ingress.Add(ingress)
 		}
-		_ = cb.BackendAddressPools(cb.k8sContext.GetHTTPIngressList(), serviceList)
+		kr := &k8scontext.KubernetesResources{
+			IngressList: cb.k8sContext.GetHTTPIngressList(),
+			ServiceList: serviceList,
+		}
+		_ = cb.BackendAddressPools(kr)
 		actualPool := newPool("pool-name", subset)
 		It("should contain unique addresses only", func() {
 			Expect(len(*actualPool.BackendAddresses)).To(Equal(4))
@@ -108,7 +118,11 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		for _, ingress := range ingressList {
 			_ = cb.k8sContext.Caches.Ingress.Add(ingress)
 		}
-		_ = cb.BackendAddressPools(cb.k8sContext.GetHTTPIngressList(), serviceList)
+		kr := &k8scontext.KubernetesResources{
+			ServiceList: serviceList,
+			IngressList: cb.k8sContext.GetHTTPIngressList(),
+		}
+		_ = cb.BackendAddressPools(kr)
 
 		endpoints := tests.NewEndpointsFixture()
 		_ = cb.k8sContext.Caches.Endpoints.Add(endpoints)

--- a/pkg/appgw/backendaddresspools_test.go
+++ b/pkg/appgw/backendaddresspools_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		serviceList := []*v1.Service{
 			tests.NewServiceFixture(),
 		}
-		kr := &KubernetesResources{
+		kr := &ConfigBuilderContext{
 			IngressList: cb.k8sContext.GetHTTPIngressList(),
 			ServiceList: serviceList,
 		}
@@ -83,7 +83,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		for _, ingress := range ingressList {
 			_ = cb.k8sContext.Caches.Ingress.Add(ingress)
 		}
-		kr := &KubernetesResources{
+		kr := &ConfigBuilderContext{
 			IngressList: cb.k8sContext.GetHTTPIngressList(),
 			ServiceList: serviceList,
 		}
@@ -117,7 +117,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		for _, ingress := range ingressList {
 			_ = cb.k8sContext.Caches.Ingress.Add(ingress)
 		}
-		kr := &KubernetesResources{
+		kr := &ConfigBuilderContext{
 			ServiceList: serviceList,
 			IngressList: cb.k8sContext.GetHTTPIngressList(),
 		}

--- a/pkg/appgw/backendaddresspools_test.go
+++ b/pkg/appgw/backendaddresspools_test.go
@@ -13,7 +13,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
@@ -50,7 +49,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		serviceList := []*v1.Service{
 			tests.NewServiceFixture(),
 		}
-		kr := &k8scontext.KubernetesResources{
+		kr := &KubernetesResources{
 			IngressList: cb.k8sContext.GetHTTPIngressList(),
 			ServiceList: serviceList,
 		}
@@ -84,7 +83,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		for _, ingress := range ingressList {
 			_ = cb.k8sContext.Caches.Ingress.Add(ingress)
 		}
-		kr := &k8scontext.KubernetesResources{
+		kr := &KubernetesResources{
 			IngressList: cb.k8sContext.GetHTTPIngressList(),
 			ServiceList: serviceList,
 		}
@@ -118,7 +117,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		for _, ingress := range ingressList {
 			_ = cb.k8sContext.Caches.Ingress.Add(ingress)
 		}
-		kr := &k8scontext.KubernetesResources{
+		kr := &KubernetesResources{
 			ServiceList: serviceList,
 			IngressList: cb.k8sContext.GetHTTPIngressList(),
 		}

--- a/pkg/appgw/backendaddresspools_test.go
+++ b/pkg/appgw/backendaddresspools_test.go
@@ -49,11 +49,11 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		serviceList := []*v1.Service{
 			tests.NewServiceFixture(),
 		}
-		kr := &ConfigBuilderContext{
+		cbCtx := &ConfigBuilderContext{
 			IngressList: cb.k8sContext.GetHTTPIngressList(),
 			ServiceList: serviceList,
 		}
-		_ = cb.BackendAddressPools(kr)
+		_ = cb.BackendAddressPools(cbCtx)
 
 		It("should contain correct number of backend address pools", func() {
 			Expect(len(*cb.appGwConfig.BackendAddressPools)).To(Equal(1))
@@ -83,11 +83,11 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		for _, ingress := range ingressList {
 			_ = cb.k8sContext.Caches.Ingress.Add(ingress)
 		}
-		kr := &ConfigBuilderContext{
+		cbCtx := &ConfigBuilderContext{
 			IngressList: cb.k8sContext.GetHTTPIngressList(),
 			ServiceList: serviceList,
 		}
-		_ = cb.BackendAddressPools(kr)
+		_ = cb.BackendAddressPools(cbCtx)
 		actualPool := newPool("pool-name", subset)
 		It("should contain unique addresses only", func() {
 			Expect(len(*actualPool.BackendAddresses)).To(Equal(4))
@@ -117,11 +117,11 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		for _, ingress := range ingressList {
 			_ = cb.k8sContext.Caches.Ingress.Add(ingress)
 		}
-		kr := &ConfigBuilderContext{
+		cbCtx := &ConfigBuilderContext{
 			ServiceList: serviceList,
 			IngressList: cb.k8sContext.GetHTTPIngressList(),
 		}
-		_ = cb.BackendAddressPools(kr)
+		_ = cb.BackendAddressPools(cbCtx)
 
 		endpoints := tests.NewEndpointsFixture()
 		_ = cb.k8sContext.Caches.Endpoints.Add(endpoints)

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -8,8 +8,8 @@ package appgw
 import (
 	"errors"
 	"fmt"
-
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
@@ -196,8 +196,8 @@ func (c *appGwConfigBuilder) getBackendsAndSettingsMap(ingressList []*v1beta1.In
 	return &httpSettings, backendHTTPSettingsMap, finalServiceBackendPairMap, nil
 }
 
-func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error {
-	httpSettings, _, _, err := c.getBackendsAndSettingsMap(ingressList, serviceList)
+func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(kr *k8scontext.KubernetesResources) error {
+	httpSettings, _, _, err := c.getBackendsAndSettingsMap(kr.IngressList, kr.ServiceList)
 	c.appGwConfig.BackendHTTPSettingsCollection = httpSettings
 	return err
 }

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -195,8 +195,8 @@ func (c *appGwConfigBuilder) getBackendsAndSettingsMap(ingressList []*v1beta1.In
 	return &httpSettings, backendHTTPSettingsMap, finalServiceBackendPairMap, nil
 }
 
-func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(kr *ConfigBuilderContext) error {
-	httpSettings, _, _, err := c.getBackendsAndSettingsMap(kr.IngressList, kr.ServiceList)
+func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(cbCtx *ConfigBuilderContext) error {
+	httpSettings, _, _, err := c.getBackendsAndSettingsMap(cbCtx.IngressList, cbCtx.ServiceList)
 	c.appGwConfig.BackendHTTPSettingsCollection = httpSettings
 	return err
 }

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -195,7 +195,7 @@ func (c *appGwConfigBuilder) getBackendsAndSettingsMap(ingressList []*v1beta1.In
 	return &httpSettings, backendHTTPSettingsMap, finalServiceBackendPairMap, nil
 }
 
-func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(kr *KubernetesResources) error {
+func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(kr *ConfigBuilderContext) error {
 	httpSettings, _, _, err := c.getBackendsAndSettingsMap(kr.IngressList, kr.ServiceList)
 	c.appGwConfig.BackendHTTPSettingsCollection = httpSettings
 	return err

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
@@ -196,7 +195,7 @@ func (c *appGwConfigBuilder) getBackendsAndSettingsMap(ingressList []*v1beta1.In
 	return &httpSettings, backendHTTPSettingsMap, finalServiceBackendPairMap, nil
 }
 
-func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(kr *k8scontext.KubernetesResources) error {
+func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(kr *KubernetesResources) error {
 	httpSettings, _, _, err := c.getBackendsAndSettingsMap(kr.IngressList, kr.ServiceList)
 	c.appGwConfig.BackendHTTPSettingsCollection = httpSettings
 	return err

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -18,14 +18,14 @@ import (
 // ConfigBuilder is a builder for application gateway configuration
 type ConfigBuilder interface {
 	// builder pattern
-	BackendHTTPSettingsCollection(kr *KubernetesResources) error
-	BackendAddressPools(kr *KubernetesResources) error
-	Listeners(kr *KubernetesResources) error
-	RequestRoutingRules(kr *KubernetesResources) error
-	HealthProbesCollection(kr *KubernetesResources) error
+	BackendHTTPSettingsCollection(kr *ConfigBuilderContext) error
+	BackendAddressPools(kr *ConfigBuilderContext) error
+	Listeners(kr *ConfigBuilderContext) error
+	RequestRoutingRules(kr *ConfigBuilderContext) error
+	HealthProbesCollection(kr *ConfigBuilderContext) error
 	GetApplicationGatewayPropertiesFormatPtr() *network.ApplicationGatewayPropertiesFormat
-	PreBuildValidate(kr *KubernetesResources) error
-	PostBuildValidate(kr *KubernetesResources) error
+	PreBuildValidate(kr *ConfigBuilderContext) error
+	PostBuildValidate(kr *ConfigBuilderContext) error
 }
 
 type appGwConfigBuilder struct {
@@ -106,7 +106,7 @@ func (c *appGwConfigBuilder) GetApplicationGatewayPropertiesFormatPtr() *network
 type valFunc func(eventRecorder record.EventRecorder, config *network.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
 
 // PreBuildValidate runs all the validators that suggest misconfiguration in Kubernetes resources.
-func (c *appGwConfigBuilder) PreBuildValidate(kr *KubernetesResources) error {
+func (c *appGwConfigBuilder) PreBuildValidate(kr *ConfigBuilderContext) error {
 
 	validationFunctions := []valFunc{
 		validateServiceDefinition,
@@ -116,7 +116,7 @@ func (c *appGwConfigBuilder) PreBuildValidate(kr *KubernetesResources) error {
 }
 
 // PostBuildValidate runs all the validators on the config constructed to ensure it complies with App Gateway requirements.
-func (c *appGwConfigBuilder) PostBuildValidate(kr *KubernetesResources) error {
+func (c *appGwConfigBuilder) PostBuildValidate(kr *ConfigBuilderContext) error {
 	validationFunctions := []valFunc{
 		validateURLPathMaps,
 	}
@@ -124,7 +124,7 @@ func (c *appGwConfigBuilder) PostBuildValidate(kr *KubernetesResources) error {
 	return c.runValidationFunctions(kr, validationFunctions)
 }
 
-func (c *appGwConfigBuilder) runValidationFunctions(kr *KubernetesResources, validationFunctions []valFunc) error {
+func (c *appGwConfigBuilder) runValidationFunctions(kr *ConfigBuilderContext, validationFunctions []valFunc) error {
 	for _, fn := range validationFunctions {
 		if err := fn(c.recorder, &c.appGwConfig, kr.EnvVariables, kr.IngressList, kr.ServiceList); err != nil {
 			return err

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -18,14 +18,14 @@ import (
 // ConfigBuilder is a builder for application gateway configuration
 type ConfigBuilder interface {
 	// builder pattern
-	BackendHTTPSettingsCollection(kr *k8scontext.KubernetesResources) error
-	BackendAddressPools(kr *k8scontext.KubernetesResources) error
-	Listeners(kr *k8scontext.KubernetesResources) error
-	RequestRoutingRules(kr *k8scontext.KubernetesResources) error
-	HealthProbesCollection(kr *k8scontext.KubernetesResources) error
+	BackendHTTPSettingsCollection(kr *KubernetesResources) error
+	BackendAddressPools(kr *KubernetesResources) error
+	Listeners(kr *KubernetesResources) error
+	RequestRoutingRules(kr *KubernetesResources) error
+	HealthProbesCollection(kr *KubernetesResources) error
 	GetApplicationGatewayPropertiesFormatPtr() *network.ApplicationGatewayPropertiesFormat
-	PreBuildValidate(kr *k8scontext.KubernetesResources) error
-	PostBuildValidate(kr *k8scontext.KubernetesResources) error
+	PreBuildValidate(kr *KubernetesResources) error
+	PostBuildValidate(kr *KubernetesResources) error
 }
 
 type appGwConfigBuilder struct {
@@ -106,7 +106,7 @@ func (c *appGwConfigBuilder) GetApplicationGatewayPropertiesFormatPtr() *network
 type valFunc func(eventRecorder record.EventRecorder, config *network.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
 
 // PreBuildValidate runs all the validators that suggest misconfiguration in Kubernetes resources.
-func (c *appGwConfigBuilder) PreBuildValidate(kr *k8scontext.KubernetesResources) error {
+func (c *appGwConfigBuilder) PreBuildValidate(kr *KubernetesResources) error {
 
 	validationFunctions := []valFunc{
 		validateServiceDefinition,
@@ -116,7 +116,7 @@ func (c *appGwConfigBuilder) PreBuildValidate(kr *k8scontext.KubernetesResources
 }
 
 // PostBuildValidate runs all the validators on the config constructed to ensure it complies with App Gateway requirements.
-func (c *appGwConfigBuilder) PostBuildValidate(kr *k8scontext.KubernetesResources) error {
+func (c *appGwConfigBuilder) PostBuildValidate(kr *KubernetesResources) error {
 	validationFunctions := []valFunc{
 		validateURLPathMaps,
 	}
@@ -124,7 +124,7 @@ func (c *appGwConfigBuilder) PostBuildValidate(kr *k8scontext.KubernetesResource
 	return c.runValidationFunctions(kr, validationFunctions)
 }
 
-func (c *appGwConfigBuilder) runValidationFunctions(kr *k8scontext.KubernetesResources, validationFunctions []valFunc) error {
+func (c *appGwConfigBuilder) runValidationFunctions(kr *KubernetesResources, validationFunctions []valFunc) error {
 	for _, fn := range validationFunctions {
 		if err := fn(c.recorder, &c.appGwConfig, kr.EnvVariables, kr.IngressList, kr.ServiceList); err != nil {
 			return err

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -18,14 +18,14 @@ import (
 // ConfigBuilder is a builder for application gateway configuration
 type ConfigBuilder interface {
 	// builder pattern
-	BackendHTTPSettingsCollection(kr *ConfigBuilderContext) error
-	BackendAddressPools(kr *ConfigBuilderContext) error
-	Listeners(kr *ConfigBuilderContext) error
-	RequestRoutingRules(kr *ConfigBuilderContext) error
-	HealthProbesCollection(kr *ConfigBuilderContext) error
+	BackendHTTPSettingsCollection(cbCtx *ConfigBuilderContext) error
+	BackendAddressPools(cbCtx *ConfigBuilderContext) error
+	Listeners(cbCtx *ConfigBuilderContext) error
+	RequestRoutingRules(cbCtx *ConfigBuilderContext) error
+	HealthProbesCollection(cbCtx *ConfigBuilderContext) error
 	GetApplicationGatewayPropertiesFormatPtr() *network.ApplicationGatewayPropertiesFormat
-	PreBuildValidate(kr *ConfigBuilderContext) error
-	PostBuildValidate(kr *ConfigBuilderContext) error
+	PreBuildValidate(cbCtx *ConfigBuilderContext) error
+	PostBuildValidate(cbCtx *ConfigBuilderContext) error
 }
 
 type appGwConfigBuilder struct {
@@ -106,27 +106,27 @@ func (c *appGwConfigBuilder) GetApplicationGatewayPropertiesFormatPtr() *network
 type valFunc func(eventRecorder record.EventRecorder, config *network.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
 
 // PreBuildValidate runs all the validators that suggest misconfiguration in Kubernetes resources.
-func (c *appGwConfigBuilder) PreBuildValidate(kr *ConfigBuilderContext) error {
+func (c *appGwConfigBuilder) PreBuildValidate(cbCtx *ConfigBuilderContext) error {
 
 	validationFunctions := []valFunc{
 		validateServiceDefinition,
 	}
 
-	return c.runValidationFunctions(kr, validationFunctions)
+	return c.runValidationFunctions(cbCtx, validationFunctions)
 }
 
 // PostBuildValidate runs all the validators on the config constructed to ensure it complies with App Gateway requirements.
-func (c *appGwConfigBuilder) PostBuildValidate(kr *ConfigBuilderContext) error {
+func (c *appGwConfigBuilder) PostBuildValidate(cbCtx *ConfigBuilderContext) error {
 	validationFunctions := []valFunc{
 		validateURLPathMaps,
 	}
 
-	return c.runValidationFunctions(kr, validationFunctions)
+	return c.runValidationFunctions(cbCtx, validationFunctions)
 }
 
-func (c *appGwConfigBuilder) runValidationFunctions(kr *ConfigBuilderContext, validationFunctions []valFunc) error {
+func (c *appGwConfigBuilder) runValidationFunctions(cbCtx *ConfigBuilderContext, validationFunctions []valFunc) error {
 	for _, fn := range validationFunctions {
-		if err := fn(c.recorder, &c.appGwConfig, kr.EnvVariables, kr.IngressList, kr.ServiceList); err != nil {
+		if err := fn(c.recorder, &c.appGwConfig, cbCtx.EnvVariables, cbCtx.IngressList, cbCtx.ServiceList); err != nil {
 			return err
 		}
 	}

--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -15,12 +15,11 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 )
 
 // getListeners constructs the unique set of App Gateway HTTP listeners across all ingresses.
-func (c *appGwConfigBuilder) getListeners(kr *k8scontext.KubernetesResources) (*[]n.ApplicationGatewayHTTPListener, map[listenerIdentifier]*n.ApplicationGatewayHTTPListener) {
+func (c *appGwConfigBuilder) getListeners(kr *KubernetesResources) (*[]n.ApplicationGatewayHTTPListener, map[listenerIdentifier]*n.ApplicationGatewayHTTPListener) {
 	// TODO(draychev): this is for compatibility w/ RequestRoutingRules and should be removed ASAP
 	legacyMap := make(map[listenerIdentifier]*n.ApplicationGatewayHTTPListener)
 

--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -19,7 +19,7 @@ import (
 )
 
 // getListeners constructs the unique set of App Gateway HTTP listeners across all ingresses.
-func (c *appGwConfigBuilder) getListeners(kr *KubernetesResources) (*[]n.ApplicationGatewayHTTPListener, map[listenerIdentifier]*n.ApplicationGatewayHTTPListener) {
+func (c *appGwConfigBuilder) getListeners(kr *ConfigBuilderContext) (*[]n.ApplicationGatewayHTTPListener, map[listenerIdentifier]*n.ApplicationGatewayHTTPListener) {
 	// TODO(draychev): this is for compatibility w/ RequestRoutingRules and should be removed ASAP
 	legacyMap := make(map[listenerIdentifier]*n.ApplicationGatewayHTTPListener)
 

--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -19,14 +19,14 @@ import (
 )
 
 // getListeners constructs the unique set of App Gateway HTTP listeners across all ingresses.
-func (c *appGwConfigBuilder) getListeners(kr *ConfigBuilderContext) (*[]n.ApplicationGatewayHTTPListener, map[listenerIdentifier]*n.ApplicationGatewayHTTPListener) {
+func (c *appGwConfigBuilder) getListeners(cbCtx *ConfigBuilderContext) (*[]n.ApplicationGatewayHTTPListener, map[listenerIdentifier]*n.ApplicationGatewayHTTPListener) {
 	// TODO(draychev): this is for compatibility w/ RequestRoutingRules and should be removed ASAP
 	legacyMap := make(map[listenerIdentifier]*n.ApplicationGatewayHTTPListener)
 
 	var listeners []n.ApplicationGatewayHTTPListener
 
-	for listenerID, config := range c.getListenerConfigs(kr.IngressList) {
-		listener := c.newListener(listenerID, config.Protocol, kr.EnvVariables)
+	for listenerID, config := range c.getListenerConfigs(cbCtx.IngressList) {
+		listener := c.newListener(listenerID, config.Protocol, cbCtx.EnvVariables)
 		if config.Protocol == n.HTTPS {
 			sslCertificateID := c.appGwIdentifier.sslCertificateID(config.Secret.secretFullName())
 			listener.SslCertificate = resourceRef(sslCertificateID)

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
@@ -59,7 +58,7 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			ing2,
 		}
 
-		kr := &k8scontext.KubernetesResources{
+		kr := &KubernetesResources{
 			IngressList:  ingressList,
 			EnvVariables: envVariables,
 		}

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			ing2,
 		}
 
-		kr := &KubernetesResources{
+		kr := &ConfigBuilderContext{
 			IngressList:  ingressList,
 			EnvVariables: envVariables,
 		}

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -3,13 +3,15 @@ package appgw
 import (
 	"os"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
 // appgw_suite_test.go launches these Ginkgo tests
@@ -57,8 +59,13 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			ing2,
 		}
 
+		kr := &k8scontext.KubernetesResources{
+			IngressList:  ingressList,
+			EnvVariables: envVariables,
+		}
+
 		// !! Action !!
-		listeners, _ := cb.getListeners(ingressList, envVariables)
+		listeners, _ := cb.getListeners(kr)
 
 		It("should have correct number of listeners", func() {
 			Expect(len(*listeners)).To(Equal(2))

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -58,13 +58,13 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			ing2,
 		}
 
-		kr := &ConfigBuilderContext{
+		cbCtx := &ConfigBuilderContext{
 			IngressList:  ingressList,
 			EnvVariables: envVariables,
 		}
 
 		// !! Action !!
-		listeners, _ := cb.getListeners(kr)
+		listeners, _ := cb.getListeners(cbCtx)
 
 		It("should have correct number of listeners", func() {
 			Expect(len(*listeners)).To(Equal(2))

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -7,6 +7,7 @@ package appgw
 
 import (
 	"fmt"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"sort"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
@@ -42,8 +43,8 @@ func (c *appGwConfigBuilder) newProbesMap(ingressList []*v1beta1.Ingress, servic
 	return healthProbeCollection, probesMap
 }
 
-func (c *appGwConfigBuilder) HealthProbesCollection(ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error {
-	healthProbeCollection, _ := c.newProbesMap(ingressList, serviceList)
+func (c *appGwConfigBuilder) HealthProbesCollection(kr *k8scontext.KubernetesResources) error {
+	healthProbeCollection, _ := c.newProbesMap(kr.IngressList, kr.ServiceList)
 	glog.V(5).Infof("Will create %d App Gateway probes.", len(healthProbeCollection))
 	probes := make([]network.ApplicationGatewayProbe, 0, len(healthProbeCollection))
 	for _, probe := range healthProbeCollection {

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -7,7 +7,6 @@ package appgw
 
 import (
 	"fmt"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"sort"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
@@ -43,7 +42,7 @@ func (c *appGwConfigBuilder) newProbesMap(ingressList []*v1beta1.Ingress, servic
 	return healthProbeCollection, probesMap
 }
 
-func (c *appGwConfigBuilder) HealthProbesCollection(kr *k8scontext.KubernetesResources) error {
+func (c *appGwConfigBuilder) HealthProbesCollection(kr *KubernetesResources) error {
 	healthProbeCollection, _ := c.newProbesMap(kr.IngressList, kr.ServiceList)
 	glog.V(5).Infof("Will create %d App Gateway probes.", len(healthProbeCollection))
 	probes := make([]network.ApplicationGatewayProbe, 0, len(healthProbeCollection))

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -42,7 +42,7 @@ func (c *appGwConfigBuilder) newProbesMap(ingressList []*v1beta1.Ingress, servic
 	return healthProbeCollection, probesMap
 }
 
-func (c *appGwConfigBuilder) HealthProbesCollection(kr *KubernetesResources) error {
+func (c *appGwConfigBuilder) HealthProbesCollection(kr *ConfigBuilderContext) error {
 	healthProbeCollection, _ := c.newProbesMap(kr.IngressList, kr.ServiceList)
 	glog.V(5).Infof("Will create %d App Gateway probes.", len(healthProbeCollection))
 	probes := make([]network.ApplicationGatewayProbe, 0, len(healthProbeCollection))

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -42,8 +42,8 @@ func (c *appGwConfigBuilder) newProbesMap(ingressList []*v1beta1.Ingress, servic
 	return healthProbeCollection, probesMap
 }
 
-func (c *appGwConfigBuilder) HealthProbesCollection(kr *ConfigBuilderContext) error {
-	healthProbeCollection, _ := c.newProbesMap(kr.IngressList, kr.ServiceList)
+func (c *appGwConfigBuilder) HealthProbesCollection(cbCtx *ConfigBuilderContext) error {
+	healthProbeCollection, _ := c.newProbesMap(cbCtx.IngressList, cbCtx.ServiceList)
 	glog.V(5).Infof("Will create %d App Gateway probes.", len(healthProbeCollection))
 	probes := make([]network.ApplicationGatewayProbe, 0, len(healthProbeCollection))
 	for _, probe := range healthProbeCollection {

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -36,7 +36,7 @@ var _ = Describe("configure App Gateway health probes", func() {
 		pod := tests.NewPodFixture(tests.ServiceName, tests.Namespace, tests.ContainerName, tests.ContainerPort)
 		_ = cb.k8sContext.Caches.Pods.Add(pod)
 
-		kr := &KubernetesResources{
+		kr := &ConfigBuilderContext{
 			IngressList: ingressList,
 			ServiceList: serviceList,
 		}
@@ -126,7 +126,7 @@ var _ = Describe("configure App Gateway health probes", func() {
 		pod := tests.NewPodFixture(tests.ServiceName, tests.Namespace, tests.ContainerName, tests.ContainerPort)
 		_ = cb.k8sContext.Caches.Pods.Add(pod)
 
-		kr := &KubernetesResources{
+		kr := &ConfigBuilderContext{
 			IngressList: ingressList,
 			ServiceList: serviceList,
 		}

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -15,7 +15,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
@@ -37,7 +36,7 @@ var _ = Describe("configure App Gateway health probes", func() {
 		pod := tests.NewPodFixture(tests.ServiceName, tests.Namespace, tests.ContainerName, tests.ContainerPort)
 		_ = cb.k8sContext.Caches.Pods.Add(pod)
 
-		kr := &k8scontext.KubernetesResources{
+		kr := &KubernetesResources{
 			IngressList: ingressList,
 			ServiceList: serviceList,
 		}
@@ -127,7 +126,7 @@ var _ = Describe("configure App Gateway health probes", func() {
 		pod := tests.NewPodFixture(tests.ServiceName, tests.Namespace, tests.ContainerName, tests.ContainerPort)
 		_ = cb.k8sContext.Caches.Pods.Add(pod)
 
-		kr := &k8scontext.KubernetesResources{
+		kr := &KubernetesResources{
 			IngressList: ingressList,
 			ServiceList: serviceList,
 		}

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -7,13 +7,16 @@ package appgw
 
 import (
 	"fmt"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
 // appgw_suite_test.go launches these Ginkgo tests
@@ -34,8 +37,13 @@ var _ = Describe("configure App Gateway health probes", func() {
 		pod := tests.NewPodFixture(tests.ServiceName, tests.Namespace, tests.ContainerName, tests.ContainerPort)
 		_ = cb.k8sContext.Caches.Pods.Add(pod)
 
+		kr := &k8scontext.KubernetesResources{
+			IngressList: ingressList,
+			ServiceList: serviceList,
+		}
+
 		// !! Action !!
-		_ = cb.HealthProbesCollection(ingressList, serviceList)
+		_ = cb.HealthProbesCollection(kr)
 		actual := cb.appGwConfig.Probes
 
 		// We expect our health probe configurator to have arrived at this final setup
@@ -119,8 +127,13 @@ var _ = Describe("configure App Gateway health probes", func() {
 		pod := tests.NewPodFixture(tests.ServiceName, tests.Namespace, tests.ContainerName, tests.ContainerPort)
 		_ = cb.k8sContext.Caches.Pods.Add(pod)
 
+		kr := &k8scontext.KubernetesResources{
+			IngressList: ingressList,
+			ServiceList: serviceList,
+		}
+
 		// !! Action !!
-		_ = cb.HealthProbesCollection(ingressList, serviceList)
+		_ = cb.HealthProbesCollection(kr)
 		actual := cb.appGwConfig.Probes
 
 		// We expect our health probe configurator to have arrived at this final setup

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -36,13 +36,13 @@ var _ = Describe("configure App Gateway health probes", func() {
 		pod := tests.NewPodFixture(tests.ServiceName, tests.Namespace, tests.ContainerName, tests.ContainerPort)
 		_ = cb.k8sContext.Caches.Pods.Add(pod)
 
-		kr := &ConfigBuilderContext{
+		cbCtx := &ConfigBuilderContext{
 			IngressList: ingressList,
 			ServiceList: serviceList,
 		}
 
 		// !! Action !!
-		_ = cb.HealthProbesCollection(kr)
+		_ = cb.HealthProbesCollection(cbCtx)
 		actual := cb.appGwConfig.Probes
 
 		// We expect our health probe configurator to have arrived at this final setup
@@ -126,13 +126,13 @@ var _ = Describe("configure App Gateway health probes", func() {
 		pod := tests.NewPodFixture(tests.ServiceName, tests.Namespace, tests.ContainerName, tests.ContainerPort)
 		_ = cb.k8sContext.Caches.Pods.Add(pod)
 
-		kr := &ConfigBuilderContext{
+		cbCtx := &ConfigBuilderContext{
 			IngressList: ingressList,
 			ServiceList: serviceList,
 		}
 
 		// !! Action !!
-		_ = cb.HealthProbesCollection(kr)
+		_ = cb.HealthProbesCollection(cbCtx)
 		actual := cb.appGwConfig.Probes
 
 		// We expect our health probe configurator to have arrived at this final setup

--- a/pkg/appgw/http_listeners.go
+++ b/pkg/appgw/http_listeners.go
@@ -5,16 +5,16 @@
 
 package appgw
 
-func (c *appGwConfigBuilder) Listeners(kr *ConfigBuilderContext) error {
+func (c *appGwConfigBuilder) Listeners(cbCtx *ConfigBuilderContext) error {
 
-	c.appGwConfig.SslCertificates = c.getSslCertificates(kr.IngressList)
-	c.appGwConfig.FrontendPorts = c.getFrontendPorts(kr.IngressList)
-	c.appGwConfig.HTTPListeners, _ = c.getListeners(kr)
+	c.appGwConfig.SslCertificates = c.getSslCertificates(cbCtx.IngressList)
+	c.appGwConfig.FrontendPorts = c.getFrontendPorts(cbCtx.IngressList)
+	c.appGwConfig.HTTPListeners, _ = c.getListeners(cbCtx)
 
 	// App Gateway Rules can be configured to redirect HTTP traffic to HTTPS URLs.
 	// In this step here we create the redirection configurations. These configs are attached to request routing rules
 	// in the RequestRoutingRules step, which must be executed after Listeners.
-	c.appGwConfig.RedirectConfigurations = c.getRedirectConfigurations(kr.IngressList)
+	c.appGwConfig.RedirectConfigurations = c.getRedirectConfigurations(cbCtx.IngressList)
 
 	return nil
 }

--- a/pkg/appgw/http_listeners.go
+++ b/pkg/appgw/http_listeners.go
@@ -6,19 +6,19 @@
 package appgw
 
 import (
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
-	"k8s.io/api/extensions/v1beta1"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 )
 
-func (c *appGwConfigBuilder) Listeners(ingressList []*v1beta1.Ingress, envVariables environment.EnvVariables) error {
-	c.appGwConfig.SslCertificates = c.getSslCertificates(ingressList)
-	c.appGwConfig.FrontendPorts = c.getFrontendPorts(ingressList)
-	c.appGwConfig.HTTPListeners, _ = c.getListeners(ingressList, envVariables)
+func (c *appGwConfigBuilder) Listeners(kr *k8scontext.KubernetesResources) error {
+
+	c.appGwConfig.SslCertificates = c.getSslCertificates(kr.IngressList)
+	c.appGwConfig.FrontendPorts = c.getFrontendPorts(kr.IngressList)
+	c.appGwConfig.HTTPListeners, _ = c.getListeners(kr)
 
 	// App Gateway Rules can be configured to redirect HTTP traffic to HTTPS URLs.
 	// In this step here we create the redirection configurations. These configs are attached to request routing rules
 	// in the RequestRoutingRules step, which must be executed after Listeners.
-	c.appGwConfig.RedirectConfigurations = c.getRedirectConfigurations(ingressList)
+	c.appGwConfig.RedirectConfigurations = c.getRedirectConfigurations(kr.IngressList)
 
 	return nil
 }

--- a/pkg/appgw/http_listeners.go
+++ b/pkg/appgw/http_listeners.go
@@ -5,7 +5,7 @@
 
 package appgw
 
-func (c *appGwConfigBuilder) Listeners(kr *KubernetesResources) error {
+func (c *appGwConfigBuilder) Listeners(kr *ConfigBuilderContext) error {
 
 	c.appGwConfig.SslCertificates = c.getSslCertificates(kr.IngressList)
 	c.appGwConfig.FrontendPorts = c.getFrontendPorts(kr.IngressList)

--- a/pkg/appgw/http_listeners.go
+++ b/pkg/appgw/http_listeners.go
@@ -5,11 +5,7 @@
 
 package appgw
 
-import (
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
-)
-
-func (c *appGwConfigBuilder) Listeners(kr *k8scontext.KubernetesResources) error {
+func (c *appGwConfigBuilder) Listeners(kr *KubernetesResources) error {
 
 	c.appGwConfig.SslCertificates = c.getSslCertificates(kr.IngressList)
 	c.appGwConfig.FrontendPorts = c.getFrontendPorts(kr.IngressList)

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -80,7 +80,7 @@ func (c *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, serviceList []*v
 	return urlPathMap
 }
 
-func (c *appGwConfigBuilder) RequestRoutingRules(kr *KubernetesResources) error {
+func (c *appGwConfigBuilder) RequestRoutingRules(kr *ConfigBuilderContext) error {
 	_, httpListenersMap := c.getListeners(kr)
 	urlPathMaps := make(map[listenerIdentifier]*network.ApplicationGatewayURLPathMap)
 	backendPools := c.newBackendPoolMap(kr.IngressList, kr.ServiceList)

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -9,14 +9,15 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 )
 
 func (c *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, serviceList []*v1.Service, rule *v1beta1.IngressRule,
@@ -80,12 +81,12 @@ func (c *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, serviceList []*v
 	return urlPathMap
 }
 
-func (c *appGwConfigBuilder) RequestRoutingRules(ingressList []*v1beta1.Ingress, serviceList []*v1.Service, envVariables environment.EnvVariables) error {
-	_, httpListenersMap := c.getListeners(ingressList, envVariables)
+func (c *appGwConfigBuilder) RequestRoutingRules(kr *k8scontext.KubernetesResources) error {
+	_, httpListenersMap := c.getListeners(kr)
 	urlPathMaps := make(map[listenerIdentifier]*network.ApplicationGatewayURLPathMap)
-	backendPools := c.newBackendPoolMap(ingressList, serviceList)
-	_, backendHTTPSettingsMap, _, _ := c.getBackendsAndSettingsMap(ingressList, serviceList)
-	for _, ingress := range ingressList {
+	backendPools := c.newBackendPoolMap(kr.IngressList, kr.ServiceList)
+	_, backendHTTPSettingsMap, _, _ := c.getBackendsAndSettingsMap(kr.IngressList, kr.ServiceList)
+	for _, ingress := range kr.IngressList {
 		defaultAddressPoolID := c.appGwIdentifier.addressPoolID(defaultBackendAddressPoolName)
 		defaultHTTPSettingsID := c.appGwIdentifier.httpSettingsID(defaultBackendHTTPSettingsName)
 
@@ -140,13 +141,13 @@ func (c *appGwConfigBuilder) RequestRoutingRules(ingressList []*v1beta1.Ingress,
 			if httpAvailable {
 				if wildcardRule != nil && len(rule.Host) != 0 {
 					// only add wildcard rules when host is specified
-					urlPathMaps[listenerHTTPID] = c.pathMaps(ingress, serviceList, wildcardRule,
+					urlPathMaps[listenerHTTPID] = c.pathMaps(ingress, kr.ServiceList, wildcardRule,
 						listenerHTTPID, urlPathMaps[listenerHTTPID],
 						defaultAddressPoolID, defaultHTTPSettingsID)
 				}
 
 				// need to eliminate non-unique paths
-				urlPathMaps[listenerHTTPID] = c.pathMaps(ingress, serviceList, rule,
+				urlPathMaps[listenerHTTPID] = c.pathMaps(ingress, kr.ServiceList, rule,
 					listenerHTTPID, urlPathMaps[listenerHTTPID],
 					defaultAddressPoolID, defaultHTTPSettingsID)
 
@@ -159,13 +160,13 @@ func (c *appGwConfigBuilder) RequestRoutingRules(ingressList []*v1beta1.Ingress,
 			if httpsAvailable {
 				if wildcardRule != nil && len(rule.Host) != 0 {
 					// only add wildcard rules when host is specified
-					urlPathMaps[listenerHTTPSID] = c.pathMaps(ingress, serviceList, wildcardRule,
+					urlPathMaps[listenerHTTPSID] = c.pathMaps(ingress, kr.ServiceList, wildcardRule,
 						listenerHTTPSID, urlPathMaps[listenerHTTPSID],
 						defaultAddressPoolID, defaultHTTPSettingsID)
 				}
 
 				// need to eliminate non-unique paths
-				urlPathMaps[listenerHTTPSID] = c.pathMaps(ingress, serviceList, rule,
+				urlPathMaps[listenerHTTPSID] = c.pathMaps(ingress, kr.ServiceList, rule,
 					listenerHTTPSID, urlPathMaps[listenerHTTPSID],
 					defaultAddressPoolID, defaultHTTPSettingsID)
 			}

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -80,12 +80,12 @@ func (c *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, serviceList []*v
 	return urlPathMap
 }
 
-func (c *appGwConfigBuilder) RequestRoutingRules(kr *ConfigBuilderContext) error {
-	_, httpListenersMap := c.getListeners(kr)
+func (c *appGwConfigBuilder) RequestRoutingRules(cbCtx *ConfigBuilderContext) error {
+	_, httpListenersMap := c.getListeners(cbCtx)
 	urlPathMaps := make(map[listenerIdentifier]*network.ApplicationGatewayURLPathMap)
-	backendPools := c.newBackendPoolMap(kr.IngressList, kr.ServiceList)
-	_, backendHTTPSettingsMap, _, _ := c.getBackendsAndSettingsMap(kr.IngressList, kr.ServiceList)
-	for _, ingress := range kr.IngressList {
+	backendPools := c.newBackendPoolMap(cbCtx.IngressList, cbCtx.ServiceList)
+	_, backendHTTPSettingsMap, _, _ := c.getBackendsAndSettingsMap(cbCtx.IngressList, cbCtx.ServiceList)
+	for _, ingress := range cbCtx.IngressList {
 		defaultAddressPoolID := c.appGwIdentifier.addressPoolID(defaultBackendAddressPoolName)
 		defaultHTTPSettingsID := c.appGwIdentifier.httpSettingsID(defaultBackendHTTPSettingsName)
 
@@ -140,13 +140,13 @@ func (c *appGwConfigBuilder) RequestRoutingRules(kr *ConfigBuilderContext) error
 			if httpAvailable {
 				if wildcardRule != nil && len(rule.Host) != 0 {
 					// only add wildcard rules when host is specified
-					urlPathMaps[listenerHTTPID] = c.pathMaps(ingress, kr.ServiceList, wildcardRule,
+					urlPathMaps[listenerHTTPID] = c.pathMaps(ingress, cbCtx.ServiceList, wildcardRule,
 						listenerHTTPID, urlPathMaps[listenerHTTPID],
 						defaultAddressPoolID, defaultHTTPSettingsID)
 				}
 
 				// need to eliminate non-unique paths
-				urlPathMaps[listenerHTTPID] = c.pathMaps(ingress, kr.ServiceList, rule,
+				urlPathMaps[listenerHTTPID] = c.pathMaps(ingress, cbCtx.ServiceList, rule,
 					listenerHTTPID, urlPathMaps[listenerHTTPID],
 					defaultAddressPoolID, defaultHTTPSettingsID)
 
@@ -159,13 +159,13 @@ func (c *appGwConfigBuilder) RequestRoutingRules(kr *ConfigBuilderContext) error
 			if httpsAvailable {
 				if wildcardRule != nil && len(rule.Host) != 0 {
 					// only add wildcard rules when host is specified
-					urlPathMaps[listenerHTTPSID] = c.pathMaps(ingress, kr.ServiceList, wildcardRule,
+					urlPathMaps[listenerHTTPSID] = c.pathMaps(ingress, cbCtx.ServiceList, wildcardRule,
 						listenerHTTPSID, urlPathMaps[listenerHTTPSID],
 						defaultAddressPoolID, defaultHTTPSettingsID)
 				}
 
 				// need to eliminate non-unique paths
-				urlPathMaps[listenerHTTPSID] = c.pathMaps(ingress, kr.ServiceList, rule,
+				urlPathMaps[listenerHTTPSID] = c.pathMaps(ingress, cbCtx.ServiceList, rule,
 					listenerHTTPSID, urlPathMaps[listenerHTTPSID],
 					defaultAddressPoolID, defaultHTTPSettingsID)
 			}

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 )
 
@@ -81,7 +80,7 @@ func (c *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, serviceList []*v
 	return urlPathMap
 }
 
-func (c *appGwConfigBuilder) RequestRoutingRules(kr *k8scontext.KubernetesResources) error {
+func (c *appGwConfigBuilder) RequestRoutingRules(kr *KubernetesResources) error {
 	_, httpListenersMap := c.getListeners(kr)
 	urlPathMaps := make(map[listenerIdentifier]*network.ApplicationGatewayURLPathMap)
 	backendPools := c.newBackendPoolMap(kr.IngressList, kr.ServiceList)

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 
 		ingressList := []*v1beta1.Ingress{&ingress}
 		serviceList := []*v1.Service{tests.NewServiceFixture()}
-		kr := &KubernetesResources{
+		kr := &ConfigBuilderContext{
 			IngressList: ingressList,
 			ServiceList: serviceList,
 		}

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
@@ -140,7 +139,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 
 		ingressList := []*v1beta1.Ingress{&ingress}
 		serviceList := []*v1.Service{tests.NewServiceFixture()}
-		kr := &k8scontext.KubernetesResources{
+		kr := &KubernetesResources{
 			IngressList: ingressList,
 			ServiceList: serviceList,
 		}

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -139,11 +139,11 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 
 		ingressList := []*v1beta1.Ingress{&ingress}
 		serviceList := []*v1.Service{tests.NewServiceFixture()}
-		kr := &ConfigBuilderContext{
+		cbCtx := &ConfigBuilderContext{
 			IngressList: ingressList,
 			ServiceList: serviceList,
 		}
-		_ = configBuilder.RequestRoutingRules(kr)
+		_ = configBuilder.RequestRoutingRules(cbCtx)
 
 		It("should have correct RequestRoutingRules", func() {
 			Expect(len(*configBuilder.appGwConfig.RequestRoutingRules)).To(Equal(1))

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -6,9 +6,6 @@
 package appgw
 
 import (
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
@@ -17,6 +14,10 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
 var _ = Describe("Test SSL Redirect Annotations", func() {
@@ -139,8 +140,11 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 
 		ingressList := []*v1beta1.Ingress{&ingress}
 		serviceList := []*v1.Service{tests.NewServiceFixture()}
-		envVariables := environment.GetFakeEnv()
-		_ = configBuilder.RequestRoutingRules(ingressList, serviceList, envVariables)
+		kr := &k8scontext.KubernetesResources{
+			IngressList: ingressList,
+			ServiceList: serviceList,
+		}
+		_ = configBuilder.RequestRoutingRules(kr)
 
 		It("should have correct RequestRoutingRules", func() {
 			Expect(len(*configBuilder.appGwConfig.RequestRoutingRules)).To(Equal(1))

--- a/pkg/appgw/types.go
+++ b/pkg/appgw/types.go
@@ -9,9 +9,9 @@ import (
 	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
 )
 
-// KubernetesResources holds the structs we have fetches from Kubernetes + environment, based on which
+// ConfigBuilderContext holds the structs we have fetches from Kubernetes + environment, based on which
 // we will construct App Gateway config.
-type KubernetesResources struct {
+type ConfigBuilderContext struct {
 	IngressList       []*v1beta1.Ingress
 	ServiceList       []*v1.Service
 	ManagedTargets    []*mtv1.AzureIngressManagedTarget

--- a/pkg/appgw/types.go
+++ b/pkg/appgw/types.go
@@ -1,0 +1,20 @@
+package appgw
+
+import (
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
+	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+
+	mtv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressmanagedtarget/v1"
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+)
+
+// KubernetesResources holds the structs we have fetches from Kubernetes + environment, based on which
+// we will construct App Gateway config.
+type KubernetesResources struct {
+	IngressList       []*v1beta1.Ingress
+	ServiceList       []*v1.Service
+	ManagedTargets    []*mtv1.AzureIngressManagedTarget
+	ProhibitedTargets []*ptv1.AzureIngressProhibitedTarget
+	EnvVariables      environment.EnvVariables
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -72,7 +72,7 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	// Create a configbuilder based on current appgw config
 	configBuilder := appgw.NewConfigBuilder(c.k8sContext, &c.appGwIdentifier, appGw.ApplicationGatewayPropertiesFormat, c.recorder)
 
-	kr := &appgw.KubernetesResources{
+	kr := &appgw.ConfigBuilderContext{
 		// Get all Services
 		ServiceList:       c.k8sContext.GetServiceList(),
 		IngressList:       c.k8sContext.GetHTTPIngressList(),

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -72,7 +72,7 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	// Create a configbuilder based on current appgw config
 	configBuilder := appgw.NewConfigBuilder(c.k8sContext, &c.appGwIdentifier, appGw.ApplicationGatewayPropertiesFormat, c.recorder)
 
-	kr := &k8scontext.KubernetesResources{
+	kr := &appgw.KubernetesResources{
 		// Get all Services
 		ServiceList:       c.k8sContext.GetServiceList(),
 		IngressList:       c.k8sContext.GetHTTPIngressList(),

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -72,25 +72,24 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	// Create a configbuilder based on current appgw config
 	configBuilder := appgw.NewConfigBuilder(c.k8sContext, &c.appGwIdentifier, appGw.ApplicationGatewayPropertiesFormat, c.recorder)
 
-	// Get environment variables. Some environment variables can affect our config generation.
-	envVariables := environment.GetEnv()
-
-	// Get all the ingresses and services
-	ingressList := c.k8sContext.GetHTTPIngressList()
-	serviceList := c.k8sContext.GetServiceList()
-	managedTargetsList := c.k8sContext.GetAzureIngressManagedTargets()
-	prohibitedTargetsList := c.k8sContext.GetAzureProhibitedTargets()
-
+	kr := &k8scontext.KubernetesResources{
+		// Get all Services
+		ServiceList:       c.k8sContext.GetServiceList(),
+		IngressList:       c.k8sContext.GetHTTPIngressList(),
+		ManagedTargets:    c.k8sContext.GetAzureIngressManagedTargets(),
+		ProhibitedTargets: c.k8sContext.GetAzureProhibitedTargets(),
+		EnvVariables:      environment.GetEnv(),
+	}
 	{
 		var managedTargets []string
-		for _, target := range managedTargetsList {
+		for _, target := range kr.ManagedTargets {
 			managedTargets = append(managedTargets, fmt.Sprintf("%s/%s", target.Namespace, target.Name))
 		}
 		glog.V(5).Infof("AzureIngressManagedTargets: %+v", strings.Join(managedTargets, ","))
 	}
 	{
 		var prohibitedTargets []string
-		for _, target := range prohibitedTargetsList {
+		for _, target := range kr.ProhibitedTargets {
 			prohibitedTargets = append(prohibitedTargets, fmt.Sprintf("%s/%s", target.Namespace, target.Name))
 		}
 
@@ -98,32 +97,32 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	}
 
 	// Run fatal validations on the existing config of the Application Gateway.
-	if err := appgw.FatalValidateOnExistingConfig(c.recorder, appGw.ApplicationGatewayPropertiesFormat, envVariables); err != nil {
+	if err := appgw.FatalValidateOnExistingConfig(c.recorder, appGw.ApplicationGatewayPropertiesFormat, kr.EnvVariables); err != nil {
 		glog.Error("Got a fatal validation error on existing Application Gateway config. Will retry getting Application Gateway until error is resolved:", err)
 		return err
 	}
 
 	// Run validations on the Kubernetes resources which can suggest misconfiguration.
-	if err = configBuilder.PreBuildValidate(envVariables, ingressList, serviceList); err != nil {
+	if err = configBuilder.PreBuildValidate(kr); err != nil {
 		glog.Error("ConfigBuilder PostBuildValidate returned error:", err)
 	}
 
 	// The following operations need to be in sequence
-	err = configBuilder.HealthProbesCollection(ingressList, serviceList)
+	err = configBuilder.HealthProbesCollection(kr)
 	if err != nil {
 		glog.Errorf("unable to generate Health Probes, error [%v]", err.Error())
 		return errors.New("unable to generate health probes")
 	}
 
 	// The following operations need to be in sequence
-	err = configBuilder.BackendHTTPSettingsCollection(ingressList, serviceList)
+	err = configBuilder.BackendHTTPSettingsCollection(kr)
 	if err != nil {
 		glog.Errorf("unable to generate backend http settings, error [%v]", err.Error())
 		return errors.New("unable to generate backend http settings")
 	}
 
 	// BackendAddressPools depend on BackendHTTPSettings
-	err = configBuilder.BackendAddressPools(ingressList, serviceList)
+	err = configBuilder.BackendAddressPools(kr)
 	if err != nil {
 		glog.Errorf("unable to generate backend address pools, error [%v]", err.Error())
 		return errors.New("unable to generate backend address pools")
@@ -133,21 +132,21 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	// This also creates redirection configuration (if TLS is configured and Ingress is annotated).
 	// This configuration must be attached to request routing rules, which are created in the steps below.
 	// The order of operations matters.
-	err = configBuilder.Listeners(ingressList, envVariables)
+	err = configBuilder.Listeners(kr)
 	if err != nil {
 		glog.Errorf("unable to generate frontend listeners, error [%v]", err.Error())
 		return errors.New("unable to generate frontend listeners")
 	}
 
 	// SSL redirection configurations created elsewhere will be attached to the appropriate rule in this step.
-	err = configBuilder.RequestRoutingRules(ingressList, serviceList, envVariables)
+	err = configBuilder.RequestRoutingRules(kr)
 	if err != nil {
 		glog.Errorf("unable to generate request routing rules, error [%v]", err.Error())
 		return errors.New("unable to generate request routing rules")
 	}
 
 	// Run post validations to report errors in the config generation.
-	if err = configBuilder.PostBuildValidate(envVariables, ingressList, serviceList); err != nil {
+	if err = configBuilder.PostBuildValidate(kr); err != nil {
 		glog.Error("ConfigBuilder PostBuildValidate returned error:", err)
 	}
 

--- a/pkg/k8scontext/types.go
+++ b/pkg/k8scontext/types.go
@@ -48,6 +48,8 @@ type Context struct {
 	UpdateChannel *channels.RingChannel
 }
 
+// KubernetesResources holds the structs we have fetches from Kubernetes + environment, based on which
+// we will construct App Gateway config.
 type KubernetesResources struct {
 	IngressList       []*v1beta1.Ingress
 	ServiceList       []*v1.Service

--- a/pkg/k8scontext/types.go
+++ b/pkg/k8scontext/types.go
@@ -2,13 +2,8 @@ package k8scontext
 
 import (
 	"github.com/eapache/channels"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
-	mtv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressmanagedtarget/v1"
-	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
@@ -46,14 +41,4 @@ type Context struct {
 	stopChannel       chan struct{}
 
 	UpdateChannel *channels.RingChannel
-}
-
-// KubernetesResources holds the structs we have fetches from Kubernetes + environment, based on which
-// we will construct App Gateway config.
-type KubernetesResources struct {
-	IngressList       []*v1beta1.Ingress
-	ServiceList       []*v1.Service
-	ManagedTargets    []*mtv1.AzureIngressManagedTarget
-	ProhibitedTargets []*ptv1.AzureIngressProhibitedTarget
-	EnvVariables      environment.EnvVariables
 }

--- a/pkg/k8scontext/types.go
+++ b/pkg/k8scontext/types.go
@@ -2,8 +2,13 @@ package k8scontext
 
 import (
 	"github.com/eapache/channels"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
+	mtv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressmanagedtarget/v1"
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
@@ -41,4 +46,12 @@ type Context struct {
 	stopChannel       chan struct{}
 
 	UpdateChannel *channels.RingChannel
+}
+
+type KubernetesResources struct {
+	IngressList       []*v1beta1.Ingress
+	ServiceList       []*v1.Service
+	ManagedTargets    []*mtv1.AzureIngressManagedTarget
+	ProhibitedTargets []*ptv1.AzureIngressProhibitedTarget
+	EnvVariables      environment.EnvVariables
 }


### PR DESCRIPTION
This PR proposes we use `appgw.ConfigBuilderContext {}` in lieu of a list of args for each top level Controller function.  Instead of passing around `ingressList`, `serviceList` etc - let's pass around a pointer to a struct that has these.

The motivation for this is - needing to pass around the new `AzureIngressManagedTarget` and `AzureIngressProhibitedTarget`.  It seems appropriate to pave the road for the next person who'd need to pass around a new struct - they would only have to add it to `ConfigBuilderContext `

```go
type ConfigBuilderContext struct {
	IngressList       []*v1beta1.Ingress
	ServiceList       []*v1.Service
	ManagedTargets    []*mtv1.AzureIngressManagedTarget
	ProhibitedTargets []*ptv1.AzureIngressProhibitedTarget
	EnvVariables      environment.EnvVariables
}
```

At a high level - the Ingress Controller fetches a set of data from Kubernetes and some workers then construct App Gwy config based on these.  It seems we could simplify things a bit if we exposed everything we have obtained from k8s in this struct.