### PR TITLE
tests: add test suite files

### DIFF
--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -1,0 +1,13 @@
+package controller_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}

--- a/pkg/environment/environment_suite_test.go
+++ b/pkg/environment/environment_suite_test.go
@@ -1,0 +1,13 @@
+package environment_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEnvironment(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Environment Suite")
+}

--- a/pkg/tests/tests_suite_test.go
+++ b/pkg/tests/tests_suite_test.go
@@ -1,0 +1,13 @@
+package tests_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Tests Suite")
+}


### PR DESCRIPTION
ginkgo tests requires each package to have a RunSpec function to be able run the tests.
If not found, it says, `no tests to run`

Here is an issue mentioning the same.
https://github.com/onsi/ginkgo/issues/344