### PR TITLE
Remove let's encrypt anchor in Tutorials

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -5,7 +5,6 @@
 - [Expose services over HTTPS](#expose-services-over-https)
   * [Without specified hostname](#without-specified-hostname)
   * [With specified hostname](#with-specified-hostname)
-  * [Certificate issuance with `Lets Encrypt`](#certificate-issuance-with-lets-encrypt)
 - [Integrate with other services](#integrate-with-other-services)
 
 # Tutorials


### PR DESCRIPTION
Let's Encrypt was moved from tutorials to How to section in Pullrequest #295 