### PR TITLE
Alias the Azure SDK network package

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -86,7 +86,7 @@ func main() {
 	_ = flag.Lookup("logtostderr").Value.Set("true")
 	_ = flag.Set("v", strconv.Itoa(*verbosity))
 
-	appGwClient := network.NewApplicationGatewaysClient(env.SubscriptionID)
+	appGwClient := n.NewApplicationGatewaysClient(env.SubscriptionID)
 
 	var err error
 	if appGwClient.Authorizer, err = getAzAuth(env); err != nil || appGwClient.Authorizer == nil {
@@ -165,10 +165,10 @@ func getAzAuth(vars environment.EnvVariables) (autorest.Authorizer, error) {
 		return auth.NewAuthorizerFromEnvironment()
 	}
 	glog.V(1).Infoln("Creating authorizer from file referenced by AZURE_AUTH_LOCATION")
-	return auth.NewAuthorizerFromFile(network.DefaultBaseURI)
+	return auth.NewAuthorizerFromFile(n.DefaultBaseURI)
 }
 
-func waitForAzureAuth(envVars environment.EnvVariables, client network.ApplicationGatewaysClient) {
+func waitForAzureAuth(envVars environment.EnvVariables, client n.ApplicationGatewaysClient) {
 	const retryTime = 10 * time.Second
 	for counter := 0; counter <= maxAuthRetry; counter++ {
 		if _, err := client.Get(context.Background(), envVars.ResourceGroupName, envVars.AppGwName); err != nil {

--- a/pkg/appgw/certificates.go
+++ b/pkg/appgw/certificates.go
@@ -8,18 +8,19 @@ package appgw
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"sort"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 )
 
 // getSslCertificates obtains all SSL Certificates for the given Ingress object.
-func (c *appGwConfigBuilder) getSslCertificates(ingressList []*v1beta1.Ingress) *[]network.ApplicationGatewaySslCertificate {
+func (c *appGwConfigBuilder) getSslCertificates(ingressList []*v1beta1.Ingress) *[]n.ApplicationGatewaySslCertificate {
 	secretIDCertificateMap := make(map[secretIdentifier]*string)
 
 	for _, ingress := range ingressList {
@@ -28,7 +29,7 @@ func (c *appGwConfigBuilder) getSslCertificates(ingressList []*v1beta1.Ingress) 
 		}
 	}
 
-	var sslCertificates []network.ApplicationGatewaySslCertificate
+	var sslCertificates []n.ApplicationGatewaySslCertificate
 	for secretID, cert := range secretIDCertificateMap {
 		sslCertificates = append(sslCertificates, newCert(secretID, cert))
 	}
@@ -116,11 +117,11 @@ func (c *appGwConfigBuilder) newHostToSecretMap(ingress *v1beta1.Ingress) map[st
 	return hostToSecretMap
 }
 
-func newCert(secretID secretIdentifier, cert *string) network.ApplicationGatewaySslCertificate {
-	return network.ApplicationGatewaySslCertificate{
+func newCert(secretID secretIdentifier, cert *string) n.ApplicationGatewaySslCertificate {
+	return n.ApplicationGatewaySslCertificate{
 		Etag: to.StringPtr("*"),
 		Name: to.StringPtr(secretID.secretFullName()),
-		ApplicationGatewaySslCertificatePropertiesFormat: &network.ApplicationGatewaySslCertificatePropertiesFormat{
+		ApplicationGatewaySslCertificatePropertiesFormat: &n.ApplicationGatewaySslCertificatePropertiesFormat{
 			Data:     cert,
 			Password: to.StringPtr("msazure"),
 		},

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -6,7 +6,7 @@
 package appgw
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -24,7 +24,7 @@ type ConfigBuilder interface {
 	Listeners(cbCtx *ConfigBuilderContext) error
 	RequestRoutingRules(cbCtx *ConfigBuilderContext) error
 	HealthProbesCollection(cbCtx *ConfigBuilderContext) error
-	GetApplicationGatewayPropertiesFormatPtr() *network.ApplicationGatewayPropertiesFormat
+	GetApplicationGatewayPropertiesFormatPtr() *n.ApplicationGatewayPropertiesFormat
 	PreBuildValidate(cbCtx *ConfigBuilderContext) error
 	PostBuildValidate(cbCtx *ConfigBuilderContext) error
 }
@@ -32,12 +32,12 @@ type ConfigBuilder interface {
 type appGwConfigBuilder struct {
 	k8sContext      *k8scontext.Context
 	appGwIdentifier Identifier
-	appGwConfig     network.ApplicationGatewayPropertiesFormat
+	appGwConfig     n.ApplicationGatewayPropertiesFormat
 	recorder        record.EventRecorder
 }
 
 // NewConfigBuilder construct a builder
-func NewConfigBuilder(context *k8scontext.Context, appGwIdentifier *Identifier, originalConfig *network.ApplicationGatewayPropertiesFormat, recorder record.EventRecorder) ConfigBuilder {
+func NewConfigBuilder(context *k8scontext.Context, appGwIdentifier *Identifier, originalConfig *n.ApplicationGatewayPropertiesFormat, recorder record.EventRecorder) ConfigBuilder {
 	return &appGwConfigBuilder{
 		// TODO(draychev): Decommission internal state
 		k8sContext:      context,
@@ -84,9 +84,9 @@ func generateBackendID(ingress *v1beta1.Ingress, rule *v1beta1.IngressRule, path
 }
 
 func generateListenerID(rule *v1beta1.IngressRule,
-	protocol network.ApplicationGatewayProtocol, overridePort *int32) listenerIdentifier {
+	protocol n.ApplicationGatewayProtocol, overridePort *int32) listenerIdentifier {
 	frontendPort := int32(80)
-	if protocol == network.HTTPS {
+	if protocol == n.HTTPS {
 		frontendPort = int32(443)
 	}
 	if overridePort != nil {
@@ -100,11 +100,11 @@ func generateListenerID(rule *v1beta1.IngressRule,
 }
 
 // GetApplicationGatewayPropertiesFormatPtr gets a pointer to updated ApplicationGatewayPropertiesFormat.
-func (c *appGwConfigBuilder) GetApplicationGatewayPropertiesFormatPtr() *network.ApplicationGatewayPropertiesFormat {
+func (c *appGwConfigBuilder) GetApplicationGatewayPropertiesFormatPtr() *n.ApplicationGatewayPropertiesFormat {
 	return &c.appGwConfig
 }
 
-type valFunc func(eventRecorder record.EventRecorder, config *network.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
+type valFunc func(eventRecorder record.EventRecorder, config *n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error
 
 // PreBuildValidate runs all the validators that suggest misconfiguration in Kubernetes resources.
 func (c *appGwConfigBuilder) PreBuildValidate(cbCtx *ConfigBuilderContext) error {

--- a/pkg/appgw/frontend_ports.go
+++ b/pkg/appgw/frontend_ports.go
@@ -8,13 +8,14 @@ package appgw
 import (
 	"sort"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 )
 
-func (c *appGwConfigBuilder) getFrontendPorts(ingressList []*v1beta1.Ingress) *[]network.ApplicationGatewayFrontendPort {
+func (c *appGwConfigBuilder) getFrontendPorts(ingressList []*v1beta1.Ingress) *[]n.ApplicationGatewayFrontendPort {
 	allPorts := make(map[int32]interface{})
 	for _, ingress := range ingressList {
 		fePorts, _ := c.processIngressRules(ingress)
@@ -29,13 +30,13 @@ func (c *appGwConfigBuilder) getFrontendPorts(ingressList []*v1beta1.Ingress) *[
 		allPorts[port] = nil
 	}
 
-	var frontendPorts []network.ApplicationGatewayFrontendPort
+	var frontendPorts []n.ApplicationGatewayFrontendPort
 	for port := range allPorts {
 		frontendPortName := generateFrontendPortName(port)
-		frontendPorts = append(frontendPorts, network.ApplicationGatewayFrontendPort{
+		frontendPorts = append(frontendPorts, n.ApplicationGatewayFrontendPort{
 			Etag: to.StringPtr("*"),
 			Name: &frontendPortName,
-			ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
+			ApplicationGatewayFrontendPortPropertiesFormat: &n.ApplicationGatewayFrontendPortPropertiesFormat{
 				Port: to.Int32Ptr(port),
 			},
 		})

--- a/pkg/appgw/frontend_ports_test.go
+++ b/pkg/appgw/frontend_ports_test.go
@@ -1,12 +1,13 @@
 package appgw
 
 import (
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
 // appgw_suite_test.go launches these Ginkgo tests
@@ -28,8 +29,8 @@ var _ = Describe("Process ingress rules", func() {
 		})
 
 		It("should have port 80", func() {
-			expected := network.ApplicationGatewayFrontendPort{
-				ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
+			expected := n.ApplicationGatewayFrontendPort{
+				ApplicationGatewayFrontendPortPropertiesFormat: &n.ApplicationGatewayFrontendPortPropertiesFormat{
 					Port:              to.Int32Ptr(80),
 					ProvisioningState: nil,
 				},
@@ -42,8 +43,8 @@ var _ = Describe("Process ingress rules", func() {
 		})
 
 		It("should have port 443", func() {
-			expected := network.ApplicationGatewayFrontendPort{
-				ApplicationGatewayFrontendPortPropertiesFormat: &network.ApplicationGatewayFrontendPortPropertiesFormat{
+			expected := n.ApplicationGatewayFrontendPort{
+				ApplicationGatewayFrontendPortPropertiesFormat: &n.ApplicationGatewayFrontendPortPropertiesFormat{
 					Port:              to.Int32Ptr(443),
 					ProvisioningState: nil,
 				},

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -8,7 +8,7 @@ package appgw
 import (
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -46,10 +46,10 @@ var _ = Describe("configure App Gateway health probes", func() {
 		actual := cb.appGwConfig.Probes
 
 		// We expect our health probe configurator to have arrived at this final setup
-		defaultProbe := network.ApplicationGatewayProbe{
+		defaultProbe := n.ApplicationGatewayProbe{
 
-			ApplicationGatewayProbePropertiesFormat: &network.ApplicationGatewayProbePropertiesFormat{
-				Protocol:                            network.HTTP,
+			ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
+				Protocol:                            n.HTTP,
 				Host:                                to.StringPtr("localhost"),
 				Path:                                to.StringPtr("/"),
 				Interval:                            to.Int32Ptr(30),
@@ -65,9 +65,9 @@ var _ = Describe("configure App Gateway health probes", func() {
 			Type: nil,
 			ID:   nil,
 		}
-		probeForHost := network.ApplicationGatewayProbe{
-			ApplicationGatewayProbePropertiesFormat: &network.ApplicationGatewayProbePropertiesFormat{
-				Protocol:                            network.HTTP,
+		probeForHost := n.ApplicationGatewayProbe{
+			ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
+				Protocol:                            n.HTTP,
 				Host:                                to.StringPtr(tests.Host),
 				Path:                                to.StringPtr(tests.URLPath),
 				Interval:                            to.Int32Ptr(30),
@@ -84,9 +84,9 @@ var _ = Describe("configure App Gateway health probes", func() {
 			ID:   nil,
 		}
 
-		probeForOtherHost := network.ApplicationGatewayProbe{
-			ApplicationGatewayProbePropertiesFormat: &network.ApplicationGatewayProbePropertiesFormat{
-				Protocol:                            network.HTTP,
+		probeForOtherHost := n.ApplicationGatewayProbe{
+			ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
+				Protocol:                            n.HTTP,
 				Host:                                to.StringPtr(tests.Host),
 				Path:                                to.StringPtr(tests.URLPath),
 				Interval:                            to.Int32Ptr(20),
@@ -136,10 +136,10 @@ var _ = Describe("configure App Gateway health probes", func() {
 		actual := cb.appGwConfig.Probes
 
 		// We expect our health probe configurator to have arrived at this final setup
-		defaultProbe := network.ApplicationGatewayProbe{
+		defaultProbe := n.ApplicationGatewayProbe{
 
-			ApplicationGatewayProbePropertiesFormat: &network.ApplicationGatewayProbePropertiesFormat{
-				Protocol:                            network.HTTP,
+			ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
+				Protocol:                            n.HTTP,
 				Host:                                to.StringPtr("localhost"),
 				Path:                                to.StringPtr("/"),
 				Interval:                            to.Int32Ptr(30),

--- a/pkg/appgw/identifier.go
+++ b/pkg/appgw/identifier.go
@@ -8,7 +8,7 @@ package appgw
 import (
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 )
 
@@ -74,6 +74,6 @@ func (agw Identifier) publicIPID(publicIPName string) string {
 	return agw.resourceID("Microsoft.Network", "publicIPAddresses", publicIPName)
 }
 
-func resourceRef(id string) *network.SubResource {
-	return &network.SubResource{ID: to.StringPtr(id)}
+func resourceRef(id string) *n.SubResource {
+	return &n.SubResource{ID: to.StringPtr(id)}
 }

--- a/pkg/appgw/ingress_rules.go
+++ b/pkg/appgw/ingress_rules.go
@@ -6,9 +6,10 @@
 package appgw
 
 import (
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 )
 
 // processIngressRules creates the sets of front end listeners and ports, and a map of azure config per listener for the given ingress.
@@ -29,7 +30,7 @@ func (c *appGwConfigBuilder) processIngressRules(ingress *v1beta1.Ingress) (map[
 		// If a certificate is available we enable only HTTPS; unless ingress is annotated with ssl-redirect - then
 		// we enable HTTPS as well as HTTP, and redirect HTTP to HTTPS.
 		if hasTLS {
-			listenerID := generateListenerID(&rule, network.HTTPS, nil)
+			listenerID := generateListenerID(&rule, n.HTTPS, nil)
 			frontendPorts[listenerID.FrontendPort] = nil
 			// Only associate the Listener with a Redirect if redirect is enabled
 			redirect := ""
@@ -38,7 +39,7 @@ func (c *appGwConfigBuilder) processIngressRules(ingress *v1beta1.Ingress) (map[
 			}
 
 			listeners[listenerID] = listenerAzConfig{
-				Protocol:                     network.HTTPS,
+				Protocol:                     n.HTTPS,
 				Secret:                       *secID,
 				SslRedirectConfigurationName: redirect,
 			}
@@ -46,10 +47,10 @@ func (c *appGwConfigBuilder) processIngressRules(ingress *v1beta1.Ingress) (map[
 
 		// Enable HTTP only if HTTPS is not configured OR if ingress annotated with 'ssl-redirect'
 		if sslRedirect || !hasTLS {
-			listenerID := generateListenerID(&rule, network.HTTP, nil)
+			listenerID := generateListenerID(&rule, n.HTTP, nil)
 			frontendPorts[listenerID.FrontendPort] = nil
 			listeners[listenerID] = listenerAzConfig{
-				Protocol: network.HTTP,
+				Protocol: n.HTTP,
 			}
 		}
 

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -14,10 +14,11 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/golang/glog"
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 )
 
 const (
@@ -66,7 +67,7 @@ var agPrefix = environment.GetEnvironmentVariable("APPGW_CONFIG_NAME_PREFIX", ""
 
 // create xxx -> xxxconfiguration mappings to contain all the information
 type listenerAzConfig struct {
-	Protocol                     network.ApplicationGatewayProtocol
+	Protocol                     n.ApplicationGatewayProtocol
 	Secret                       secretIdentifier
 	SslRedirectConfigurationName string
 }
@@ -146,30 +147,30 @@ var defaultBackendHTTPSettingsName = fmt.Sprintf("%sdefaulthttpsetting", agPrefi
 var defaultBackendAddressPoolName = fmt.Sprintf("%sdefaultaddresspool", agPrefix)
 var defaultProbeName = fmt.Sprintf("%sdefaultprobe", agPrefix)
 
-func defaultBackendHTTPSettings(probeID string) network.ApplicationGatewayBackendHTTPSettings {
+func defaultBackendHTTPSettings(probeID string) n.ApplicationGatewayBackendHTTPSettings {
 	defHTTPSettingsName := defaultBackendHTTPSettingsName
 	defHTTPSettingsPort := int32(80)
-	return network.ApplicationGatewayBackendHTTPSettings{
+	return n.ApplicationGatewayBackendHTTPSettings{
 		Name: &defHTTPSettingsName,
-		ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &network.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
-			Protocol: network.HTTP,
+		ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
+			Protocol: n.HTTP,
 			Port:     &defHTTPSettingsPort,
 			Probe:    resourceRef(probeID),
 		},
 	}
 }
 
-func defaultProbe() network.ApplicationGatewayProbe {
+func defaultProbe() n.ApplicationGatewayProbe {
 	defProbeName := defaultProbeName
-	defProtocol := network.HTTP
+	defProtocol := n.HTTP
 	defHost := "localhost"
 	defPath := "/"
 	defInterval := int32(30)
 	defTimeout := int32(30)
 	defUnHealthyCount := int32(3)
-	return network.ApplicationGatewayProbe{
+	return n.ApplicationGatewayProbe{
 		Name: &defProbeName,
-		ApplicationGatewayProbePropertiesFormat: &network.ApplicationGatewayProbePropertiesFormat{
+		ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
 			Protocol:           defProtocol,
 			Host:               &defHost,
 			Path:               &defPath,
@@ -180,12 +181,12 @@ func defaultProbe() network.ApplicationGatewayProbe {
 	}
 }
 
-func defaultBackendAddressPool() *network.ApplicationGatewayBackendAddressPool {
+func defaultBackendAddressPool() *n.ApplicationGatewayBackendAddressPool {
 	defBackendAddressPool := defaultBackendAddressPoolName
-	return &network.ApplicationGatewayBackendAddressPool{
+	return &n.ApplicationGatewayBackendAddressPool{
 		Name: &defBackendAddressPool,
-		ApplicationGatewayBackendAddressPoolPropertiesFormat: &network.ApplicationGatewayBackendAddressPoolPropertiesFormat{
-			BackendAddresses: &[]network.ApplicationGatewayBackendAddress{},
+		ApplicationGatewayBackendAddressPoolPropertiesFormat: &n.ApplicationGatewayBackendAddressPoolPropertiesFormat{
+			BackendAddresses: &[]n.ApplicationGatewayBackendAddress{},
 		},
 	}
 }

--- a/pkg/appgw/test_fixtures.go
+++ b/pkg/appgw/test_fixtures.go
@@ -8,26 +8,26 @@ package appgw
 import (
 	"fmt"
 
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
-	"github.com/Azure/go-autorest/autorest/to"
-	"k8s.io/client-go/tools/cache"
 )
 
-func newAppGwyConfigFixture() network.ApplicationGatewayPropertiesFormat {
-	feIPConfigs := []network.ApplicationGatewayFrontendIPConfiguration{
+func newAppGwyConfigFixture() n.ApplicationGatewayPropertiesFormat {
+	feIPConfigs := []n.ApplicationGatewayFrontendIPConfiguration{
 		{
 			// Public IP
 			Name: to.StringPtr("xx3"),
 			Etag: to.StringPtr("xx2"),
 			Type: to.StringPtr("xx1"),
 			ID:   to.StringPtr(tests.IPID1),
-			ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+			ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &n.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
 				PrivateIPAddress: nil,
-				PublicIPAddress: &network.SubResource{
+				PublicIPAddress: &n.SubResource{
 					ID: to.StringPtr("xyz"),
 				},
 			},
@@ -38,13 +38,13 @@ func newAppGwyConfigFixture() network.ApplicationGatewayPropertiesFormat {
 			Etag: to.StringPtr("yy2"),
 			Type: to.StringPtr("yy1"),
 			ID:   to.StringPtr(tests.IPID2),
-			ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &network.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+			ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &n.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
 				PrivateIPAddress: to.StringPtr("abc"),
 				PublicIPAddress:  nil,
 			},
 		},
 	}
-	return network.ApplicationGatewayPropertiesFormat{
+	return n.ApplicationGatewayPropertiesFormat{
 		FrontendIPConfigurations: &feIPConfigs,
 	}
 }
@@ -112,13 +112,13 @@ func newCertsFixture() map[string]interface{} {
 	return toAdd
 }
 
-func newURLPathMap() network.ApplicationGatewayURLPathMap {
-	rule := network.ApplicationGatewayPathRule{
+func newURLPathMap() n.ApplicationGatewayURLPathMap {
+	rule := n.ApplicationGatewayPathRule{
 		ID:   to.StringPtr("-the-id-"),
 		Type: to.StringPtr("-the-type-"),
 		Etag: to.StringPtr("-the-etag-"),
 		Name: to.StringPtr("/some/path"),
-		ApplicationGatewayPathRulePropertiesFormat: &network.ApplicationGatewayPathRulePropertiesFormat{
+		ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 			// A Path Rule must have either RedirectConfiguration xor (BackendAddressPool + BackendHTTPSettings)
 			RedirectConfiguration: nil,
 
@@ -130,16 +130,16 @@ func newURLPathMap() network.ApplicationGatewayURLPathMap {
 		},
 	}
 
-	return network.ApplicationGatewayURLPathMap{
+	return n.ApplicationGatewayURLPathMap{
 		Name: to.StringPtr("-path-map-name-"),
-		ApplicationGatewayURLPathMapPropertiesFormat: &network.ApplicationGatewayURLPathMapPropertiesFormat{
+		ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 			// URL Path Map must have either DefaultRedirectConfiguration xor (DefaultBackendAddressPool + DefaultBackendHTTPSettings)
 			DefaultRedirectConfiguration: nil,
 
 			DefaultBackendAddressPool:  resourceRef("--DefaultBackendAddressPool--"),
 			DefaultBackendHTTPSettings: resourceRef("--DefaultBackendHTTPSettings--"),
 
-			PathRules: &[]network.ApplicationGatewayPathRule{rule},
+			PathRules: &[]n.ApplicationGatewayPathRule{rule},
 		},
 	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/eapache/channels"
 	"github.com/golang/glog"
@@ -27,7 +27,7 @@ import (
 
 // AppGwIngressController configures the application gateway based on the ingress rules defined.
 type AppGwIngressController struct {
-	appGwClient     network.ApplicationGatewaysClient
+	appGwClient     n.ApplicationGatewaysClient
 	appGwIdentifier appgw.Identifier
 
 	k8sContext       *k8scontext.Context
@@ -42,7 +42,7 @@ type AppGwIngressController struct {
 }
 
 // NewAppGwIngressController constructs a controller object.
-func NewAppGwIngressController(appGwClient network.ApplicationGatewaysClient, appGwIdentifier appgw.Identifier, k8sContext *k8scontext.Context, recorder record.EventRecorder) *AppGwIngressController {
+func NewAppGwIngressController(appGwClient n.ApplicationGatewaysClient, appGwIdentifier appgw.Identifier, k8sContext *k8scontext.Context, recorder record.EventRecorder) *AppGwIngressController {
 	controller := &AppGwIngressController{
 		appGwClient:      appGwClient,
 		appGwIdentifier:  appGwIdentifier,
@@ -201,7 +201,7 @@ func (c AppGwIngressController) Process(event QueuedEvent) error {
 }
 
 // addTags will add certain tags to Application Gateway
-func addTags(appGw *network.ApplicationGateway) {
+func addTags(appGw *n.ApplicationGateway) {
 	if appGw.Tags == nil {
 		appGw.Tags = make(map[string]*string)
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -8,11 +8,11 @@ package controller
 import (
 	"testing"
 
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 )
 
@@ -23,7 +23,7 @@ func TestController(t *testing.T) {
 
 var _ = Describe("configure App Gateway", func() {
 	Context("ensure app gwy is tagged", func() {
-		agw := &network.ApplicationGateway{}
+		agw := &n.ApplicationGateway{}
 		version.Version = "a"
 		version.GitCommit = "b"
 		version.BuildDate = "c"

--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/golang/glog"
 )
 
@@ -19,7 +19,7 @@ var keysToDeleteForCache = []string{
 	"etag",
 }
 
-func (c *AppGwIngressController) updateCache(appGw *network.ApplicationGateway) {
+func (c *AppGwIngressController) updateCache(appGw *n.ApplicationGateway) {
 	jsonConfig, err := appGw.MarshalJSON()
 	if err != nil {
 		glog.Error("Could not marshal App Gwy to update cache; Wiping cache.", err)
@@ -37,7 +37,7 @@ func (c *AppGwIngressController) updateCache(appGw *network.ApplicationGateway) 
 }
 
 // configIsSame compares the newly created App Gwy configuration with a cache to determine whether anything has changed.
-func (c *AppGwIngressController) configIsSame(appGw *network.ApplicationGateway) bool {
+func (c *AppGwIngressController) configIsSame(appGw *n.ApplicationGateway) bool {
 	if c.configCache == nil {
 		return false
 	}
@@ -58,7 +58,7 @@ func (c *AppGwIngressController) configIsSame(appGw *network.ApplicationGateway)
 	return c.configCache != nil && bytes.Compare(*c.configCache, sanitized) == 0
 }
 
-func (c *AppGwIngressController) dumpSanitizedJSON(appGw *network.ApplicationGateway) ([]byte, error) {
+func (c *AppGwIngressController) dumpSanitizedJSON(appGw *n.ApplicationGateway) ([]byte, error) {
 	jsonConfig, err := appGw.MarshalJSON()
 	if err != nil {
 		return nil, err

--- a/pkg/controller/helpers_test.go
+++ b/pkg/controller/helpers_test.go
@@ -6,7 +6,7 @@
 package controller
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -66,7 +66,7 @@ var _ = Describe("configure App Gateway", func() {
 	Context("ensure configIsSame works as expected", func() {
 		It("should deal with nil cache and store stuff in it", func() {
 			c := AppGwIngressController{}
-			config := network.ApplicationGateway{
+			config := n.ApplicationGateway{
 				ID: to.StringPtr("something"),
 			}
 			Expect(c.configIsSame(&config)).To(BeFalse())


### PR DESCRIPTION
While working on the brownfield-deployment feature, I noticed that we are not benefiting much from the `network.` prefix in the SDK's structs. Instead these cause for long function signatures and subjectively verbose code.

The structs from the SDK are already with very high specificity - for instance `network.ApplicationGatewayProbe`.  Shortening this to `n.ApplicationGatewayProbe` does not reduce clarity.

In [quite a few files we are already](https://github.com/Azure/application-gateway-kubernetes-ingress/search?utf8=%E2%9C%93&q=n+%22github.com%2FAzure%2Fazure-sdk-for-go%2Fservices%2Fnetwork%2Fmgmt%2F2018-12-01%2Fnetwork%22&type=) employing this aliasing. The PR here completes the work across 100% of the imports.