### PR TITLE
pools: Apply AzureIngress{Managed,Prohibited}Target CRDs

### DIFF
--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -6,16 +6,14 @@
 package appgw
 
 import (
-	"sort"
-	"strconv"
-
+	"fmt"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
 	"k8s.io/api/extensions/v1beta1"
-
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
+	"sort"
 )
 
 func (c *appGwConfigBuilder) RequestRoutingRules(cbCtx *ConfigBuilderContext) error {
@@ -35,7 +33,7 @@ func (c *appGwConfigBuilder) getURLPathMaps(cbCtx *ConfigBuilderContext) map[lis
 	urlPathMaps := make(map[listenerIdentifier]*n.ApplicationGatewayURLPathMap)
 	backendPools := c.newBackendPoolMap(cbCtx)
 	_, backendHTTPSettingsMap, _, _ := c.getBackendsAndSettingsMap(cbCtx)
-	for _, ingress := range cbCtx.IngressList {
+	for ingressIdx, ingress := range cbCtx.IngressList {
 		defaultAddressPoolID := c.appGwIdentifier.addressPoolID(defaultBackendAddressPoolName)
 		defaultHTTPSettingsID := c.appGwIdentifier.httpSettingsID(defaultBackendHTTPSettingsName)
 
@@ -92,13 +90,13 @@ func (c *appGwConfigBuilder) getURLPathMaps(cbCtx *ConfigBuilderContext) map[lis
 					// only add wildcard rules when host is specified
 					urlPathMaps[listenerHTTPID] = c.pathMaps(ingress, cbCtx, wildcardRule,
 						listenerHTTPID, urlPathMaps[listenerHTTPID],
-						defaultAddressPoolID, defaultHTTPSettingsID)
+						defaultAddressPoolID, defaultHTTPSettingsID, ingressIdx)
 				}
 
 				// need to eliminate non-unique paths
 				urlPathMaps[listenerHTTPID] = c.pathMaps(ingress, cbCtx, rule,
 					listenerHTTPID, urlPathMaps[listenerHTTPID],
-					defaultAddressPoolID, defaultHTTPSettingsID)
+					defaultAddressPoolID, defaultHTTPSettingsID, ingressIdx)
 
 				// If ingress is annotated with "ssl-redirect" and we have TLS - setup redirection configuration.
 				if sslRedirect, _ := annotations.IsSslRedirect(ingress); sslRedirect && httpsAvailable {
@@ -111,13 +109,13 @@ func (c *appGwConfigBuilder) getURLPathMaps(cbCtx *ConfigBuilderContext) map[lis
 					// only add wildcard rules when host is specified
 					urlPathMaps[listenerHTTPSID] = c.pathMaps(ingress, cbCtx, wildcardRule,
 						listenerHTTPSID, urlPathMaps[listenerHTTPSID],
-						defaultAddressPoolID, defaultHTTPSettingsID)
+						defaultAddressPoolID, defaultHTTPSettingsID, ingressIdx)
 				}
 
 				// need to eliminate non-unique paths
 				urlPathMaps[listenerHTTPSID] = c.pathMaps(ingress, cbCtx, rule,
 					listenerHTTPSID, urlPathMaps[listenerHTTPSID],
-					defaultAddressPoolID, defaultHTTPSettingsID)
+					defaultAddressPoolID, defaultHTTPSettingsID, ingressIdx)
 			}
 		}
 	}
@@ -177,7 +175,7 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 
 func (c *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, cbCtx *ConfigBuilderContext, rule *v1beta1.IngressRule,
 	listenerID listenerIdentifier, urlPathMap *n.ApplicationGatewayURLPathMap,
-	defaultAddressPoolID string, defaultHTTPSettingsID string) *n.ApplicationGatewayURLPathMap {
+	defaultAddressPoolID string, defaultHTTPSettingsID string, ingressIdx int) *n.ApplicationGatewayURLPathMap {
 	if urlPathMap == nil {
 		urlPathMap = &n.ApplicationGatewayURLPathMap{
 			Etag: to.StringPtr("*"),
@@ -218,15 +216,17 @@ func (c *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, cbCtx *ConfigBui
 			}
 		} else {
 			// associate backend with a path-based rule
-			pathRules = append(pathRules, n.ApplicationGatewayPathRule{
+			suffix := fmt.Sprintf("%d-%d", ingressIdx, pathIdx)
+			pathRule := n.ApplicationGatewayPathRule{
 				Etag: to.StringPtr("*"),
-				Name: to.StringPtr(generatePathRuleName(ingress.Namespace, ingress.Name, strconv.Itoa(pathIdx))),
+				Name: to.StringPtr(generatePathRuleName(ingress.Namespace, ingress.Name, suffix)),
 				ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 					Paths:               &[]string{path.Path},
 					BackendAddressPool:  &backendPoolSubResource,
 					BackendHTTPSettings: &backendHTTPSettingsSubResource,
 				},
-			})
+			}
+			pathRules = append(pathRules, pathRule)
 		}
 
 		urlPathMap.PathRules = &pathRules

--- a/pkg/brownfield/common.go
+++ b/pkg/brownfield/common.go
@@ -1,0 +1,15 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+
+func portFromListener(listener *network.ApplicationGatewayHTTPListener) int32 {
+	if listener != nil && listener.Protocol == network.HTTPS {
+		return int32(443)
+	}
+	return int32(80)
+}

--- a/pkg/brownfield/ingress.go
+++ b/pkg/brownfield/ingress.go
@@ -1,0 +1,76 @@
+package brownfield
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+// PruneIngress mutates the ingress object to prune prohibited targets and leaves ones AGIC will manage.
+func PruneIngress(ing *v1beta1.Ingress, blacklist TargetBlacklist, whitelist TargetWhitelist) {
+	var rules []v1beta1.IngressRule
+
+	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
+
+		target := Target{
+			Hostname: rule.Host,
+			Port:     443, // TODO(delyan) !!!!!
+			Path:     nil,
+		}
+
+		if rule.HTTP.Paths == nil {
+			if shouldKeep(target, blacklist, whitelist) {
+				rules = append(rules, rule)
+			}
+			continue // to next rule
+		}
+
+		newRule := v1beta1.IngressRule{
+			Host: rule.Host,
+			IngressRuleValue: v1beta1.IngressRuleValue{
+				HTTP: &v1beta1.HTTPIngressRuleValue{
+					Paths: []v1beta1.HTTPIngressPath{},
+				},
+			},
+		}
+		for _, path := range rule.HTTP.Paths {
+			target.Path = &path.Path
+			if shouldKeep(target, blacklist, whitelist) {
+				newRule.HTTP.Paths = append(newRule.HTTP.Paths, path)
+			}
+		}
+		if len(newRule.HTTP.Paths) > 0 {
+			rules = append(rules, newRule)
+		}
+	}
+
+	ing.Spec.Rules = rules
+}
+
+func shouldKeep(target Target, blacklist TargetBlacklist, whitelist TargetWhitelist) bool {
+	// Apply Blacklist first to remove explicitly forbidden targets.
+	if blacklist != nil && len(*blacklist) > 0 {
+		targetJSON, _ := target.MarshalJSON()
+		if target.IsIn(blacklist) {
+			glog.V(5).Infof("Target is in blacklist. Ignore: %s", string(targetJSON))
+			return false
+		}
+		glog.V(5).Infof("Target is not in blacklist. Keep: %s", string(targetJSON))
+		return true
+	}
+
+	if whitelist != nil && len(*whitelist) > 0 {
+		targetJSON, _ := target.MarshalJSON()
+		if target.IsIn(whitelist) {
+			glog.V(5).Infof("Target is in the whitelist. Keep: %s", string(targetJSON))
+			return true
+		}
+		glog.V(5).Infof("Target is not in the whitelist. Ignore: %s", string(targetJSON))
+		return false
+	}
+
+	//There's neither blacklist nor whitelist - keep it
+	return true
+}

--- a/pkg/brownfield/pools.go
+++ b/pkg/brownfield/pools.go
@@ -1,0 +1,195 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/glog"
+
+	mtv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressmanagedtarget/v1"
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
+)
+
+// GetManagedPools filters the given list of backend pools to the list pools that AGIC is allowed to manage.
+func GetManagedPools(pools []n.ApplicationGatewayBackendAddressPool, managed []*mtv1.AzureIngressManagedTarget, prohibited []*ptv1.AzureIngressProhibitedTarget, ctx PoolContext) []n.ApplicationGatewayBackendAddressPool {
+	blacklist := GetProhibitedTargetList(prohibited)
+	whitelist := GetManagedTargetList(managed)
+
+	if len(*blacklist) == 0 && len(*whitelist) == 0 {
+		// There is neither TargetBlacklist nor TargetWhitelist -- AGIC will manage all.
+		return pools
+	}
+
+	// Ignore the TargetWhitelist if TargetBlacklist exists
+	if len(*blacklist) > 0 {
+		return ctx.applyBlacklist(pools, blacklist)
+	}
+	return ctx.applyWhitelist(pools, whitelist)
+}
+
+// PruneManagedPools removes the managed pools from the given list of pools; resulting in a list of pools not managed by AGIC.
+func PruneManagedPools(pools []n.ApplicationGatewayBackendAddressPool, managedTargets []*mtv1.AzureIngressManagedTarget, prohibitedTargets []*ptv1.AzureIngressProhibitedTarget, ctx PoolContext) []n.ApplicationGatewayBackendAddressPool {
+	managedPools := GetManagedPools(pools, managedTargets, prohibitedTargets, ctx)
+	if managedPools == nil {
+		return pools
+	}
+	managedByName := indexByName(managedPools)
+	var unmanagedPools []n.ApplicationGatewayBackendAddressPool
+	for _, pool := range pools {
+		if _, isManaged := managedByName[backendPoolName(*pool.Name)]; isManaged {
+			continue
+		}
+		unmanagedPools = append(unmanagedPools, pool)
+	}
+	return unmanagedPools
+}
+
+// MergePools merges list of lists of backend address pools into a single list, maintaining uniqueness.
+func MergePools(pools ...[]n.ApplicationGatewayBackendAddressPool) []n.ApplicationGatewayBackendAddressPool {
+	uniqPool := make(poolsByName)
+	for _, bucket := range pools {
+		for _, pool := range bucket {
+			uniqPool[backendPoolName(*pool.Name)] = pool
+		}
+	}
+	var merged []n.ApplicationGatewayBackendAddressPool
+	for _, pool := range uniqPool {
+		merged = append(merged, pool)
+	}
+	return merged
+}
+
+func indexByName(pools []n.ApplicationGatewayBackendAddressPool) poolsByName {
+	indexed := make(map[backendPoolName]n.ApplicationGatewayBackendAddressPool)
+	for _, pool := range pools {
+		indexed[backendPoolName(*pool.Name)] = pool
+	}
+	return indexed
+}
+
+func (c PoolContext) applyBlacklist(pools []n.ApplicationGatewayBackendAddressPool, blacklist TargetBlacklist) []n.ApplicationGatewayBackendAddressPool {
+	poolToTarget := c.getPoolToTargets()
+	managedPools := make(poolsByName)
+
+	for _, pool := range pools {
+		for _, target := range poolToTarget[backendPoolName(*pool.Name)] {
+			if target.IsIn(blacklist) {
+				logTarget(5, target, "in blacklist")
+				continue
+			}
+			logTarget(5, target, "implicitly managed")
+			managedPools[backendPoolName(*pool.Name)] = pool
+		}
+	}
+	return poolsMapToList(managedPools)
+}
+
+func (c PoolContext) applyWhitelist(pools []n.ApplicationGatewayBackendAddressPool, whitelist TargetWhitelist) []n.ApplicationGatewayBackendAddressPool {
+	poolToTarget := c.getPoolToTargets()
+	managedPools := make(poolsByName)
+
+	for _, pool := range pools {
+		for _, target := range poolToTarget[backendPoolName(*pool.Name)] {
+			if target.IsIn(whitelist) {
+				logTarget(5, target, "in whitelist")
+				managedPools[backendPoolName(*pool.Name)] = pool
+				continue
+			}
+			logTarget(5, target, "NOT in whitelist")
+		}
+	}
+	return poolsMapToList(managedPools)
+}
+
+func logTarget(verbosity glog.Level, target Target, message string) {
+	t, _ := target.MarshalJSON()
+	glog.V(verbosity).Infof("Target is "+message+": %s", t)
+}
+
+// getPoolToTargets creates a map from backend pool to targets this backend pool is responsible for.
+// We rely on the configuration that AGIC has already constructed: Frontend Listener, Routing Rules, etc.
+// We use the Listener to obtain the target hostname, the RoutingRule to get the
+func (c PoolContext) getPoolToTargets() poolToTargets {
+
+	listenerMap := c.listenersByName()
+	pathNameToPath := c.pathsByName()
+
+	poolToTarget := make(poolToTargets)
+
+	for _, rule := range c.RoutingRules {
+
+		listenerName := listenerName(utils.GetLastChunkOfSlashed(*rule.HTTPListener.ID))
+
+		var hostName string
+		if listener, found := listenerMap[listenerName]; !found {
+			continue
+		} else {
+			hostName = *listener.HostName
+		}
+
+		target := Target{
+			Hostname: hostName,
+			Port:     portFromListener(listenerMap[listenerName]),
+		}
+
+		if rule.URLPathMap == nil {
+			// SSL Redirects do not have BackendAddressPool
+			if rule.BackendAddressPool == nil {
+				continue
+			}
+			poolName := backendPoolName(utils.GetLastChunkOfSlashed(*rule.BackendAddressPool.ID))
+			poolToTarget[poolName] = append(poolToTarget[poolName], target)
+		} else {
+			// Follow the path map
+			pathMapName := pathmapName(utils.GetLastChunkOfSlashed(*rule.URLPathMap.ID))
+			for _, pathRule := range *pathNameToPath[pathMapName].PathRules {
+				if pathRule.BackendAddressPool == nil {
+					glog.Errorf("Path Rule %+v does not have BackendAddressPool", *pathRule.Name)
+					continue
+				}
+				poolName := backendPoolName(utils.GetLastChunkOfSlashed(*pathRule.BackendAddressPool.ID))
+				if pathRule.Paths == nil {
+					glog.V(5).Infof("Path Rule %+v does not have paths list", *pathRule.Name)
+					continue
+				}
+				for _, path := range *pathRule.Paths {
+					target.Path = to.StringPtr(NormalizePath(path))
+					poolToTarget[poolName] = append(poolToTarget[poolName], target)
+				}
+			}
+		}
+	}
+	return poolToTarget
+}
+
+func poolsMapToList(pools poolsByName) []n.ApplicationGatewayBackendAddressPool {
+	var managedPools []n.ApplicationGatewayBackendAddressPool
+	for _, pool := range pools {
+		managedPools = append(managedPools, pool)
+	}
+	return managedPools
+}
+
+// listenersByName indexes HTTPListeners by their name.
+func (c PoolContext) listenersByName() map[listenerName]*n.ApplicationGatewayHTTPListener {
+	// Index listeners by their Name
+	listenerMap := make(map[listenerName]*n.ApplicationGatewayHTTPListener)
+	for _, listener := range c.Listeners {
+		listenerMap[listenerName(*listener.Name)] = listener
+	}
+	return listenerMap
+}
+
+// pathsByName indexes URLPathMaps by their name.
+func (c PoolContext) pathsByName() map[pathmapName]n.ApplicationGatewayURLPathMap {
+	pathNameToPath := make(map[pathmapName]n.ApplicationGatewayURLPathMap)
+	for _, pm := range c.PathMaps {
+		pathNameToPath[pathmapName(*pm.Name)] = pm
+	}
+	return pathNameToPath
+}

--- a/pkg/brownfield/pools_test.go
+++ b/pkg/brownfield/pools_test.go
@@ -1,0 +1,182 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
+)
+
+var _ = Describe("test TargetBlacklist/TargetWhitelist backend pools", func() {
+
+	listeners := []*n.ApplicationGatewayHTTPListener{
+		fixtures.GetListener1(),
+		fixtures.GetListener2(),
+	}
+
+	routingRules := []n.ApplicationGatewayRequestRoutingRule{
+		*fixtures.GetRequestRoutingRulePathBased(),
+		*fixtures.GetRequestRoutingRuleBasic(),
+	}
+
+	paths := []n.ApplicationGatewayURLPathMap{
+		*fixtures.GeURLPathMap(),
+	}
+
+	brownfieldContext := PoolContext{
+		Listeners:    listeners,
+		RoutingRules: routingRules,
+		PathMaps:     paths,
+	}
+
+	targetFoo := Target{
+		Hostname: tests.Host,
+		Port:     443,
+		Path:     to.StringPtr(fixtures.PathFoo),
+	}
+
+	targets := poolToTargets{
+		fixtures.BackendAddressPoolName1: {
+			targetFoo,
+
+			{
+				Hostname: tests.Host,
+				Port:     443,
+				Path:     to.StringPtr(fixtures.PathBar),
+			},
+
+			{
+				Hostname: tests.Host,
+				Port:     443,
+				Path:     to.StringPtr(fixtures.PathBaz),
+			},
+		},
+
+		fixtures.BackendAddressPoolName2: {
+			{
+				Hostname: tests.OtherHost,
+				Port:     80,
+			},
+		},
+	}
+
+	pool1 := fixtures.GetBackendPool1()
+	pool2 := fixtures.GetBackendPool2()
+	pool3 := fixtures.GetBackendPool3()
+
+	// Create a list of pools
+	pools := []n.ApplicationGatewayBackendAddressPool{
+		pool1, // managed
+		pool2, // managed
+		pool3, // unmanaged / prohibited
+	}
+
+	Context("Test normalizing  permit/prohibit URL paths", func() {
+
+		actual := brownfieldContext.getPoolToTargets()
+
+		It("should have created map of pool name to list of targets", func() {
+			Expect(actual).To(Equal(targets))
+		})
+	})
+
+	Context("Test MergePools()", func() {
+
+		poolList0 := []n.ApplicationGatewayBackendAddressPool{
+			pool1,
+		}
+
+		poolList1 := []n.ApplicationGatewayBackendAddressPool{
+			pool1,
+			pool2,
+		}
+
+		poolList2 := []n.ApplicationGatewayBackendAddressPool{
+			pool2,
+		}
+
+		It("should be able to merge lists of pools", func() {
+			merge1 := MergePools(poolList1, poolList2)
+			Expect(len(merge1)).To(Equal(2))
+			Expect(merge1).To(ContainElement(pool1))
+			Expect(merge1).To(ContainElement(pool2))
+
+			merge2 := MergePools(poolList0, poolList2)
+			Expect(len(merge2)).To(Equal(2))
+			Expect(merge1).To(ContainElement(pool1))
+			Expect(merge1).To(ContainElement(pool2))
+		})
+	})
+
+	Context("Test GetManagedPools()", func() {
+
+		It("should be able to merge lists of pools", func() {
+
+			managedTargets := fixtures.GetManagedTargets()
+			prohibitedTargets := fixtures.GetProhibitedTargets()
+
+			// !! Action !!
+			actual := GetManagedPools(pools, managedTargets, prohibitedTargets, brownfieldContext)
+
+			Expect(len(actual)).To(Equal(2))
+			Expect(actual).To(ContainElement(pool1))
+			Expect(actual).To(ContainElement(pool2))
+			Expect(actual).ToNot(ContainElement(pool3))
+		})
+	})
+
+	Context("Test PruneManagedPools()", func() {
+
+		It("should be able to merge lists of pools", func() {
+			managedTargets := fixtures.GetManagedTargets()
+			prohibitedTargets := fixtures.GetProhibitedTargets()
+
+			// !! Action !!
+			actual := PruneManagedPools(pools, managedTargets, prohibitedTargets, brownfieldContext)
+
+			Expect(len(actual)).To(Equal(1))
+			Expect(actual).To(ContainElement(pool3))
+		})
+	})
+
+	Context("Apply Blacklist", func() {
+
+		It("should filter a list of backend pools based on a Blacklist", func() {
+			blacklistedTargets := []Target{targetFoo}
+
+			// !! Action !!
+			actual := brownfieldContext.applyBlacklist(pools, &blacklistedTargets)
+
+			Expect(len(pools)).To(Equal(3))
+			Expect(len(actual)).To(Equal(2))
+			Expect(actual).To(ContainElement(pool1))
+			Expect(actual).To(ContainElement(pool2))
+			Expect(actual).ToNot(ContainElement(pool3))
+		})
+	})
+
+	Context("Apply Whitelist", func() {
+
+		It("should filter a list of backend pools based on a Whitelist", func() {
+			whitelistedTargets := []Target{targetFoo}
+
+			// !! Action !!
+			actual := brownfieldContext.applyWhitelist(pools, &whitelistedTargets)
+
+			Expect(len(pools)).To(Equal(3))
+			Expect(len(actual)).To(Equal(1))
+			Expect(actual).To(ContainElement(pool1))
+			Expect(actual).ToNot(ContainElement(pool2))
+			Expect(actual).ToNot(ContainElement(pool3))
+		})
+	})
+
+})

--- a/pkg/brownfield/targets.go
+++ b/pkg/brownfield/targets.go
@@ -1,0 +1,129 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"encoding/json"
+	"strings"
+
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+
+	mtv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressmanagedtarget/v1"
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+)
+
+// NameToTarget is a helper type.
+type NameToTarget map[string]Target
+
+// ListenersByName is a helper type.
+type ListenersByName map[string]*n.ApplicationGatewayHTTPListener
+
+// URLPathMapByName is a helper type.
+type URLPathMapByName map[string]n.ApplicationGatewayURLPathMap
+
+// Target uniquely identifies a subset of App Gateway configuration, which AGIC will manage or be prohibited from managing.
+type Target struct {
+	Hostname string
+	Port     int32
+	Path     *string
+}
+
+// IsIn figures out whether a given Target objects in a list of Target objects.
+func (t Target) IsIn(targetList *[]Target) bool {
+	for _, otherTarget := range *targetList {
+		hostIsSame := strings.ToLower(t.Hostname) == strings.ToLower(otherTarget.Hostname)
+		portIsSame := t.Port == otherTarget.Port
+		pathA, pathB := "", ""
+		if t.Path != nil {
+			pathA = *t.Path
+		}
+		if otherTarget.Path != nil {
+			pathB = *otherTarget.Path
+		}
+
+		if hostIsSame && portIsSame && pathA == pathB {
+			// Found it
+			return true
+		}
+	}
+
+	// Did not find it
+	return false
+}
+
+// prettyTarget is used for pretty-printing the Target struct for debugging purposes.
+type prettyTarget struct {
+	Hostname string `json:"Hostname"`
+	Port     int32  `json:"Port"`
+	Path     string `json:"Path,omitempty"`
+}
+
+// MarshalJSON converts the Target object to a JSON byte array.
+func (t Target) MarshalJSON() ([]byte, error) {
+	pt := prettyTarget{
+		Hostname: t.Hostname,
+		Port:     t.Port,
+	}
+	if t.Path != nil {
+		pt.Path = *t.Path
+	}
+	return json.Marshal(pt)
+}
+
+// GetProhibitedTargetList returns the list of Targets given a list ProhibitedTarget CRDs.
+func GetProhibitedTargetList(prohibitedTargets []*ptv1.AzureIngressProhibitedTarget) TargetBlacklist {
+	var target []Target
+	for _, prohibitedTarget := range prohibitedTargets {
+		if len(prohibitedTarget.Spec.Paths) == 0 {
+			target = append(target, Target{
+				Hostname: prohibitedTarget.Spec.Hostname,
+				Port:     prohibitedTarget.Spec.Port,
+				Path:     nil,
+			})
+		}
+		for _, path := range prohibitedTarget.Spec.Paths {
+			target = append(target, Target{
+				Hostname: prohibitedTarget.Spec.Hostname,
+				Port:     prohibitedTarget.Spec.Port,
+				Path:     to.StringPtr(NormalizePath(path)),
+			})
+		}
+	}
+	return &target
+}
+
+// GetManagedTargetList returns the list of Targets given a list ManagedTarget CRDs.
+func GetManagedTargetList(managedTargets []*mtv1.AzureIngressManagedTarget) TargetWhitelist {
+	var target []Target
+	for _, managedTarget := range managedTargets {
+		if len(managedTarget.Spec.Paths) == 0 {
+			target = append(target, Target{
+				Hostname: managedTarget.Spec.Hostname,
+				Port:     managedTarget.Spec.Port,
+				Path:     nil,
+			})
+		}
+		for _, path := range managedTarget.Spec.Paths {
+			target = append(target, Target{
+				Hostname: managedTarget.Spec.Hostname,
+				Port:     managedTarget.Spec.Port,
+				Path:     to.StringPtr(NormalizePath(path)),
+			})
+		}
+	}
+	return &target
+}
+
+func NormalizePath(path string) string {
+	trimmed, prevTrimmed := "", path
+	cutset := "*/"
+	for trimmed != prevTrimmed {
+		prevTrimmed = trimmed
+		trimmed = strings.TrimRight(path, cutset)
+	}
+	return trimmed
+}

--- a/pkg/brownfield/targets_test.go
+++ b/pkg/brownfield/targets_test.go
@@ -1,0 +1,116 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
+)
+
+func TestAppgw(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Brownfield Deployment Tests")
+}
+
+var _ = Describe("test TargetBlacklist/TargetWhitelist health probes", func() {
+
+	Context("Test normalizing  permit/prohibit URL paths", func() {
+		actual := NormalizePath("*//*hello/**/*//")
+		It("should have exactly 1 record", func() {
+			Expect(actual).To(Equal("*//*hello"))
+		})
+	})
+
+	Context("test GetManagedTargetList", func() {
+		actual := GetManagedTargetList(fixtures.GetManagedTargets())
+		It("Should have produced correct Managed Targets list", func() {
+			Expect(len(*actual)).To(Equal(3))
+			{
+				expected := Target{
+					Hostname: tests.Host,
+					Port:     443,
+					Path:     to.StringPtr("/foo"),
+				}
+				Expect(*actual).To(ContainElement(expected))
+			}
+			{
+				expected := Target{
+					Hostname: tests.Host,
+					Port:     443,
+					Path:     to.StringPtr("/bar"),
+				}
+				Expect(*actual).To(ContainElement(expected))
+			}
+			{
+				expected := Target{
+					Hostname: tests.Host,
+					Port:     443,
+					Path:     to.StringPtr("/baz"),
+				}
+				Expect(*actual).To(ContainElement(expected))
+			}
+		})
+	})
+
+	Context("test GetProhibitedTargetList", func() {
+		actual := GetProhibitedTargetList(fixtures.GetProhibitedTargets())
+		It("should have produced correct Prohibited Targets list", func() {
+			Expect(len(*actual)).To(Equal(2))
+			{
+				expected := Target{
+					Hostname: tests.Host,
+					Port:     443,
+					Path:     to.StringPtr("/fox"),
+				}
+				Expect(*actual).To(ContainElement(expected))
+			}
+			{
+				expected := Target{
+					Hostname: tests.Host,
+					Port:     443,
+					Path:     to.StringPtr("/bar"),
+				}
+				Expect(*actual).To(ContainElement(expected))
+			}
+		})
+	})
+
+	Context("Test IsIn", func() {
+		t1 := Target{
+			Hostname: tests.Host,
+			Port:     443,
+			Path:     to.StringPtr("/bar"),
+		}
+
+		t2 := Target{
+			Hostname: tests.Host,
+			Port:     9898,
+			Path:     to.StringPtr("/xyz"),
+		}
+
+		targetList := []Target{
+			{Hostname: tests.Host,
+				Port: 443,
+				Path: to.StringPtr("/foo"),
+			},
+			{Hostname: tests.Host,
+				Port: 443,
+				Path: to.StringPtr("/bar"),
+			},
+		}
+
+		It("Should be able to find a new Target in an existing list of Targets", func() {
+			Expect(t1.IsIn(&targetList)).To(BeTrue())
+			Expect(t2.IsIn(&targetList)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -1,0 +1,29 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+)
+
+// PoolContext is the basket of App Gateway configs necessary to determine what settings should be
+// managed and what should be left as-is.
+type PoolContext struct {
+	Listeners    []*n.ApplicationGatewayHTTPListener
+	RoutingRules []n.ApplicationGatewayRequestRoutingRule
+	PathMaps     []n.ApplicationGatewayURLPathMap
+}
+
+type listenerName string
+type pathmapName string
+type backendPoolName string
+
+type poolToTargets map[backendPoolName][]Target
+
+type poolsByName map[backendPoolName]n.ApplicationGatewayBackendAddressPool
+
+type TargetWhitelist *[]Target
+type TargetBlacklist *[]Target

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -232,6 +232,7 @@ func (c *Context) ListHTTPIngresses() []*v1beta1.Ingress {
 			ingressList = append(ingressList, ingress)
 		}
 	}
+
 	// Sorting the return list ensures that the iterations over this list and
 	// subsequently created structs have deterministic order. This increases
 	// cache hits, and lowers the load on ARM.


### PR DESCRIPTION
This PR introduces (a partial implementation of) brownfield deployment.
The strategy is described in [a proposal here](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/proposals/config_ownership_crd.md).


### Overview 
The overall goal is to define certain targets (think `domain:port/url`) that are "owned" by Kubernetes Ingress definitions and manipulated by AGIC.  More importantly, this also means we have targets that are not going to be mutated by AGIC.

This would allow an administrator to manually set some settings on Application Gateway, while allowing the ingress controller to mutate others.


### Changes
  - this PR implements target whitelist/blacklist for backend pools only
  - introducing feature flag to guard these changes (until they are fully fleshed out and tested): `cbCtx.EnvVariables.EnableBrownfieldDeployment`
  - new package `brownfield` contains helpers:
    - `PruneManagedPools` - given a list of backend pools - remove the ones that AGIS can manage - leaving the ones that should not be mutated
    - `GetManagedPools` - given a list of backend pools - figures out which ones are to be mutated by AGIC
    - `MergePools` - merges list of pools into one


### Overall strategy:

1. Get the list of backend pools from App Gateway
2. From App Gwy - delete the ones we are allowed to manage / keep the ones we are *not* allowed to manage
3. Construct all configs from Ingress resource
4. Delete config for targets AGIC is not allowed to mutate
5. Merge the output 2 and 4 - apply onto App Gateway