### PR TITLE
eventqueue: simple worker

### DIFF
--- a/pkg/worker/fake.go
+++ b/pkg/worker/fake.go
@@ -1,0 +1,27 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package worker
+
+import (
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+)
+
+// FakeProcessor is fake event processor type
+type FakeProcessor struct {
+	processFunc func(events.Event) error
+}
+
+// Process will call the callback provided
+func (fp FakeProcessor) Process(event events.Event) error {
+	return fp.processFunc(event)
+}
+
+// NewFakeProcessor returns a fake processor struct.
+func NewFakeProcessor(process func(events.Event) error) FakeProcessor {
+	return FakeProcessor{
+		processFunc: process,
+	}
+}

--- a/pkg/worker/types.go
+++ b/pkg/worker/types.go
@@ -1,0 +1,21 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package worker
+
+import (
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+)
+
+// EventProcessor provides a mechanism to act on events in the internal queue.
+type EventProcessor interface {
+	Process(events.Event) error
+}
+
+// Worker listens on the eventChannel and runs the EventProcessor.Process
+// for each event.
+type Worker struct {
+	EventProcessor
+}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -17,8 +17,8 @@ import (
 
 const sleepOnErrorSeconds = 5
 
-// NewWorker creates an EventQueue with a callback function. The callback
-// function processFunc is executed for each event in the queue.
+// NewWorker creates a worker with a callback function. The callback
+// function is executed for each event in the queue.
 func NewWorker(processor EventProcessor) *Worker {
 	w := &Worker{
 		EventProcessor: processor,
@@ -27,7 +27,7 @@ func NewWorker(processor EventProcessor) *Worker {
 	return w
 }
 
-// Run starts the worker . It loops until
+// Run starts the worker which listens for events in eventChannel. It loops until
 // stopChannel is closed.
 func (w *Worker) Run(eventChannel *channels.RingChannel, stopChannel chan struct{}) {
 	go func() {
@@ -47,7 +47,7 @@ func (w *Worker) Run(eventChannel *channels.RingChannel, stopChannel chan struct
 					glog.Error("Processing event failed:", err)
 					time.Sleep(sleepOnErrorSeconds * time.Second)
 				} else {
-					glog.V(3).Infoln("Processing event done, updating lastEventTimestamp")
+					glog.V(3).Infoln("Successfully processed event")
 				}
 			case <-stopChannel:
 				break

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -1,0 +1,57 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package worker
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/eapache/channels"
+	"github.com/golang/glog"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+)
+
+const sleepOnErrorSeconds = 5
+
+// NewWorker creates an EventQueue with a callback function. The callback
+// function processFunc is executed for each event in the queue.
+func NewWorker(processor EventProcessor) *Worker {
+	w := &Worker{
+		EventProcessor: processor,
+	}
+
+	return w
+}
+
+// Run starts the worker . It loops until
+// stopChannel is closed.
+func (w *Worker) Run(eventChannel *channels.RingChannel, stopChannel chan struct{}) {
+	go func() {
+		for {
+			select {
+			case in := <-eventChannel.Out():
+				event := in.(events.Event)
+
+				if jsonEvent, err := json.Marshal(event); err != nil {
+					glog.Error("Failed marshalling event:", err)
+				} else {
+					glog.V(5).Infof("Received event: %s", jsonEvent)
+				}
+
+				// Use callback to process event.
+				if err := w.Process(event); err != nil {
+					glog.Error("Processing event failed:", err)
+					time.Sleep(sleepOnErrorSeconds * time.Second)
+				} else {
+					glog.V(3).Infoln("Processing event done, updating lastEventTimestamp")
+				}
+			case <-stopChannel:
+				break
+			}
+		}
+	}()
+}

--- a/pkg/worker/worker_suite_test.go
+++ b/pkg/worker/worker_suite_test.go
@@ -1,0 +1,13 @@
+package worker_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestWorker(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Worker Suite")
+}

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
-var _ = Describe("WorkerTest", func() {
+var _ = Describe("Worker Test", func() {
 	var stopChannel chan struct{}
 	var eventChannel *channels.RingChannel
 
@@ -29,8 +29,8 @@ var _ = Describe("WorkerTest", func() {
 		close(stopChannel)
 	})
 
-	Context("Check that worker executes the processFunc and Exists", func() {
-		It("Should be able to run the process function on update event", func() {
+	Context("Check that worker executes the process", func() {
+		It("Should be able to run process func", func() {
 			backChannel := make(chan struct{})
 			eventProcessor := NewFakeProcessor(func(events.Event) error {
 				backChannel <- struct{}{}

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -1,0 +1,60 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package worker
+
+import (
+	"time"
+
+	"github.com/eapache/channels"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+)
+
+var _ = Describe("WorkerTest", func() {
+	var stopChannel chan struct{}
+	var eventChannel *channels.RingChannel
+
+	BeforeEach(func() {
+		stopChannel = make(chan struct{})
+		eventChannel = channels.NewRingChannel(1024)
+	})
+
+	AfterEach(func() {
+		close(stopChannel)
+	})
+
+	Context("Check that worker executes the processFunc and Exists", func() {
+		It("Should be able to run the process function on update event", func() {
+			backChannel := make(chan struct{})
+			eventProcessor := NewFakeProcessor(func(events.Event) error {
+				backChannel <- struct{}{}
+				return nil
+			})
+			worker := NewWorker(eventProcessor)
+			worker.Run(eventChannel, stopChannel)
+
+			ingress := *tests.NewIngressFixture()
+			eventChannel.In() <- events.Event{
+				Type:  events.Create,
+				Value: ingress,
+			}
+
+			processCalled := false
+			select {
+			case <-backChannel:
+				processCalled = true
+				break
+			case <-time.After(1 * time.Second):
+				processCalled = false
+			}
+
+			Expect(processCalled).To(Equal(true), "Worker was not able to call process function within timeout")
+		})
+	})
+})


### PR DESCRIPTION
This PR is first part of replacing `eventqueue`.
It adds a simple worker process which listens on the `eventChannel` linked to `k8sContext`.