### PR TITLE
Update Helm upgrade documentation

### DIFF
--- a/docs/how-tos/helm-upgrade.md
+++ b/docs/how-tos/helm-upgrade.md
@@ -1,51 +1,90 @@
-# Upgrading AGIC using helm
+# Upgrading AGIC using Helm
 
-1) Update the helm repo and check the available chart versions.
+The Azure Application Gateway Ingress Controller for Kubernetes (AGIC) can be upgraded
+using [a Helm repository hosted on GitHub](https://azure.github.io/application-gateway-kubernetes-ingress/helm/).
+
+Before we begin the upgrade procedure, ensure that you have added the required repository:
+
+- View your currently added Helm repositories with:
+    ```bash
+    helm repo list
+    ```
+
+- Add the AGIC repo with:
+    ```bash
+    helm repo add \
+        application-gateway-kubernetes-ingress \
+        https://azure.github.io/application-gateway-kubernetes-ingress/helm/
+    ```
+
+
+### Upgrade
+1) Refresh the AGIC Helm repository to get the latest release:
 
     ```bash
-    $> helm repo update && helm search -l application-gateway-kubernetes-ingress
-    NAME                                                    CHART VERSION   APP VERSION     DESCRIPTION                                                 
+    helm repo update
+    ```
+
+2) View available versions of the `application-gateway-kubernetes-ingress` chart:
+
+    ```bash
+    helm search -l application-gateway-kubernetes-ingress
+    ```
+
+    Sample response:
+    ```bash
+    NAME                                                    CHART VERSION   APP VERSION     DESCRIPTION
     application-gateway-kubernetes-ingress/ingress-azure    0.7.0-rc1       0.7.0-rc1       Use Azure Application Gateway as the ingress for an Azure...
     application-gateway-kubernetes-ingress/ingress-azure    0.6.0           0.6.0           Use Azure Application Gateway as the ingress for an Azure...
-    application-gateway-kubernetes-ingress/ingress-azure    0.6.0-rc1       0.6.0-rc1       Use Azure Application Gateway as the ingress for an Azure...
-    ...
     ```
-    
-    Latest Version (current): `0.7.0-rc1`
 
-2) Look up your helm chart release name
+    Latest available version from the list above is: `0.7.0-rc1`
+
+2) View the Helm charts currently installed:
 
     ```bash
-    $> helm list
+    helm list
+    ```
+
+    Sample response:
+    ```
     NAME            REVISION        UPDATED                         STATUS  CHART                   APP VERSION     NAMESPACE
     odd-billygoat   22              Fri Jun 21 15:56:06 2019        FAILED  ingress-azure-0.7.0-rc1 0.7.0-rc1       default
     ```
 
-    Release name: `odd-billygoat`
+    The Helm chart installation from the sample response above is named `odd-billygoat`. We will
+    use this name for the rest of the commands. Your actual deployment name will most likely differ.
 
-2) Now to upgrade to a new version, use
+2) Upgrade the Helm deployment to a new version:
 
     ```bash
-    $> helm upgrade application-gateway-kubernetes-ingress/ingress-azure -n odd-billygoat --version 0.7.0-rc1
+    helm upgrade \
+        application-gateway-kubernetes-ingress/ingress-azure \
+        -n odd-billygoat \
+        --version 0.7.0-rc1
     ```
 
 ## Rollback
 
-If for some reason, the new deployment of the ingres controller goes to a bad state.
-Check your previous revision number by,
+Should the Helm deployment fail, you can rollback to a previous release.
+1) Get the last known healthy release number:
 
-```bash
-$> helm history odd-billygoat
-REVISION        UPDATED                         STATUS          CHART                   DESCRIPTION                                                 
-1               Mon Jun 17 13:49:42 2019        DEPLOYED      ingress-azure-0.6.0     Install complete                                            
-2              Fri Jun 21 15:56:06 2019        FAILED          ingress-azure-xx    xxxx
-```
+    ```bash
+    helm history odd-billygoat
+    ```
 
-Previous Successful Revision: `1`
+    Sample output:
 
-Rollback using:
+    ```
+    REVISION        UPDATED                         STATUS          CHART                   DESCRIPTION
+    1               Mon Jun 17 13:49:42 2019        DEPLOYED        ingress-azure-0.6.0     Install complete
+    2               Fri Jun 21 15:56:06 2019        FAILED          ingress-azure-xx        xxxx
+    ```
 
-```bash
-$> helm rollback odd-billygoat 1
-Rollback was a success! Happy Helming!
-```
+    From the sample output of the `helm history` command it looks like the last successful deployment of our `odd-billygoat` was revision `1`
+
+2) Rollback to the last successful revision:
+
+    ```bash
+    helm rollback odd-billygoat 1
+    ```


### PR DESCRIPTION
A few small tweaks to the upgrade documentation to bring it to consistency with the rest of our docs:

- removing custom shell prompt
- capitalize Helm
- split `&&` commands
- split into multiple lines where lines too long