### PR TITLE
health_probes: Apply blacklist based on AzureIngressProhibitedTarget CRDs

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -23,6 +23,7 @@ import (
 	istio_fake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned/fake"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/health_probes"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
@@ -208,7 +209,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		Expect(len(probes)).To(Equal(2))
 
 		// Test the default health probe.
-		Expect(probes).To(ContainElement(defaultProbe()))
+		Expect(probes).To(ContainElement(health_probes.GetDefaultProbe(agPrefix)))
 		// Test the ingress health probe that we installed.
 		Expect(probes).To(ContainElement(*probe))
 	}
@@ -501,7 +502,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			ingressList := testIngress()
 
 			EmptyHealthProbeChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
-				Expect((*appGW.Probes)[0]).To(Equal(defaultProbe()))
+				Expect((*appGW.Probes)[0]).To(Equal(health_probes.GetDefaultProbe(agPrefix)))
 			}
 
 			EmptyBackendHTTPSettingsChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/health_probes"
 )
 
 const (
@@ -145,7 +146,7 @@ func generatePathRuleName(namespace, ingress, suffix string) string {
 
 var defaultBackendHTTPSettingsName = fmt.Sprintf("%sdefaulthttpsetting", agPrefix)
 var defaultBackendAddressPoolName = fmt.Sprintf("%sdefaultaddresspool", agPrefix)
-var defaultProbeName = fmt.Sprintf("%sdefaultprobe", agPrefix)
+var defaultProbeName = health_probes.GetDefaultProbeName(agPrefix)
 
 func defaultBackendHTTPSettings(probeID string) n.ApplicationGatewayBackendHTTPSettings {
 	defHTTPSettingsName := defaultBackendHTTPSettingsName
@@ -156,27 +157,6 @@ func defaultBackendHTTPSettings(probeID string) n.ApplicationGatewayBackendHTTPS
 			Protocol: n.HTTP,
 			Port:     &defHTTPSettingsPort,
 			Probe:    resourceRef(probeID),
-		},
-	}
-}
-
-func defaultProbe() n.ApplicationGatewayProbe {
-	defProbeName := defaultProbeName
-	defProtocol := n.HTTP
-	defHost := "localhost"
-	defPath := "/"
-	defInterval := int32(30)
-	defTimeout := int32(30)
-	defUnHealthyCount := int32(3)
-	return n.ApplicationGatewayProbe{
-		Name: &defProbeName,
-		ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
-			Protocol:           defProtocol,
-			Host:               &defHost,
-			Path:               &defPath,
-			Interval:           &defInterval,
-			Timeout:            &defTimeout,
-			UnhealthyThreshold: &defUnHealthyCount,
 		},
 	}
 }

--- a/pkg/brownfield/health_probes.go
+++ b/pkg/brownfield/health_probes.go
@@ -1,0 +1,109 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"strings"
+
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/golang/glog"
+
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+)
+
+// GetBlacklistedProbes filters the given list of health probes to the list Probes that AGIC is allowed to manage.
+func GetBlacklistedProbes(probes []n.ApplicationGatewayProbe, prohibited []*ptv1.AzureIngressProhibitedTarget) ([]n.ApplicationGatewayProbe, []n.ApplicationGatewayProbe) {
+	blacklist := GetTargetBlacklist(prohibited)
+	if len(*blacklist) == 0 {
+		return nil, probes
+	}
+	var nonBlacklistedProbes []n.ApplicationGatewayProbe
+	var blacklistedProbes []n.ApplicationGatewayProbe
+	for _, probe := range probes {
+		if inProbeBlacklist(&probe, blacklist) {
+			logProbe(5, probe, "in blacklist")
+			blacklistedProbes = append(blacklistedProbes, probe)
+			continue
+		}
+		logProbe(5, probe, "not blacklisted")
+		nonBlacklistedProbes = append(nonBlacklistedProbes, probe)
+	}
+	return blacklistedProbes, nonBlacklistedProbes
+}
+
+// MergeProbes merges list of lists of health probes into a single list, maintaining uniqueness.
+func MergeProbes(probesBuckets ...[]n.ApplicationGatewayProbe) []n.ApplicationGatewayProbe {
+	uniqProbes := make(probesByName)
+	for _, bucket := range probesBuckets {
+		for _, probe := range bucket {
+			uniqProbes[probeName(*probe.Name)] = probe
+		}
+	}
+	var managedProbes []n.ApplicationGatewayProbe
+	for _, probe := range uniqProbes {
+		managedProbes = append(managedProbes, probe)
+	}
+	return managedProbes
+}
+
+// LogProbes emits a few log lines detailing what probes are created, blacklisted, and removed from ARM.
+func LogProbes(existingBlacklisted []n.ApplicationGatewayProbe, existingNonBlacklisted []n.ApplicationGatewayProbe, managedProbes []n.ApplicationGatewayProbe) {
+	var garbage []n.ApplicationGatewayProbe
+
+	blacklistedSet := indexProbesByName(existingBlacklisted)
+	managedSet := indexProbesByName(managedProbes)
+
+	for probeName, probe := range indexProbesByName(existingNonBlacklisted) {
+		_, existsInBlacklist := blacklistedSet[probeName]
+		_, existsInNewProbes := managedSet[probeName]
+		if !existsInBlacklist && !existsInNewProbes {
+			garbage = append(garbage, probe)
+		}
+	}
+
+	glog.V(3).Info("[brownfield] Probes AGIC created: ", getProbeNames(managedProbes))
+	glog.V(3).Info("[brownfield] Existing Blacklisted Probes AGIC will retain: ", getProbeNames(existingBlacklisted))
+	glog.V(3).Info("[brownfield] Existing Probes AGIC will remove: ", getProbeNames(garbage))
+}
+
+func logProbe(verbosity glog.Level, probe n.ApplicationGatewayProbe, message string) {
+	t, _ := probe.MarshalJSON()
+	glog.V(verbosity).Infof("Probe %s is "+message+": %s", *probe.Name, t)
+}
+
+func inProbeBlacklist(probe *n.ApplicationGatewayProbe, blacklist TargetBlacklist) bool {
+	for _, target := range *blacklist {
+		if target.Hostname == "" || target.Hostname == *probe.Host {
+			if target.Path == "" {
+				// Host matches; No paths - it is blacklisted
+				return true
+			} else if strings.HasPrefix(*probe.Path, strings.TrimRight(target.Path, "/*")) {
+				// Matches a path or sub-path - it is blacklisted
+				// If the target is: /abc -- will match probes for "/abc", as well as "/abc/healthz"
+				return true
+			}
+		}
+	}
+
+	// Did not find it - is not blacklisted
+	return false
+}
+
+func indexProbesByName(probes []n.ApplicationGatewayProbe) probesByName {
+	probesByName := make(probesByName)
+	for _, probe := range probes {
+		probesByName[probeName(*probe.Name)] = probe
+	}
+	return probesByName
+}
+
+func getProbeNames(Probe []n.ApplicationGatewayProbe) string {
+	var names []string
+	for _, p := range Probe {
+		names = append(names, *p.Name)
+	}
+	return strings.Join(names, ", ")
+}

--- a/pkg/brownfield/health_probes_test.go
+++ b/pkg/brownfield/health_probes_test.go
@@ -1,0 +1,173 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
+)
+
+var _ = Describe("Test blacklist health probes", func() {
+
+	managedProbe := fixtures.GetApplicationGatewayProbe(nil, to.StringPtr(fixtures.PathFoo))
+	blacklistedProbe := fixtures.GetApplicationGatewayProbe(nil, to.StringPtr(fixtures.PathBar))
+	blacklistedByHost := fixtures.GetApplicationGatewayProbe(to.StringPtr(tests.OtherHost), nil)
+
+	managedProbeWeirdURL := fixtures.GetApplicationGatewayProbe(nil, to.StringPtr(fixtures.PathFoo+"/healthz"))
+	blackListedProbeWeirdURL := fixtures.GetApplicationGatewayProbe(nil, to.StringPtr(fixtures.PathBar+"/healthz"))
+	blacklistedByHostWeirdURL := fixtures.GetApplicationGatewayProbe(to.StringPtr(tests.OtherHost), to.StringPtr("/healthz"))
+
+	probes := []n.ApplicationGatewayProbe{
+		managedProbe,     // /foo
+		blacklistedProbe, // /bar
+		blacklistedByHost,
+
+		managedProbeWeirdURL,      // /foo/healthz
+		blackListedProbeWeirdURL,  // /bar/healthz
+		blacklistedByHostWeirdURL, // /healthz
+	}
+
+	Context("Test GetBlacklistedProbes() with a blacklist", func() {
+
+		It("should create a list of blacklisted and non blacklisted health probes", func() {
+
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets() // /fox  /bar
+
+			blacklisted, nonBlacklisted := GetBlacklistedProbes(probes, prohibitedTargets)
+
+			// When there is both blacklist and whitelist - the whitelist is ignored.
+			Expect(len(blacklisted)).To(Equal(4))
+
+			// not explicitly blacklisted (does not matter that it is in blacklist)
+			Expect(blacklisted).ToNot(ContainElement(managedProbe))
+			Expect(blacklisted).ToNot(ContainElement(managedProbeWeirdURL))
+
+			// not explicitly blacklisted -- it is in neither blacklist or whitelist
+			Expect(blacklisted).To(ContainElement(blacklistedByHost))
+			Expect(blacklisted).To(ContainElement(blacklistedByHostWeirdURL))
+
+			// explicitly blacklisted
+			Expect(blacklisted).To(ContainElement(blacklistedProbe))
+			Expect(blacklisted).To(ContainElement(blackListedProbeWeirdURL))
+
+			Expect(nonBlacklisted).ToNot(ContainElement(blackListedProbeWeirdURL))
+		})
+	})
+
+	Context("Test GetBlacklistedProbes() with a blacklist containing a wildcard blacklist target", func() {
+
+		It("should create a list of blacklisted and non blacklisted health probes with a wildcard", func() {
+
+			wildcard := &ptv1.AzureIngressProhibitedTarget{
+				Spec: ptv1.AzureIngressProhibitedTargetSpec{},
+			}
+			prohibitedTargets := append(fixtures.GetAzureIngressProhibitedTargets(), wildcard)
+
+			// Everything is blacklisted
+			blacklisted, nonBlacklisted := GetBlacklistedProbes(probes, prohibitedTargets)
+
+			Expect(len(blacklisted)).To(Equal(6))
+			Expect(len(nonBlacklisted)).To(Equal(0))
+
+			Expect(blacklisted).To(ContainElement(managedProbe))
+			Expect(blacklisted).To(ContainElement(managedProbeWeirdURL))
+
+			// This is the only blacklisted probe
+			Expect(blacklisted).To(ContainElement(blacklistedProbe))
+			Expect(blacklisted).To(ContainElement(blackListedProbeWeirdURL))
+
+			Expect(blacklisted).To(ContainElement(blacklistedByHost))
+			Expect(blacklisted).To(ContainElement(blacklistedByHostWeirdURL))
+		})
+	})
+
+	Context("Test MergeProbes()", func() {
+
+		probeList1 := []n.ApplicationGatewayProbe{
+			managedProbe,
+		}
+
+		probeList2 := []n.ApplicationGatewayProbe{
+			managedProbe,
+			blacklistedProbe,
+		}
+
+		probeList3 := []n.ApplicationGatewayProbe{
+			blacklistedProbe,
+		}
+
+		It("should correctly merge lists of probes", func() {
+			merge1 := MergeProbes(probeList2, probeList3)
+			Expect(len(merge1)).To(Equal(2))
+			Expect(merge1).To(ContainElement(managedProbe))
+			Expect(merge1).To(ContainElement(blacklistedProbe))
+
+			merge2 := MergeProbes(probeList1, probeList3)
+			Expect(len(merge2)).To(Equal(2))
+			Expect(merge1).To(ContainElement(managedProbe))
+			Expect(merge1).To(ContainElement(blacklistedProbe))
+		})
+	})
+
+	Context("test inProbeBlacklist with non blacklisted probe", func() {
+		probe := fixtures.GetApplicationGatewayProbe(nil, nil)
+		blacklist := GetTargetBlacklist(fixtures.GetAzureIngressProhibitedTargets())
+		actual := inProbeBlacklist(&probe, blacklist)
+		It("should be able to find probe in prohibited Target list", func() {
+			Expect(actual).To(BeFalse())
+		})
+	})
+
+	Context("test inProbeBlacklist with a blacklisted probe by Host only", func() {
+		blacklist := GetTargetBlacklist(fixtures.GetAzureIngressProhibitedTargets())
+		actual := inProbeBlacklist(&blacklistedByHost, blacklist)
+		It("should be able to find probe in prohibited Target list", func() {
+			Expect(actual).To(BeTrue())
+		})
+	})
+
+	Context("test inProbeBlacklist with a blacklisted probe by Host and URL", func() {
+		blacklist := GetTargetBlacklist(fixtures.GetAzureIngressProhibitedTargets())
+		actual := inProbeBlacklist(&blacklistedByHostWeirdURL, blacklist)
+		It("should be able to find probe in prohibited Target list", func() {
+			Expect(actual).To(BeTrue())
+		})
+	})
+
+	Context("test inProbeBlacklist with health probe to a sub-path", func() {
+		target := Target{
+			Hostname: tests.Host,
+			Path:     "/abc/*",
+		}
+		targetList := []Target{target}
+
+		It("should be able to match a probe in the sub-path of the target", func() {
+			probe := fixtures.GetApplicationGatewayProbe(to.StringPtr(tests.Host), to.StringPtr("/abc/healthz"))
+			actual := inProbeBlacklist(&probe, &targetList)
+			Expect(actual).To(BeTrue())
+		})
+
+		It("should be able to find probe exactly matching the path of the target", func() {
+			probe := fixtures.GetApplicationGatewayProbe(to.StringPtr(tests.Host), to.StringPtr("/abc"))
+
+			actual := inProbeBlacklist(&probe, &targetList)
+			Expect(actual).To(BeTrue())
+		})
+
+		It("should not be able to find probe not matching the target", func() {
+			probe := fixtures.GetApplicationGatewayProbe(to.StringPtr(tests.Host), to.StringPtr("/xyz"))
+			actual := inProbeBlacklist(&probe, &targetList)
+			Expect(actual).To(BeFalse())
+		})
+
+	})
+})

--- a/pkg/brownfield/pools.go
+++ b/pkg/brownfield/pools.go
@@ -113,7 +113,7 @@ func logTarget(verbosity glog.Level, target Target, message string) {
 
 // getPoolToTargetsMap creates a map from backend pool to targets this backend pool is responsible for.
 // We rely on the configuration that AGIC has already constructed: Frontend Listener, Routing Rules, etc.
-// We use the Listener to obtain the target hostname, the RoutingRule to get the
+// We use the Listener to obtain the target hostname, the RoutingRule to get the URL etc.
 func (c PoolContext) getPoolToTargetsMap() poolToTargets {
 
 	// Index listeners by their name

--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -31,3 +31,6 @@ type poolsByName map[backendPoolName]n.ApplicationGatewayBackendAddressPool
 
 // TargetBlacklist is a list of Targets, which AGIC is not allowed to apply configuration for.
 type TargetBlacklist *[]Target
+
+type probeName string
+type probesByName map[probeName]n.ApplicationGatewayProbe

--- a/pkg/health_probes/defaults.go
+++ b/pkg/health_probes/defaults.go
@@ -1,0 +1,32 @@
+package health_probes
+
+import (
+	"fmt"
+
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+)
+
+func GetDefaultProbeName(agPrefix string) string {
+	return fmt.Sprintf("%sdefaultprobe", agPrefix)
+}
+
+func GetDefaultProbe(agPrefix string) n.ApplicationGatewayProbe {
+	defProbeName := GetDefaultProbeName(agPrefix)
+	defProtocol := n.HTTP
+	defHost := "localhost"
+	defPath := "/"
+	defInterval := int32(30)
+	defTimeout := int32(30)
+	defUnHealthyCount := int32(3)
+	return n.ApplicationGatewayProbe{
+		Name: &defProbeName,
+		ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
+			Protocol:           defProtocol,
+			Host:               &defHost,
+			Path:               &defPath,
+			Interval:           &defInterval,
+			Timeout:            &defTimeout,
+			UnhealthyThreshold: &defUnHealthyCount,
+		},
+	}
+}

--- a/pkg/tests/fixtures/probes.go
+++ b/pkg/tests/fixtures/probes.go
@@ -6,6 +6,8 @@
 package fixtures
 
 import (
+	"fmt"
+
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 
@@ -26,7 +28,7 @@ func GetApplicationGatewayProbe(host *string, path *string) n.ApplicationGateway
 			Host:     host,
 			Path:     path,
 		},
-		Name: to.StringPtr("probe-name"),
+		Name: to.StringPtr(fmt.Sprintf("probe-name-%s-%s", *host, *path)),
 		ID:   to.StringPtr("abcd"),
 	}
 }


### PR DESCRIPTION
This PR introduces the second part (of a few) following https://github.com/Azure/application-gateway-kubernetes-ingress/pull/340

This implements `brownfield deployment` CRDs for Application Gateway **health probes**.

### Overview
From the Ingress, Services etc Kubernetes resources we determine possible traffic targets - `host:port/url`
Based on the `AzureIngress{Managed,Prohibited}Target` CRDs we determine what subset of the possible targets AGIC can configure.

### Changes
  - `GetManagedProbes` - filters the given list of health probes to the list pools that AGIC is allowed to manage
  - `PruneManagedProbes` - removes the managed health probes from the given list of probes; resulting in a list of probes not managed by AGIC
  - `MergeProbes` - merges list of lists of health probes into a single list, maintaining uniqueness

The goal is to:
  1. Get health probes from Application Gateway
  2. From 1 - Remove the ones we can manage; leave the ones AGIC is not allowed to mutate
  3. Based on Ingress/Service etc create a list of health probes
  4. Filter 3 - remove the ones we are not allowed to mutate
  5. Merge 2 and 4 and apply to Application Gateway