### PR TITLE
Refactor logging into 3 verbosity levels; Document

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -204,9 +204,9 @@ func getKubeClientConfig() *rest.Config {
 
 func getEventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(glog.Infof)
-	eventBroadcaster.StartRecordingToSink(
-		&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	eventBroadcaster.StartLogging(glog.V(3).Infof)
+	sink := &typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")}
+	eventBroadcaster.StartRecordingToSink(sink)
 	hostname, err := os.Hostname()
 	if err != nil {
 		glog.Error("Could not obtain host name from the operating system", err)

--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
@@ -73,7 +74,7 @@ func main() {
 	env := environment.GetEnv()
 	environment.ValidateEnv(env)
 
-	glog.Infof("Logging at verbosity level %d", getVerbosity(*verbosity, env.VerbosityLevel))
+	verbosity = to.IntPtr(getVerbosity(*verbosity, env.VerbosityLevel))
 
 	if *versionInfo {
 		version.PrintVersionAndExit()

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,12 +53,32 @@ kubectl get ingress --namespace  <which-namespace?>  <which-ingress?>  -o yaml
 ```
 
 
-* AGIC has verbose logging capability. It is not enabled by default. This is controlled via an environment variable. Increase the **verbosity level** of AGIC to `5` to get the JSON config
-dispatched to [ARM](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview):
-  - add `verbosityLevel: 5` on a line by itself in [helm-config.yaml](examples/sample-helm-config.yaml) and re-install
-  - get logs with `kubectl logs <pod-name>`
-
-
 * AGIC emits Kubernetes events for certain critical errors. You can view these:
   - in your terminal via `kubectl get events --sort-by=.metadata.creationTimestamp`
   - in your browser using the [Kubernetes Web UI (Dashboard)](https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/)
+
+
+# Logging Levels
+
+AGIC has 3 logging levels. Level 1 is the default one and it shows minimal number of log lines.
+Level 5, on the other hand, would display all logs, including sanitized contents of config applied
+to ARM.
+
+The Kubernetes community has established 9 levels of logging for
+the [kubectl](go get github.com/knative/pkg/apis/istio/v1alpha3) tool. In this
+repository we are utilizing 3 of these, with similar semantics:
+
+
+| Verbosity | Description |
+|-----------|-------------|
+|  1        | Default log level; shows startup details, warnings and errors |
+|  3        | Extended information about events and changes; lists of created objects |
+|  5        | Logs marshaled objects; shows sanitized JSON config applied to ARM |
+
+
+The verbosity levels are adjustable via the `verbosityLevel` variable in the
+[helm-config.yaml](examples/sample-helm-config.yaml) file. Increase verbosity level to `5` to get
+the JSON config dispatched to
+[ARM](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview):
+  - add `verbosityLevel: 5` on a line by itself in [helm-config.yaml](examples/sample-helm-config.yaml) and re-install
+  - get logs with `kubectl logs <pod-name>`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -65,7 +65,7 @@ Level 5, on the other hand, would display all logs, including sanitized contents
 to ARM.
 
 The Kubernetes community has established 9 levels of logging for
-the [kubectl](go get github.com/knative/pkg/apis/istio/v1alpha3) tool. In this
+the [kubectl](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-output-verbosity-and-debugging) tool. In this
 repository we are utilizing 3 of these, with similar semantics:
 
 

--- a/pkg/appgw/certificates.go
+++ b/pkg/appgw/certificates.go
@@ -8,6 +8,7 @@ package appgw
 import (
 	"encoding/base64"
 	"fmt"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"sort"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
@@ -52,7 +53,7 @@ func (c *appGwConfigBuilder) getSecretToCertificateMap(ingress *v1beta1.Ingress)
 			secretIDCertificateMap[tlsSecret] = to.StringPtr(base64.StdEncoding.EncodeToString(cert))
 		} else {
 			logLine := fmt.Sprintf("Unable to find the secret associated to secretId: [%s]", tlsSecret.secretKey())
-			c.recorder.Event(ingress, v1.EventTypeWarning, "SecretNotFound", logLine)
+			c.recorder.Event(ingress, v1.EventTypeWarning, events.ReasonSecretNotFound, logLine)
 		}
 	}
 	return secretIDCertificateMap

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -6,13 +6,14 @@
 package appgw
 
 import (
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/record"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 )
 
 // ConfigBuilder is a builder for application gateway configuration

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -82,7 +82,7 @@ func formatPropName(val string) string {
 	separator := "-"
 	prefix := val[0 : maxLen-len(hash)-len(separator)]
 	finalVal := fmt.Sprintf("%s%s%s", prefix, separator, hash)
-	glog.Infof("Prop name %s with length %d is longer than %d characters; Transformed to %s", val, len(val), maxLen, finalVal)
+	glog.V(3).Infof("Prop name %s with length %d is longer than %d characters; Transformed to %s", val, len(val), maxLen, finalVal)
 	return finalVal
 }
 

--- a/pkg/appgw/redirects.go
+++ b/pkg/appgw/redirects.go
@@ -29,7 +29,7 @@ func (c *appGwConfigBuilder) getRedirectConfigurations(ingressList []*v1beta1.In
 		if isHTTPS && hasSslRedirect {
 			targetListener := resourceRef(c.appGwIdentifier.listenerID(generateListenerName(listenerID)))
 			redirectConfigs = append(redirectConfigs, newSSLRedirectConfig(listenerConfig, targetListener))
-			glog.Infof("Created redirection configuration %s; not yet linked to a routing rule", listenerConfig.SslRedirectConfigurationName)
+			glog.V(3).Infof("Created redirection configuration %s; not yet linked to a routing rule", listenerConfig.SslRedirectConfigurationName)
 		}
 	}
 	sort.Sort(sorter.ByRedirectName(redirectConfigs))

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -247,7 +247,7 @@ func (c *appGwConfigBuilder) modifyPathRulesForRedirection(httpURLPathMap *netwo
 	if len(*httpURLPathMap.PathRules) == 0 {
 		// There are no paths. This is a rule of type "Basic"
 		redirectRef := c.getSslRedirectConfigResourceReference(targetListener)
-		glog.Infof("Attaching redirection config %s to basic request routing rule: %s\n", *redirectRef.ID, *httpURLPathMap.Name)
+		glog.V(5).Infof("Attaching redirection config %s to basic request routing rule: %s\n", *redirectRef.ID, *httpURLPathMap.Name)
 
 		// URL Path Map must have either DefaultRedirectConfiguration xor (DefaultBackendAddressPool + DefaultBackendHTTPSettings)
 		httpURLPathMap.DefaultRedirectConfiguration = redirectRef
@@ -262,7 +262,7 @@ func (c *appGwConfigBuilder) modifyPathRulesForRedirection(httpURLPathMap *netwo
 		// This is a rule of type "Path-based"
 		pathRule := &(*httpURLPathMap.PathRules)[idx]
 		redirectRef := c.getSslRedirectConfigResourceReference(targetListener)
-		glog.Infof("Attaching redirection config %s request routing rule: %s\n", *redirectRef.ID, *pathRule.Name)
+		glog.V(5).Infof("Attaching redirection config %s request routing rule: %s\n", *redirectRef.ID, *pathRule.Name)
 
 		// A Path Rule must have either RedirectConfiguration xor (BackendAddressPool + BackendHTTPSettings)
 		pathRule.RedirectConfiguration = redirectRef

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -58,8 +58,6 @@ func NewAppGwIngressController(appGwClient network.ApplicationGatewaysClient, ap
 // Process is the callback function that will be executed for every event
 // in the EventQueue.
 func (c AppGwIngressController) Process(event QueuedEvent) error {
-	glog.V(1).Infof("controller.Process called with type %T", event.Event)
-
 	ctx := context.Background()
 
 	// Get current application gateway config
@@ -164,12 +162,12 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	addTags(&appGw)
 
 	if c.configIsSame(&appGw) {
-		glog.Infoln("cache: Config has NOT changed! No need to connect to ARM.")
+		glog.V(3).Info("cache: Config has NOT changed! No need to connect to ARM.")
 		return nil
 	}
 
-	glog.V(1).Info("BEGIN ApplicationGateway deployment")
-	defer glog.V(1).Info("END ApplicationGateway deployment")
+	glog.V(3).Info("BEGIN ApplicationGateway deployment")
+	defer glog.V(3).Info("END ApplicationGateway deployment")
 
 	deploymentStart := time.Now()
 	// Initiate deployment
@@ -185,16 +183,18 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	err = appGwFuture.WaitForCompletionRef(ctx, c.appGwClient.BaseClient.Client)
 	configJSON, _ := c.dumpSanitizedJSON(&appGw)
 	glog.V(5).Info(string(configJSON))
-	glog.V(1).Infof("deployment took %+v", time.Now().Sub(deploymentStart).String())
+
+	// We keep this at log level 1 to show some heartbeat in the logs. Without this it is way too quiet.
+	glog.V(1).Infof("Applied App Gateway config in %+v", time.Now().Sub(deploymentStart).String())
 
 	if err != nil {
 		// Reset cache
 		c.configCache = nil
-		glog.Warningf("unable to deploy ApplicationGateway, error [%v]", err.Error())
-		return errors.New("unable to deploy ApplicationGateway")
+		glog.Warning("unable to deploy App Gateway config.", err)
+		return errors.New("unable to deploy App Gateway config.")
 	}
 
-	glog.Info("cache: Updated with latest applied config.")
+	glog.V(3).Info("cache: Updated with latest applied config.")
 	c.updateCache(&appGw)
 
 	return nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -190,8 +190,8 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 	if err != nil {
 		// Reset cache
 		c.configCache = nil
-		glog.Warning("unable to deploy App Gateway config.", err)
-		return errors.New("unable to deploy App Gateway config.")
+		glog.Warning("Unable to deploy App Gateway config.", err)
+		return errors.New("unable to deploy App Gateway config")
 	}
 
 	glog.V(3).Info("cache: Updated with latest applied config.")

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -9,13 +9,16 @@ package events
 type EventType int
 
 const (
-	// Create type = 1
 	Create EventType = iota + 1
-	// Update type = 2
 	Update
-	// Delete type = 3
 	Delete
 )
+
+var EventTypeLookup = map[EventType]string{
+	1: "Create",
+	2: "Update",
+	3: "Delete",
+}
 
 // Event is the combined type and actual object we received from Kubernetes
 type Event struct {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -9,11 +9,17 @@ package events
 type EventType int
 
 const (
+	// Create is a type of a Kubernetes API event.
 	Create EventType = iota + 1
+
+	// Update is a type of a Kubernetes API event.
 	Update
+
+	// Delete is a type of a Kubernetes API event.
 	Delete
 )
 
+// EventTypeLookup is a reverse map of the EventType enums; used for logging purposes
 var EventTypeLookup = map[EventType]string{
 	1: "Create",
 	2: "Update",

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -1,10 +1,21 @@
 package events
 
 const (
-	ReasonBackendPortTargetMatch    = "BackendPortTargetMatch"
-	ReasonEndpointsEmpty            = "EndpointsEmpty"
+	// ReasonBackendPortTargetMatch is a reason for an event to be emitted.
+	ReasonBackendPortTargetMatch = "BackendPortTargetMatch"
+
+	// ReasonEndpointsEmpty is a reason for an event to be emitted.
+	ReasonEndpointsEmpty = "EndpointsEmpty"
+
+	// ReasonIngressServiceTargetMatch is a reason for an event to be emitted.
 	ReasonIngressServiceTargetMatch = "IngressServiceTargetMatch"
-	ReasonSecretNotFound            = "SecretNotFound"
-	ReasonServiceNotFound           = "ServiceNotFound"
-	ReasonPortResolutionError       = "PortResolutionError"
+
+	// ReasonSecretNotFound is a reason for an event to be emitted.
+	ReasonSecretNotFound = "SecretNotFound"
+
+	// ReasonServiceNotFound is a reason for an event to be emitted.
+	ReasonServiceNotFound = "ServiceNotFound"
+
+	// ReasonPortResolutionError is a reason for an event to be emitted.
+	ReasonPortResolutionError = "PortResolutionError"
 )

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -1,0 +1,10 @@
+package events
+
+const (
+	ReasonBackendPortTargetMatch    = "BackendPortTargetMatch"
+	ReasonEndpointsEmpty            = "EndpointsEmpty"
+	ReasonIngressServiceTargetMatch = "IngressServiceTargetMatch"
+	ReasonSecretNotFound            = "SecretNotFound"
+	ReasonServiceNotFound           = "ServiceNotFound"
+	ReasonPortResolutionError       = "PortResolutionError"
+)


### PR DESCRIPTION
For customers with many namespaces, logging volume could get overwhelming.
Reusing the semantics from [kubectl](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-output-verbosity-and-debugging) verbosity logging - introducing 3 levels:

| Verbosity | Description |
|-----------|-------------|
|  1        | Default log level; shows startup details, warnings and errors |
|  3        | Extended information about events and changes; lists of created objects |
|  5        | Logs marshaled objects; shows sanitized JSON config applied to ARM |

Added section to the Troubleshooting doc on how to change verbosity setting.

### Example:

With `verbosity==1`:
```
Version: 0.7.0-rc2; Commit: 05d27892; Date: 2019-06-25-12:48T-0700
ERROR: logging before flag.Parse: I0625 12:48:47.641806   20750 main.go:228] Using verbosity level 1 from environment variable APPGW_VERBOSITY_LEVEL
ERROR: logging before flag.Parse: I0625 12:48:47.642038   20750 main.go:76] Logging at verbosity level 1
I0625 12:48:47.642062   20750 main.go:166] Creating authorizer from file referenced by AZURE_AUTH_LOCATION
I0625 12:48:48.409939   20750 main.go:107] Ingress Controller will observe the following namespaces:
I0625 12:48:48.473991   20750 context.go:114] k8s context run started
I0625 12:48:48.474063   20750 context.go:299] Wait for initial cache sync
I0625 12:48:48.874968   20750 context.go:306] initial cache sync done
I0625 12:48:48.875020   20750 context.go:116] k8s context run finished
I0625 12:50:40.690675   20750 controller.go:188] Applied App Gateway config in 1m51.752702s
I0625 12:50:40.993235   20750 controller.go:188] Applied App Gateway config in 230.7958ms
```

With `verbosity==3`:
```
Version: 0.7.0-rc2; Commit: 10c2a714; Date: 2019-06-25-12:58T-0700
ERROR: logging before flag.Parse: I0625 12:58:51.480294   21880 main.go:226] Using verbosity level 3 from CLI flag verbosity
I0625 12:58:51.480833   21880 main.go:167] Creating authorizer from file referenced by AZURE_AUTH_LOCATION
I0625 12:58:52.186119   21880 main.go:108] Ingress Controller will observe the following namespaces:
I0625 12:58:52.244460   21880 context.go:114] k8s context run started
I0625 12:58:52.244505   21880 context.go:299] Wait for initial cache sync
I0625 12:58:52.544776   21880 context.go:306] initial cache sync done
I0625 12:58:52.544834   21880 context.go:116] k8s context run finished
I0625 12:58:52.544859   21880 eventqueue.go:69] Enqueuing skip(false) item
I0625 12:58:52.606668   21880 controller.go:169] BEGIN ApplicationGateway deployment
I0625 12:58:52.645316   21880 eventqueue.go:69] Enqueuing skip(false) item
I0625 12:58:53.291386   21880 controller.go:188] Applied App Gateway config in 684.685ms
I0625 12:58:53.291433   21880 controller.go:197] cache: Updated with latest applied config.

```

With `verbosity==5`:
```
Version: 0.7.0-rc2; Commit: 10c2a714; Date: 2019-06-25-13:00T-0700
ERROR: logging before flag.Parse: I0625 13:00:15.394473   22070 main.go:229] Using verbosity level 5 from environment variable APPGW_VERBOSITY_LEVEL
I0625 13:00:15.394730   22070 main.go:167] Creating authorizer from file referenced by AZURE_AUTH_LOCATION
I0625 13:00:16.072720   22070 main.go:108] Ingress Controller will observe the following namespaces:
I0625 13:00:16.143946   22070 validators.go:132] HTTP Listeners:{"etag":"W/\"695ecc4a-dd2e-40b6-866f-fb35c2c0ce8c\"","id":"/subscriptions/................ ,"type":"Microsoft.Network/applicationGateways/frontendIPConfigurations"}
I0625 13:00:16.144045   22070 context.go:114] k8s context run started
I0625 13:00:16.144069   22070 context.go:299] Wait for initial cache sync
I0625 13:00:16.544504   22070 context.go:306] initial cache sync done
I0625 13:00:16.544534   22070 context.go:116] k8s context run finished
I0625 13:00:16.544578   22070 eventqueue.go:69] Enqueuing skip(false) item
I0625 13:00:16.544929   22070 eventqueue.go:127] Received event Create: {"Type":1,"Value":{"metadata":{"name":"heapster","namespace":"kube-system","selfLink":"/api/v1/namespaces/kube-system/services/heapster","uid":"..................
I0625 13:00:16.545121   22070 eventqueue.go:69] Enqueuing skip(false) item
I0625 13:00:16.545197   22070 eventqueue.go:69] Enqueuing skip(false) item
I0625 13:01:51.308898   22215 health_probes.go:27] Adding default probe:defaultprobe
I0625 13:01:51.308925   22215 health_probes.go:47] Will create 1 App Gateway probes.
I0625 13:01:51.308992   22215 controller.go:169] BEGIN ApplicationGateway deployment
I0625 13:01:51.495603   22215 controller.go:185] {
-- App Gwy config --    "etag": "W/\"xx-xx-xx-xx-xx\"",
-- App Gwy config --    "id": "/subscriptions/xxxx/resourceGroups/derayche-rg-X/providers/Microsoft.Network/applicationGateways/xxxx",
-- App Gwy config --    "location": "westus2",
-- App Gwy config --    "properties": {
-- App Gwy config --        "backendAddressPools": [
-- App Gwy config --            {
-- App Gwy config --                "name": "defaultaddresspool",
-- App Gwy config --                "properties": {
-- App Gwy config --                    "backendAddresses": []
-- App Gwy config --                }
-- App Gwy config --            }
-- App Gwy config --        ],
-- App Gwy config --        "backendHttpSettingsCollection": [
.....
```