### PR TITLE
helm: modify clusterrole for events and appgw.ingress.k8s.io/networking.istio.io crds

### DIFF
--- a/helm/ingress-azure/templates/clusterrole.yaml
+++ b/helm/ingress-azure/templates/clusterrole.yaml
@@ -24,6 +24,15 @@ rules:
     - list
     - watch
 - apiGroups:
+    - "appgw.ingress.k8s.io"
+    - "networking.istio.io"
+  resources:
+    - "*"
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
     - extensions
   resources:
     - ingresses
@@ -37,4 +46,11 @@ rules:
     - ingresses/status
   verbs:
     - update
+- apiGroups:
+    - ""
+  resources:
+    - events
+  verbs:
+    - create
+    - patch
 {{- end -}}


### PR DESCRIPTION
This PR modifies the cluster role to
1) allow create/patch on events
2) allow list/get/watch on `appgw.ingress.k8s.io`/`networking.istio.io` apiGroup CRDs.

```bash
Name:         odd-billygoat-ingress-azure
Labels:       app=ingress-azure
              chart=ingress-azure-0.7.0-rc1
              heritage=Tiller
              release=odd-billygoat
Annotations:  <none>
PolicyRule:
  Resources                    Non-Resource URLs  Resource Names  Verbs
  ---------                    -----------------  --------------  -----
  events                       []                 []              [get list watch create patch]
  configmaps                   []                 []              [get list watch]
  endpoints                    []                 []              [get list watch]
  namespaces                   []                 []              [get list watch]
  pods                         []                 []              [get list watch]
  secrets                      []                 []              [get list watch]
  services                     []                 []              [get list watch]
  *.appgw.ingress.k8s.io       []                 []              [get list watch]
  ingresses.extensions         []                 []              [get list watch]
  *.networking.istio.io        []                 []              [get list watch]
  ingresses.extensions/status  []                 []              [update]
```