### PR TITLE
fix: error creating configmap and rbac default: false

### DIFF
--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -14,6 +14,6 @@ data:
   APPGW_SUBSCRIPTION_ID: {{ required "A valid appgw entry is required!" .Values.appgw.subscriptionId }}
   APPGW_RESOURCE_GROUP:  {{ required "A valid appgw entry is required!" .Values.appgw.resourceGroup }}
   APPGW_NAME:            {{ required "A valid appgw entry is required!" .Values.appgw.name }}
-  APPGW_VERBOSITY_LEVEL: {{ .Values.verbosityLevel }}
+  APPGW_VERBOSITY_LEVEL: "{{ .Values.verbosityLevel }}"
   KUBERNETES_WATCHNAMESPACE:  {{ required "A valid kubernetes watch namespace is required!" .Values.kubernetes.watchNamespace }}
   USE_PRIVATE_IP: "{{ .Values.appgw.usePrivateIP }}"

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -40,5 +40,5 @@ kubernetes:
 
 ################################################################################
 # Specify if the cluster is RBAC enabled or not
-# rbac:
-#     enabled: false # true/false
+rbac:
+  enabled: false # true/false


### PR DESCRIPTION
This PR fixes the configmap template.
Configmap can only take a list `string: string` in data field.

When verbosityLevel: 3 is passed from the values.yaml, helm deployment fails with error.
```bash
Error: UPGRADE FAILED: v1.ConfigMap.ObjectMeta: v1.ObjectMeta.TypeMeta: Kind: Data: ReadString: expects " or n, but found 3, error found in #10 byte of ...|Y_LEVEL":3,"KUBERNET|..., bigger context ...|-xxx","APPGW_VERBOSITY_LEVEL":3,"KUBERNETES_WATCHNAMESPACE":"default","USE_PRIVAT|...
```