### PR TITLE
utils: Adding GetLastChunkOfSlashed - returns the last slice of a string split on slash

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -40,3 +40,9 @@ func IntsToString(l []int, delim string) string {
 func GetResourceKey(namespace, name string) string {
 	return fmt.Sprintf("%v/%v", namespace, name)
 }
+
+// GetLastChunkOfSlashed splits a string by slash and returns the last chunk.
+func GetLastChunkOfSlashed(s string) string {
+	split := strings.Split(s, "/")
+	return split[len(split)-1]
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -31,5 +31,15 @@ var _ = Describe("Utils", func() {
 				Expect(utils.GetResourceKey("default", "pod")).To(Equal("default/pod"))
 			})
 		})
+
+		Context("Test GetLastChunkOfSlashed", func() {
+			It("Should return the last slice of a string split on a slash.", func() {
+				Expect(utils.GetLastChunkOfSlashed("a/b/c")).To(Equal("c"))
+			})
+
+			It("Should return the full string when there are no slashes.", func() {
+				Expect(utils.GetLastChunkOfSlashed("abc")).To(Equal("abc"))
+			})
+		})
 	})
 })


### PR DESCRIPTION
This tiny utility comes-in handy when one wants to get the last piece (the resource name) of a Resource Id.

For instance
when given `/subscriptions/yxxxyxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/draychev-rg-X/providers/Microsoft.Network/applicationGateways/applicationgatewayxxxx/redirectConfigurations/sslr-fl-app3.domain.com-443`
it will return `sslr-fl-app3.domain.com-443`