### PR TITLE
AzureIngress{Managed,Prohibited}Target: renaming host to hostname

### DIFF
--- a/crds/AzureIngressManagedTarget.yaml
+++ b/crds/AzureIngressManagedTarget.yaml
@@ -17,7 +17,7 @@ spec:
             ip:
               description: "(required) IP address of the target managed by Ingress Controller; Could be the public or private address attached to the Application Gateway"
               type: string
-            host:
+            hostname:
               description: "(optional) Hostname of the target"
               type: string
             port:

--- a/crds/AzureIngressProhibitedTarget.yaml
+++ b/crds/AzureIngressProhibitedTarget.yaml
@@ -17,7 +17,7 @@ spec:
             ip:
               description: "(required) IP address of the prohibited target; Could be the public or private address attached to the Application Gateway"
               type: string
-            host:
+            hostname:
               description: "(optional) Hostname of the prohibited target"
               type: string
             port:

--- a/crds/examples/AzureIngressManagedTarget.yaml
+++ b/crds/examples/AzureIngressManagedTarget.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ingress-managed-location
 spec:
   ip: 23.45.67.89
-  host: "www.contoso.com"
+  hostname: "www.contoso.com"
   port: 80
   paths:
     - "/foo/*"

--- a/crds/examples/AzureIngressProhibitedTarget.yaml
+++ b/crds/examples/AzureIngressProhibitedTarget.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ingress-prohibited-location
 spec:
   ip: 23.45.67.21
-  host: "ftp.contoso.com"
+  hostname: "ftp.contoso.com"
   port: 88
   paths:
     - "/fox/*"

--- a/proposals/config_ownership_crd.md
+++ b/proposals/config_ownership_crd.md
@@ -59,7 +59,7 @@ spec:
             ip:
               description: "(required) IP address of the target managed by Ingress Controller; Could be the public or private address attached to the Application Gateway"
               type: string
-            host:
+            hostname:
               description: "(optional) Hostname of the target"
               type: string
             port:
@@ -98,7 +98,7 @@ spec:
             ip:
               description: "(required) IP address of the prohibited target; Could be the public or private address attached to the Application Gateway"
               type: string
-            host:
+            hostname:
               description: "(optional) Hostname of the prohibited target"
               type: string
             port:
@@ -125,7 +125,7 @@ metadata:
   name: ingress-managed-target
 spec:
   ip: 23.45.67.89
-  host: "www.contoso.com"
+  hostname: "www.contoso.com"
   port: 80
   paths:
     - "/foo/*"


### PR DESCRIPTION
Changing this documentation (not in Helm yet) to match the Go code:
https://github.com/Azure/application-gateway-kubernetes-ingress/blob/71b94ef2aaa5ffb47d26aa93f0221241436b775f/pkg/apis/azureingressmanagedtarget/v1/types.go#L25-L44
