### PR TITLE
Introducing feature flags controlling brownfield deployment and Istio integration

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -117,7 +117,7 @@ func main() {
 		glog.Fatal("Got a fatal validation error on existing Application Gateway config. Please update Application Gateway or the controller's helm config. Error:", err)
 	}
 
-	go controller.NewAppGwIngressController(appGwClient, appGwIdentifier, k8sContext, recorder).Start()
+	go controller.NewAppGwIngressController(appGwClient, appGwIdentifier, k8sContext, recorder).Start(env)
 	select {}
 }
 

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -447,7 +447,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	Context("Tests Application Gateway Configuration", func() {
 		It("Should be able to create Application Gateway Configuration from Ingress", func() {
 			// Start the informers. This will sync the cache with the latest ingress.
-			ctxt.Run(true)
+			ctxt.Run(true, environment.GetFakeEnv())
 
 			// Wait for the controller to receive an ingress update.
 			ingressEvent()
@@ -495,7 +495,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			Expect(err).Should(BeNil(), "Unable to delete endpoint resource due to: %v", err)
 
 			// Start the informers. This will sync the cache with the latest ingress.
-			ctxt.Run(true)
+			ctxt.Run(true, environment.GetFakeEnv())
 
 			// Wait for the controller to receive an ingress update.
 			ingressEvent()
@@ -606,7 +606,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			Expect(err).Should(BeNil(), "Unabled to update ingress resource due to: %v", err)
 
 			// Start the informers. This will sync the cache with the latest ingress.
-			ctxt.Run(true)
+			ctxt.Run(true, environment.GetFakeEnv())
 
 			// Wait for the controller to receive an ingress update.
 			ingressEvent()
@@ -711,7 +711,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			Expect(err).Should(BeNil(), "Unable to update ingress resource due to: %v", err)
 
 			// Start the informers. This will sync the cache with the latest ingress.
-			ctxt.Run(true)
+			ctxt.Run(true, environment.GetFakeEnv())
 
 			// Wait for the controller to receive an ingress update.
 			ingressEvent()
@@ -797,7 +797,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	Context("Tests Application Gateway Generate HTTP Settings Name", func() {
 		It("Should be create an Application Gateway Backend Pool Name With Less than 80 Characters", func() {
 			// Start the informers. This will sync the cache with the latest ingress.
-			ctxt.Run(true)
+			ctxt.Run(true, environment.GetFakeEnv())
 
 			// Wait for the controller to receive an ingress update.
 			ingressEvent()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -203,12 +203,12 @@ func addTags(appGw *network.ApplicationGateway) {
 
 // Start function runs the k8scontext and continues to listen to the
 // event channel and enqueue events before stopChannel is closed
-func (c *AppGwIngressController) Start() {
+func (c *AppGwIngressController) Start(envVariables environment.EnvVariables) {
 	// Starts event queue
 	go c.eventQueue.Run(time.Second, c.stopChannel)
 
 	// Starts k8scontext which contains all the informers
-	c.k8sContext.Run(false)
+	c.k8sContext.Run(false, envVariables)
 
 	// Continue to enqueue events into eventqueue until stopChannel is closed
 	for {

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -15,41 +15,57 @@ import (
 const (
 	// SubscriptionIDVarName is the name of the APPGW_SUBSCRIPTION_ID
 	SubscriptionIDVarName = "APPGW_SUBSCRIPTION_ID"
+
 	// ResourceGroupNameVarName is the name of the APPGW_RESOURCE_GROUP
 	ResourceGroupNameVarName = "APPGW_RESOURCE_GROUP"
+
 	// AppGwNameVarName is the name of the APPGW_NAME
 	AppGwNameVarName = "APPGW_NAME"
+
 	// AuthLocationVarName is the name of the AZURE_AUTH_LOCATION
 	AuthLocationVarName = "AZURE_AUTH_LOCATION"
+
 	// WatchNamespaceVarName is the name of the KUBERNETES_WATCHNAMESPACE
 	WatchNamespaceVarName = "KUBERNETES_WATCHNAMESPACE"
+
 	// UsePrivateIPVarName is the name of the USE_PRIVATE_IP
 	UsePrivateIPVarName = "USE_PRIVATE_IP"
+
 	// VerbosityLevelVarName sets the level of glog verbosity should the CLI argument be blank
 	VerbosityLevelVarName = "APPGW_VERBOSITY_LEVEL"
+
+	// EnableBrownfieldDeploymentVarName is a feature flag enabling observation of {Managed,Prohibited}Target CRDs
+	EnableBrownfieldDeploymentVarName = "APPGW_ENABLE_BROWNFIELD_DEPLOYMENT"
+
+	// EnableIstioIntegrationVarName is a feature flag enabling observation of Istio specific CRDs
+	EnableIstioIntegrationVarName = "APPGW_ENABLE_ISTIO_INTEGRATION"
 )
 
 // EnvVariables is a struct storing values for environment variables.
 type EnvVariables struct {
-	SubscriptionID    string
-	ResourceGroupName string
-	AppGwName         string
-	AuthLocation      string
-	WatchNamespace    string
-	UsePrivateIP      string
-	VerbosityLevel    string
+	SubscriptionID             string
+	ResourceGroupName          string
+	AppGwName                  string
+	AuthLocation               string
+	WatchNamespace             string
+	UsePrivateIP               string
+	VerbosityLevel             string
+	EnableBrownfieldDeployment string
+	EnableIstioIntegration     string
 }
 
 // GetEnv returns values for defined environment variables for Ingress Controller.
 func GetEnv() EnvVariables {
 	env := EnvVariables{
-		SubscriptionID:    os.Getenv(SubscriptionIDVarName),
-		ResourceGroupName: os.Getenv(ResourceGroupNameVarName),
-		AppGwName:         os.Getenv(AppGwNameVarName),
-		AuthLocation:      os.Getenv(AuthLocationVarName),
-		WatchNamespace:    os.Getenv(WatchNamespaceVarName),
-		UsePrivateIP:      os.Getenv(UsePrivateIPVarName),
-		VerbosityLevel:    os.Getenv(VerbosityLevelVarName),
+		SubscriptionID:             os.Getenv(SubscriptionIDVarName),
+		ResourceGroupName:          os.Getenv(ResourceGroupNameVarName),
+		AppGwName:                  os.Getenv(AppGwNameVarName),
+		AuthLocation:               os.Getenv(AuthLocationVarName),
+		WatchNamespace:             os.Getenv(WatchNamespaceVarName),
+		UsePrivateIP:               os.Getenv(UsePrivateIPVarName),
+		VerbosityLevel:             os.Getenv(VerbosityLevelVarName),
+		EnableBrownfieldDeployment: os.Getenv(EnableBrownfieldDeploymentVarName),
+		EnableIstioIntegration:     os.Getenv(EnableIstioIntegrationVarName),
 	}
 
 	return env

--- a/pkg/k8scontext/k8scontext_test.go
+++ b/pkg/k8scontext/k8scontext_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/client/clientset/versioned/fake"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	istio_fake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/istio_client/clientset/versioned/fake"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
@@ -76,7 +77,7 @@ var _ = Describe("K8scontext", func() {
 			Expect(len(ingresses.Items)).To(Equal(1), "Expected to have a single ingress stored in mock K8s but found: %d ingresses", len(ingresses.Items))
 
 			// Start the informers. This will sync the cache with the latest ingress.
-			ctxt.Run(true)
+			ctxt.Run(true, environment.GetFakeEnv())
 
 			ingressListInterface := ctxt.Caches.Ingress.List()
 			Expect(len(ingressListInterface)).To(Equal(1), "Expected to have a single ingress in the cache but found: %d ingresses", len(ingressListInterface))
@@ -103,7 +104,7 @@ var _ = Describe("K8scontext", func() {
 
 			// Due to the large sync time we don't expect the cache to be synced, till we force sync the cache.
 			// Start the informers. This will sync the cache with the latest ingress.
-			ctxt.Run(true)
+			ctxt.Run(true, environment.GetFakeEnv())
 
 			ingressListInterface := ctxt.Caches.Ingress.List()
 			// There should still be only one ingress resource.
@@ -128,7 +129,7 @@ var _ = Describe("K8scontext", func() {
 
 			// Due to the large sync time we don't expect the cache to be synced, till we force sync the cache.
 			// Start the informers. This will sync the cache with the latest ingress.
-			ctxt.Run(true)
+			ctxt.Run(true, environment.GetFakeEnv())
 
 			ingressListInterface := ctxt.Caches.Ingress.List()
 			// There should still be only one ingress resource.
@@ -156,7 +157,7 @@ var _ = Describe("K8scontext", func() {
 
 			// Due to the large sync time we don't expect the cache to be synced, till we force sync the cache.
 			// Start the informers. This will sync the cache with the latest ingress.
-			ctxt.Run(true)
+			ctxt.Run(true, environment.GetFakeEnv())
 
 			ingressListInterface := ctxt.Caches.Ingress.List()
 			// There should two ingress resource.
@@ -188,7 +189,7 @@ var _ = Describe("K8scontext", func() {
 			Expect(len(podList.Items)).To(Equal(2), "Expected to have two pod stored but found: %d pods", len(podList.Items))
 
 			// Run context
-			ctxt.Run(true)
+			ctxt.Run(true, environment.GetFakeEnv())
 
 			// Get and check that one of the pods exists.
 			_, exists, _ := ctxt.Caches.Pods.Get(pod)


### PR DESCRIPTION
This PR introduces 2 new environment variables, to serve as feature flags.

Behind these feature flags we hide the Brownfield work currently in progress, and will hide the Istio integration. The overall goal is to introduce a mechanism by which we can toggle portions of the software.

This could be further improved by separating the feature flags into their own struct and introducing better types (than simply comparing to some string) - this could come at a later stage.