### PR TITLE
[RFC] Adding VERBOSITY_LEVEL env var; Add to helm template

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -220,6 +220,6 @@ func getVerbosity(flagVerbosity int, envVerbosity string) int {
 		glog.Infof("Using verbosity level %d from CLI flag %s", flagVerbosity, verbosityFlag)
 		return flagVerbosity
 	}
-	glog.Infof("Using verbosity level %d from environment variable %s", envVerbosityInt, environment.VerbosityLevel)
+	glog.Infof("Using verbosity level %d from environment variable %s", envVerbosityInt, environment.VerbosityLevelVarName)
 	return envVerbosityInt
 }

--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -37,6 +37,11 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 )
 
+const (
+	verbosityFlag = "verbosity"
+	maxAuthRetry  = 10
+)
+
 var (
 	flags = pflag.NewFlagSet(`appgw-ingress`, pflag.ExitOnError)
 
@@ -54,7 +59,7 @@ var (
 
 	versionInfo = flags.Bool("version", false, "Print version")
 
-	verbosity = flags.Int("verbosity", 1, "Set logging verbosity level")
+	verbosity = flags.Int(verbosityFlag, 1, "Set logging verbosity level")
 )
 
 func main() {
@@ -64,7 +69,10 @@ func main() {
 		glog.Fatal("Error parsing command line arguments:", err)
 	}
 
-	glog.Infof("Logging at verbosity level %d", *verbosity)
+	env := environment.GetEnv()
+	environment.ValidateEnv(env)
+
+	glog.Infof("Logging at verbosity level %d", getVerbosity(*verbosity, env.VerbosityLevel))
 
 	if *versionInfo {
 		version.PrintVersionAndExit()
@@ -75,9 +83,6 @@ func main() {
 	_ = flag.CommandLine.Parse([]string{})
 	_ = flag.Lookup("logtostderr").Value.Set("true")
 	_ = flag.Set("v", strconv.Itoa(*verbosity))
-
-	env := environment.GetEnv()
-	environment.ValidateEnv(env)
 
 	appGwClient := network.NewApplicationGatewaysClient(env.SubscriptionID)
 
@@ -158,9 +163,8 @@ func getAzAuth(vars environment.EnvVariables) (autorest.Authorizer, error) {
 }
 
 func waitForAzureAuth(envVars environment.EnvVariables, client network.ApplicationGatewaysClient) {
-	maxRetry := 10
 	const retryTime = 10 * time.Second
-	for counter := 0; counter <= maxRetry; counter++ {
+	for counter := 0; counter <= maxAuthRetry; counter++ {
 		if _, err := client.Get(context.Background(), envVars.ResourceGroupName, envVars.AppGwName); err != nil {
 			glog.Error("Error getting Application Gateway", envVars.AppGwName, err)
 			glog.Infof("Retrying in %v", retryTime)
@@ -208,4 +212,14 @@ func getEventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {
 		Host:      hostname,
 	}
 	return eventBroadcaster.NewRecorder(scheme.Scheme, source)
+}
+
+func getVerbosity(flagVerbosity int, envVerbosity string) int {
+	envVerbosityInt, err := strconv.Atoi(envVerbosity)
+	if err != nil {
+		glog.Infof("Using verbosity level %d from CLI flag %s", flagVerbosity, verbosityFlag)
+		return flagVerbosity
+	}
+	glog.Infof("Using verbosity level %d from environment variable %s", envVerbosityInt, environment.VerbosityLevel)
+	return envVerbosityInt
 }

--- a/docs/examples/helm-config.yaml
+++ b/docs/examples/helm-config.yaml
@@ -1,5 +1,8 @@
 # This file contains the essential configs for the ingress controller helm chart
 
+# Verbosity level of the App Gateway Ingress Controller
+verbosityLevel: 3
+
 ################################################################################
 # Specify which application gateway the ingress controller will manage
 #

--- a/docs/install-existing.md
+++ b/docs/install-existing.md
@@ -55,6 +55,9 @@ The [aad-pod-identity](https://github.com/Azure/aad-pod-identity) gives a clean 
     ```yaml
     # This file contains the essential configs for the ingress controller helm chart
 
+    # Verbosity level of the App Gateway Ingress Controller
+    verbosityLevel: 3
+
     ################################################################################
     # Specify which application gateway the ingress controller will manage
     #

--- a/docs/install-new.md
+++ b/docs/install-new.md
@@ -95,6 +95,9 @@ Steps:
     ```yaml
     # This file contains the essential configs for the ingress controller helm chart
 
+    # Verbosity level of the App Gateway Ingress Controller
+    verbosityLevel: 3
+
     ################################################################################
     # Specify which application gateway the ingress controller will manage
     #

--- a/helm/ingress-azure/templates/NOTES.txt
+++ b/helm/ingress-azure/templates/NOTES.txt
@@ -1,11 +1,11 @@
-Thank you for installing {{ .Chart.Name }}:{{ .Chart.Version }}. 
+Thank you for installing {{ .Chart.Name }}:{{ .Chart.Version }}.
 
-Your release is named {{ .Release.Name }}. 
+Your release is named {{ .Release.Name }}.
 The controller is deployed in deployment {{ template "application-gateway-kubernetes-ingress.fullname" . }}.
 
 Configuration Details:
 ----------------------
- * AzureRM Authentication Method: 
+ * AzureRM Authentication Method:
 {{- if eq .Values.armAuth.type "aadPodIdentity"}}
     - Use AAD-Pod-Identity
 {{- else if eq .Values.armAuth.type "servicePrincipal"}}
@@ -19,6 +19,7 @@ Configuration Details:
     - Application Gateway Name : {{ .Values.appgw.name }}
  * Kubernetes:
     - Watch Namespace : {{ .Values.kubernetes.watchNamespace }}
+ * Verbosity level: {{ .Values.verbosityLevel }}
 {{ if eq .Values.armAuth.type "aadPodIdentity"}}
 Please make sure the associated aadpodidentity and aadpodidbinding is configured.
 For more information on AAD-Pod-Identity, please visit https://github.com/Azure/aad-pod-identity

--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -14,5 +14,6 @@ data:
   APPGW_SUBSCRIPTION_ID: {{ required "A valid appgw entry is required!" .Values.appgw.subscriptionId }}
   APPGW_RESOURCE_GROUP:  {{ required "A valid appgw entry is required!" .Values.appgw.resourceGroup }}
   APPGW_NAME:            {{ required "A valid appgw entry is required!" .Values.appgw.name }}
+  APPGW_VERBOSITY_LEVEL: {{ .Values.verbosityLevel }}
   KUBERNETES_WATCHNAMESPACE:  {{ required "A valid kubernetes watch namespace is required!" .Values.kubernetes.watchNamespace }}
   USE_PRIVATE_IP: "{{ .Values.appgw.usePrivateIP }}"

--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
 
+# Verbosity level of the App Gateway Ingress Controller
+verbosityLevel: 3
+
 image:
   repository: mcr.microsoft.com/azure-application-gateway/kubernetes-ingress
   tag: XXVERSIONXX

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
 
+# Verbosity level of the App Gateway Ingress Controller
+verbosityLevel: 3
+
 image:
   repository: mcr.microsoft.com/azure-application-gateway/kubernetes-ingress
   tag: 0.6.0
@@ -18,7 +21,7 @@ kubernetes:
 #   subscriptionId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 #   resourceGroup: myResourceGroup
 #   name: myApplicationGateway
-#   usePrivateIP: true 
+#   usePrivateIP: true
 
 ################################################################################
 # Specify the authentication with Azure Resource Manager

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -26,7 +26,7 @@ const (
 	// UsePrivateIPVarName is the name of the USE_PRIVATE_IP
 	UsePrivateIPVarName = "USE_PRIVATE_IP"
 	// VerbosityLevel sets the level of glog verbosity should the CLI argument be blank
-	VerbosityLevel = "APPGW_VERBOSITY_LEVEL"
+	VerbosityLevelVarName = "APPGW_VERBOSITY_LEVEL"
 )
 
 // EnvVariables is a struct storing values for environment variables.
@@ -49,7 +49,7 @@ func GetEnv() EnvVariables {
 		AuthLocation:      os.Getenv(AuthLocationVarName),
 		WatchNamespace:    os.Getenv(WatchNamespaceVarName),
 		UsePrivateIP:      os.Getenv(UsePrivateIPVarName),
-		VerbosityLevel:    os.Getenv(VerbosityLevel),
+		VerbosityLevel:    os.Getenv(VerbosityLevelVarName),
 	}
 
 	return env
@@ -62,7 +62,7 @@ func ValidateEnv(env EnvVariables) {
 	}
 
 	if env.WatchNamespace == "" {
-		glog.V(1).Infof("%s is not set. Watching all available namespaces.", VerbosityLevel)
+		glog.V(1).Infof("%s is not set. Watching all available namespaces.", WatchNamespaceVarName)
 	}
 }
 

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -25,7 +25,7 @@ const (
 	WatchNamespaceVarName = "KUBERNETES_WATCHNAMESPACE"
 	// UsePrivateIPVarName is the name of the USE_PRIVATE_IP
 	UsePrivateIPVarName = "USE_PRIVATE_IP"
-	// VerbosityLevel sets the level of glog verbosity should the CLI argument be blank
+	// VerbosityLevelVarName sets the level of glog verbosity should the CLI argument be blank
 	VerbosityLevelVarName = "APPGW_VERBOSITY_LEVEL"
 )
 

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -25,6 +25,8 @@ const (
 	WatchNamespaceVarName = "KUBERNETES_WATCHNAMESPACE"
 	// UsePrivateIPVarName is the name of the USE_PRIVATE_IP
 	UsePrivateIPVarName = "USE_PRIVATE_IP"
+	// VerbosityLevel sets the level of glog verbosity should the CLI argument be blank
+	VerbosityLevel = "APPGW_VERBOSITY_LEVEL"
 )
 
 // EnvVariables is a struct storing values for environment variables.
@@ -35,6 +37,7 @@ type EnvVariables struct {
 	AuthLocation      string
 	WatchNamespace    string
 	UsePrivateIP      string
+	VerbosityLevel    string
 }
 
 // GetEnv returns values for defined environment variables for Ingress Controller.
@@ -46,6 +49,7 @@ func GetEnv() EnvVariables {
 		AuthLocation:      os.Getenv(AuthLocationVarName),
 		WatchNamespace:    os.Getenv(WatchNamespaceVarName),
 		UsePrivateIP:      os.Getenv(UsePrivateIPVarName),
+		VerbosityLevel:    os.Getenv(VerbosityLevel),
 	}
 
 	return env
@@ -58,7 +62,7 @@ func ValidateEnv(env EnvVariables) {
 	}
 
 	if env.WatchNamespace == "" {
-		glog.Info("KUBERNETES_WATCHNAMESPACE is not set. Watching all available namespaces.")
+		glog.V(1).Infof("%s is not set. Watching all available namespaces.", VerbosityLevel)
 	}
 }
 

--- a/pkg/environment/fake.go
+++ b/pkg/environment/fake.go
@@ -14,6 +14,7 @@ func GetFakeEnv() EnvVariables {
 		AuthLocation:      "--AuthLocation--",
 		WatchNamespace:    "--WatchNamespace--",
 		UsePrivateIP:      "false",
+		VerbosityLevel:    "123456789",
 	}
 
 	return env


### PR DESCRIPTION
I realize that we have great logging (and improving), but no easy way to enable that on the actual AGIC pod.

This PR adds:
 - `APPGW_VERBOSITY_LEVEL` environment variable to the Docker container
 - `verbosityLevel` to the Helm templates
 - read both - `APPGW_VERBOSITY_LEVEL` over `verbosityLevel` CLI flag

When AGIC starts - we see:
- `Using verbosity level 5 from environment variable APPGW_VERBOSITY_LEVEL`
or 
- `Using verbosity level 1 from CLI flag verbosity`

Having this environment variable would enable customers to easily bump verbosity to `5` so that they can see (sanitized) App Gateway config / JSON being applied to ARM. (w/ `kubectl logs ...`)