### PR TITLE
pools: Apply blacklist based on AzureIngressProhibitedTarget CRDs

### DIFF
--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -47,18 +47,17 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 	}
 
 	if cbCtx.EnvVariables.EnableBrownfieldDeployment == "true" {
-		brownfieldCtx := brownfield.PoolContext{}
-		brownfieldCtx.RoutingRules, brownfieldCtx.PathMaps = c.getRules(cbCtx)
-
+		// These are existing resources we obtain from App Gateway
 		existingBrownfieldCtx := brownfield.PoolContext{
-			Listeners:    c.getExistingListeners(),
-			RoutingRules: c.getExistingRoutingRules(),
-			PathMaps:     c.getExistingPathMaps(),
-			BackendPools: c.getExistingBackendPools(),
+			Listeners:         c.getExistingListeners(),
+			RoutingRules:      c.getExistingRoutingRules(),
+			PathMaps:          c.getExistingPathMaps(),
+			BackendPools:      c.getExistingBackendPools(),
+			ProhibitedTargets: cbCtx.ProhibitedTargets,
 		}
 
 		// Pools we obtained from App Gateway - we segment them into ones AGIC is and is not allowed to change.
-		existingBlacklisted, existingNonBlacklisted := brownfield.GetExistingBlacklistedPools(cbCtx.ProhibitedTargets, existingBrownfieldCtx)
+		existingBlacklisted, existingNonBlacklisted := existingBrownfieldCtx.GetBlacklistedPools()
 
 		brownfield.LogPools(existingBlacklisted, existingNonBlacklisted, agicCreatedPools)
 

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -49,11 +49,12 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 	if cbCtx.EnvVariables.EnableBrownfieldDeployment == "true" {
 		// These are existing resources we obtain from App Gateway
 		existingBrownfieldCtx := brownfield.PoolContext{
-			Listeners:         c.getExistingListeners(),
-			RoutingRules:      c.getExistingRoutingRules(),
-			PathMaps:          c.getExistingPathMaps(),
-			BackendPools:      c.getExistingBackendPools(),
-			ProhibitedTargets: cbCtx.ProhibitedTargets,
+			Listeners:          c.getExistingListeners(),
+			RoutingRules:       c.getExistingRoutingRules(),
+			PathMaps:           c.getExistingPathMaps(),
+			BackendPools:       c.getExistingBackendPools(),
+			ProhibitedTargets:  cbCtx.ProhibitedTargets,
+			DefaultBackendPool: *defaultPool,
 		}
 
 		// Pools we obtained from App Gateway - we segment them into ones AGIC is and is not allowed to change.

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -8,12 +8,14 @@ package appgw
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/brownfield"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 )
@@ -45,7 +47,33 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 		allPools = append(allPools, *addr)
 	}
 
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment == "true" {
+		brownfieldCtx := brownfield.PoolContext{}
+		brownfieldCtx.RoutingRules, brownfieldCtx.PathMaps = c.getRules(cbCtx)
+
+		var allExisting []n.ApplicationGatewayBackendAddressPool
+		if c.appGw.BackendAddressPools != nil {
+			allExisting = *c.appGw.BackendAddressPools
+		}
+
+		// These are pools we fetch from App Gateway; These we are NOT allowed to mutate.
+		existingUnmanaged := brownfield.PruneManagedPools(allExisting, cbCtx.ProhibitedTargets, brownfieldCtx)
+
+		glog.V(3).Info("Subset of pools from Ingress; AGIC will manage:", getPoolNames(allPools))
+		glog.V(3).Info("Existing pools from App Gateway; AGIC will not mutate:", getPoolNames(existingUnmanaged))
+
+		allPools = brownfield.MergePools(existingUnmanaged, allPools)
+	}
+
 	return allPools
+}
+
+func getPoolNames(pool []n.ApplicationGatewayBackendAddressPool) string {
+	var names []string
+	for _, p := range pool {
+		names = append(names, *p.Name)
+	}
+	return strings.Join(names, ", ")
 }
 
 func (c *appGwConfigBuilder) newBackendPoolMap(cbCtx *ConfigBuilderContext) map[backendIdentifier]*n.ApplicationGatewayBackendAddressPool {

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -59,7 +59,11 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 
 		// Pools we obtained from App Gateway - we segment them into ones AGIC is and is not allowed to change.
 		existingBlacklisted, existingNonBlacklisted := brownfield.GetExistingBlacklistedPools(cbCtx.ProhibitedTargets, existingBrownfieldCtx)
+
 		brownfield.LogPools(existingBlacklisted, existingNonBlacklisted, agicCreatedPools)
+
+		// MergePools would produce unique list of pools based on Name. Blacklisted pools, which have the same name
+		// as a managed pool would be overwritten.
 		return brownfield.MergePools(existingBlacklisted, agicCreatedPools)
 	}
 

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -57,12 +57,15 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 		}
 
 		// These are pools we fetch from App Gateway; These we are NOT allowed to mutate.
-		existingUnmanaged := brownfield.PruneManagedPools(allExisting, cbCtx.ProhibitedTargets, brownfieldCtx)
+		existingBlacklisted := brownfield.PruneManagedPools(allExisting, cbCtx.ProhibitedTargets, brownfieldCtx)
 
-		glog.V(3).Info("Subset of pools from Ingress; AGIC will manage:", getPoolNames(allPools))
-		glog.V(3).Info("Existing pools from App Gateway; AGIC will not mutate:", getPoolNames(existingUnmanaged))
+		garbage := []n.ApplicationGatewayBackendAddressPool{}
 
-		allPools = brownfield.MergePools(existingUnmanaged, allPools)
+		glog.V(3).Info("[brownfield] Backend Address Pools AGIC created:", getPoolNames(allPools))
+		glog.V(3).Info("[brownfield] Blacklisted Backend Address Pools AGIC will retain:", getPoolNames(existingBlacklisted))
+		glog.V(3).Info("[brownfield] Backend Address Pools AGIC will remove:", getPoolNames(garbage))
+
+		allPools = brownfield.MergePools(existingBlacklisted, allPools)
 	}
 
 	return allPools

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -204,7 +204,6 @@ func (c *appGwConfigBuilder) getExistingRoutingRules() []n.ApplicationGatewayReq
 func (c *appGwConfigBuilder) getExistingPathMaps() []n.ApplicationGatewayURLPathMap {
 	if c.appGw.BackendAddressPools == nil {
 		return []n.ApplicationGatewayURLPathMap{}
-
 	}
 	return *c.appGw.URLPathMaps
 }

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -179,3 +179,36 @@ func (c *appGwConfigBuilder) addTags() {
 	// Identify the App Gateway as being exclusively managed by a Kubernetes Ingress.
 	c.appGw.Tags[managedByK8sIngress] = to.StringPtr(fmt.Sprintf("%s/%s/%s", version.Version, version.GitCommit, version.BuildDate))
 }
+
+func (c *appGwConfigBuilder) getExistingBackendPools() []n.ApplicationGatewayBackendAddressPool {
+	if c.appGw.BackendAddressPools == nil {
+		return []n.ApplicationGatewayBackendAddressPool{}
+	}
+	return *c.appGw.BackendAddressPools
+}
+
+func (c *appGwConfigBuilder) getExistingListeners() []*n.ApplicationGatewayHTTPListener {
+	var listeners []*n.ApplicationGatewayHTTPListener
+	if c.appGw.HTTPListeners == nil {
+		return listeners
+	}
+	for _, listener := range *c.appGw.HTTPListeners {
+		listeners = append(listeners, &listener)
+	}
+	return listeners
+}
+
+func (c *appGwConfigBuilder) getExistingRoutingRules() []n.ApplicationGatewayRequestRoutingRule {
+	if c.appGw.BackendAddressPools == nil {
+		return []n.ApplicationGatewayRequestRoutingRule{}
+	}
+	return *c.appGw.RequestRoutingRules
+}
+
+func (c *appGwConfigBuilder) getExistingPathMaps() []n.ApplicationGatewayURLPathMap {
+	if c.appGw.BackendAddressPools == nil {
+		return []n.ApplicationGatewayURLPathMap{}
+
+	}
+	return *c.appGw.URLPathMaps
+}

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -187,15 +187,11 @@ func (c *appGwConfigBuilder) getExistingBackendPools() []n.ApplicationGatewayBac
 	return *c.appGw.BackendAddressPools
 }
 
-func (c *appGwConfigBuilder) getExistingListeners() []*n.ApplicationGatewayHTTPListener {
-	var listeners []*n.ApplicationGatewayHTTPListener
+func (c *appGwConfigBuilder) getExistingListeners() []n.ApplicationGatewayHTTPListener {
 	if c.appGw.HTTPListeners == nil {
-		return listeners
+		return []n.ApplicationGatewayHTTPListener{}
 	}
-	for _, listener := range *c.appGw.HTTPListeners {
-		listeners = append(listeners, &listener)
-	}
-	return listeners
+	return *c.appGw.HTTPListeners
 }
 
 func (c *appGwConfigBuilder) getExistingRoutingRules() []n.ApplicationGatewayRequestRoutingRule {

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -195,14 +195,14 @@ func (c *appGwConfigBuilder) getExistingListeners() []n.ApplicationGatewayHTTPLi
 }
 
 func (c *appGwConfigBuilder) getExistingRoutingRules() []n.ApplicationGatewayRequestRoutingRule {
-	if c.appGw.BackendAddressPools == nil {
+	if c.appGw.RequestRoutingRules == nil {
 		return []n.ApplicationGatewayRequestRoutingRule{}
 	}
 	return *c.appGw.RequestRoutingRules
 }
 
 func (c *appGwConfigBuilder) getExistingPathMaps() []n.ApplicationGatewayURLPathMap {
-	if c.appGw.BackendAddressPools == nil {
+	if c.appGw.URLPathMaps == nil {
 		return []n.ApplicationGatewayURLPathMap{}
 	}
 	return *c.appGw.URLPathMaps

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -182,9 +182,8 @@ func defaultProbe() n.ApplicationGatewayProbe {
 }
 
 func defaultBackendAddressPool() *n.ApplicationGatewayBackendAddressPool {
-	defBackendAddressPool := defaultBackendAddressPoolName
 	return &n.ApplicationGatewayBackendAddressPool{
-		Name: &defBackendAddressPool,
+		Name: &defaultBackendAddressPoolName,
 		ApplicationGatewayBackendAddressPoolPropertiesFormat: &n.ApplicationGatewayBackendAddressPoolPropertiesFormat{
 			BackendAddresses: &[]n.ApplicationGatewayBackendAddress{},
 		},

--- a/pkg/brownfield/ingress_test.go
+++ b/pkg/brownfield/ingress_test.go
@@ -98,21 +98,4 @@ var _ = Describe("test pruning Ingress based on white/white lists", func() {
 		})
 	})
 
-	Context("Test canManage()", func() {
-		blacklist := []Target{{
-			Hostname: tests.Host,
-			Path:     fixtures.PathFox,
-		}}
-
-		It("should have properly identified the ingress rules AGIC is NOT allowed to manage", func() {
-			actual := canManage(tests.Host, fixtures.PathFox, &blacklist)
-			Expect(actual).To(BeFalse())
-		})
-
-		It("should have properly identified the ingress rules AGIC is allowed to manage", func() {
-			actual := canManage(tests.Host, fixtures.PathBaz, &blacklist)
-			Expect(actual).To(BeTrue())
-		})
-	})
-
 })

--- a/pkg/brownfield/ingress_test.go
+++ b/pkg/brownfield/ingress_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("test pruning Ingress based on white/white lists", func() {
 
 	Context("Test PruneIngressRules()", func() {
-		prohibited := fixtures.GetProhibitedTargets()
+		prohibited := fixtures.GetAzureIngressProhibitedTargets()
 
 		ingress := v1beta1.Ingress{
 			Spec: v1beta1.IngressSpec{
@@ -69,13 +69,6 @@ var _ = Describe("test pruning Ingress based on white/white lists", func() {
 		expected := v1beta1.Ingress{
 			Spec: v1beta1.IngressSpec{
 				Rules: []v1beta1.IngressRule{
-					{
-						// Should have kept the rule with no Paths
-						Host: tests.OtherHost,
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{},
-						},
-					},
 					{
 						// Should have kept one of the Paths of this Rule
 						Host: tests.Host,

--- a/pkg/brownfield/pools.go
+++ b/pkg/brownfield/pools.go
@@ -85,7 +85,7 @@ func MergePools(pools ...[]n.ApplicationGatewayBackendAddressPool) []n.Applicati
 }
 
 func indexByName(pools []n.ApplicationGatewayBackendAddressPool) poolsByName {
-	indexed := make(map[backendPoolName]n.ApplicationGatewayBackendAddressPool)
+	indexed := make(poolsByName)
 	for _, pool := range pools {
 		indexed[backendPoolName(*pool.Name)] = pool
 	}

--- a/pkg/brownfield/pools.go
+++ b/pkg/brownfield/pools.go
@@ -68,22 +68,14 @@ func MergePools(pools ...[]n.ApplicationGatewayBackendAddressPool) []n.Applicati
 	return merged
 }
 
-func IndexPoolsByName(pools []n.ApplicationGatewayBackendAddressPool) PoolsByName {
-	indexed := make(PoolsByName)
-	for _, pool := range pools {
-		indexed[backendPoolName(*pool.Name)] = pool
-	}
-	return indexed
-}
-
 // LogPools emits a few log lines detailing what pools are created, blacklisted, and removed from ARM.
 func LogPools(existingBlacklisted []n.ApplicationGatewayBackendAddressPool, existingNonBlacklisted []n.ApplicationGatewayBackendAddressPool, managedPools []n.ApplicationGatewayBackendAddressPool) {
 	var garbage []n.ApplicationGatewayBackendAddressPool
 
-	blacklistedSet := IndexPoolsByName(existingBlacklisted)
-	managedSet := IndexPoolsByName(managedPools)
+	blacklistedSet := indexPoolsByName(existingBlacklisted)
+	managedSet := indexPoolsByName(managedPools)
 
-	for poolName, pool := range IndexPoolsByName(existingNonBlacklisted) {
+	for poolName, pool := range indexPoolsByName(existingNonBlacklisted) {
 		_, existsInBlacklist := blacklistedSet[poolName]
 		_, existsInNewPools := managedSet[poolName]
 		if !existsInBlacklist && !existsInNewPools {
@@ -94,6 +86,14 @@ func LogPools(existingBlacklisted []n.ApplicationGatewayBackendAddressPool, exis
 	glog.V(3).Info("[brownfield] Pools AGIC created: ", getPoolNames(managedPools))
 	glog.V(3).Info("[brownfield] Existing Blacklisted Pools AGIC will retain: ", getPoolNames(existingBlacklisted))
 	glog.V(3).Info("[brownfield] Existing Pools AGIC will remove: ", getPoolNames(garbage))
+}
+
+func indexPoolsByName(pools []n.ApplicationGatewayBackendAddressPool) PoolsByName {
+	indexed := make(PoolsByName)
+	for _, pool := range pools {
+		indexed[backendPoolName(*pool.Name)] = pool
+	}
+	return indexed
 }
 
 func getPoolNames(pool []n.ApplicationGatewayBackendAddressPool) string {

--- a/pkg/brownfield/pools.go
+++ b/pkg/brownfield/pools.go
@@ -128,7 +128,11 @@ func (c PoolContext) getPoolToTargetsMap() poolToTargets {
 		pathNameToPath[pathmapName(*pm.Name)] = pm
 	}
 
-	poolToTarget := make(poolToTargets)
+	// Add the default backend pool - with no target. This will be overwritten if the default backend pool exists with
+	// some targets already.
+	poolToTarget := poolToTargets{
+		backendPoolName(*c.DefaultBackendPool.Name): []Target{},
+	}
 
 	for _, rule := range c.RoutingRules {
 		listenerName := listenerName(utils.GetLastChunkOfSlashed(*rule.HTTPListener.ID))
@@ -136,8 +140,10 @@ func (c PoolContext) getPoolToTargetsMap() poolToTargets {
 		var hostName string
 		if listener, found := listenersByName[listenerName]; !found {
 			continue
-		} else {
+		} else if listener.HostName != nil {
 			hostName = *listener.HostName
+		} else {
+			hostName = ""
 		}
 
 		target := Target{Hostname: hostName}
@@ -151,19 +157,31 @@ func (c PoolContext) getPoolToTargetsMap() poolToTargets {
 		} else {
 			// Follow the path map
 			pathMapName := pathmapName(utils.GetLastChunkOfSlashed(*rule.URLPathMap.ID))
-			for _, pathRule := range *pathNameToPath[pathMapName].PathRules {
-				if pathRule.BackendAddressPool == nil {
-					glog.Errorf("Path Rule %+v does not have BackendAddressPool", *pathRule.Name)
+
+			// In case there are no PathRules
+			if pathNameToPath[pathMapName].PathRules == nil {
+				if pathNameToPath[pathMapName].DefaultBackendAddressPool == nil {
+					glog.Errorf("Path map with name %s does not have PathRules and does not have DefaultBackendAddressPool", pathMapName)
 					continue
 				}
-				poolName := backendPoolName(utils.GetLastChunkOfSlashed(*pathRule.BackendAddressPool.ID))
-				if pathRule.Paths == nil {
-					glog.V(5).Infof("Path Rule %+v does not have paths list", *pathRule.Name)
-					continue
-				}
-				for _, path := range *pathRule.Paths {
-					target.Path = strings.ToLower(path)
-					poolToTarget[poolName] = append(poolToTarget[poolName], target)
+				poolName := backendPoolName(*c.DefaultBackendPool.Name)
+				poolToTarget[poolName] = append(poolToTarget[poolName], target)
+			} else {
+				// Go through the path rules
+				for _, pathRule := range *pathNameToPath[pathMapName].PathRules {
+					if pathRule.BackendAddressPool == nil {
+						glog.Errorf("Path Rule %+v does not have BackendAddressPool", *pathRule.Name)
+						continue
+					}
+					poolName := backendPoolName(utils.GetLastChunkOfSlashed(*pathRule.BackendAddressPool.ID))
+					if pathRule.Paths == nil {
+						glog.V(5).Infof("Path Rule %+v does not have paths list", *pathRule.Name)
+						continue
+					}
+					for _, path := range *pathRule.Paths {
+						target.Path = strings.ToLower(path)
+						poolToTarget[poolName] = append(poolToTarget[poolName], target)
+					}
 				}
 			}
 		}

--- a/pkg/brownfield/pools.go
+++ b/pkg/brownfield/pools.go
@@ -1,0 +1,160 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"encoding/json"
+	"strings"
+
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/golang/glog"
+
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
+)
+
+// GetManagedPools filters the given list of backend pools to the list pools that AGIC is allowed to manage.
+func GetManagedPools(pools []n.ApplicationGatewayBackendAddressPool, prohibited []*ptv1.AzureIngressProhibitedTarget, ctx PoolContext) []n.ApplicationGatewayBackendAddressPool {
+	blacklist := GetTargetBlacklist(prohibited)
+	if len(*blacklist) == 0 {
+		// There is no TargetBlacklist - AGIC will manage all configuration.
+		return pools
+	}
+
+	poolToTarget := ctx.getPoolToTargetsMap()
+
+	// Figure out if the given BackendAddressPool is blacklisted. It will be if it has a host/path that
+	// has been referenced in a AzureIngressProhibitedTarget CRD (even if it has some other paths that are not)
+	isPoolBlacklisted := func(pool n.ApplicationGatewayBackendAddressPool) bool {
+		targetsForPool := poolToTarget[backendPoolName(*pool.Name)]
+		for _, target := range targetsForPool {
+			if target.IsBlacklisted(blacklist) {
+				logTarget(5, target, "in blacklist")
+				return true
+			}
+			logTarget(5, target, "implicitly managed")
+		}
+		return false
+	}
+
+	var managedPools []n.ApplicationGatewayBackendAddressPool
+	for _, pool := range pools {
+		if isPoolBlacklisted(pool) {
+			glog.V(5).Infof("Backend Address Pool %s is blacklisted", *pool.Name)
+			continue
+		}
+		glog.V(5).Infof("Backend Address Pool %s is NOT blacklisted", *pool.Name)
+		managedPools = append(managedPools, pool)
+	}
+	return managedPools
+}
+
+// PruneManagedPools removes the managed pools from the given list of pools; resulting in a list of pools not managed by AGIC.
+func PruneManagedPools(pools []n.ApplicationGatewayBackendAddressPool, prohibitedTargets []*ptv1.AzureIngressProhibitedTarget, ctx PoolContext) []n.ApplicationGatewayBackendAddressPool {
+	managedPools := GetManagedPools(pools, prohibitedTargets, ctx)
+	if managedPools == nil {
+		return pools
+	}
+	managedByName := indexByName(managedPools)
+	var unmanagedPools []n.ApplicationGatewayBackendAddressPool
+	for _, pool := range pools {
+		if _, isManaged := managedByName[backendPoolName(*pool.Name)]; isManaged {
+			continue
+		}
+		unmanagedPools = append(unmanagedPools, pool)
+	}
+	return unmanagedPools
+}
+
+// MergePools merges list of lists of backend address pools into a single list, maintaining uniqueness.
+func MergePools(pools ...[]n.ApplicationGatewayBackendAddressPool) []n.ApplicationGatewayBackendAddressPool {
+	uniqPool := make(poolsByName)
+	for _, bucket := range pools {
+		for _, pool := range bucket {
+			uniqPool[backendPoolName(*pool.Name)] = pool
+		}
+	}
+	var merged []n.ApplicationGatewayBackendAddressPool
+	for _, pool := range uniqPool {
+		merged = append(merged, pool)
+	}
+	return merged
+}
+
+func indexByName(pools []n.ApplicationGatewayBackendAddressPool) poolsByName {
+	indexed := make(map[backendPoolName]n.ApplicationGatewayBackendAddressPool)
+	for _, pool := range pools {
+		indexed[backendPoolName(*pool.Name)] = pool
+	}
+	return indexed
+}
+
+func logTarget(verbosity glog.Level, target Target, message string) {
+	t, _ := json.Marshal(target)
+	glog.V(verbosity).Infof("Target is "+message+": %s", t)
+}
+
+// getPoolToTargetsMap creates a map from backend pool to targets this backend pool is responsible for.
+// We rely on the configuration that AGIC has already constructed: Frontend Listener, Routing Rules, etc.
+// We use the Listener to obtain the target hostname, the RoutingRule to get the
+func (c PoolContext) getPoolToTargetsMap() poolToTargets {
+
+	// Index listeners by their name
+	listenersByName := make(map[listenerName]*n.ApplicationGatewayHTTPListener)
+	for _, listener := range c.Listeners {
+		listenersByName[listenerName(*listener.Name)] = listener
+	}
+
+	// Index URLPathMaps by the path map name
+	pathNameToPath := make(map[pathmapName]n.ApplicationGatewayURLPathMap)
+	for _, pm := range c.PathMaps {
+		pathNameToPath[pathmapName(*pm.Name)] = pm
+	}
+
+	poolToTarget := make(poolToTargets)
+
+	for _, rule := range c.RoutingRules {
+
+		listenerName := listenerName(utils.GetLastChunkOfSlashed(*rule.HTTPListener.ID))
+
+		var hostName string
+		if listener, found := listenersByName[listenerName]; !found {
+			continue
+		} else {
+			hostName = *listener.HostName
+		}
+
+		target := Target{Hostname: hostName}
+
+		if rule.URLPathMap == nil {
+			// SSL Redirects do not have BackendAddressPool
+			if rule.BackendAddressPool == nil {
+				continue
+			}
+			poolName := backendPoolName(utils.GetLastChunkOfSlashed(*rule.BackendAddressPool.ID))
+			poolToTarget[poolName] = append(poolToTarget[poolName], target)
+		} else {
+			// Follow the path map
+			pathMapName := pathmapName(utils.GetLastChunkOfSlashed(*rule.URLPathMap.ID))
+			for _, pathRule := range *pathNameToPath[pathMapName].PathRules {
+				if pathRule.BackendAddressPool == nil {
+					glog.Errorf("Path Rule %+v does not have BackendAddressPool", *pathRule.Name)
+					continue
+				}
+				poolName := backendPoolName(utils.GetLastChunkOfSlashed(*pathRule.BackendAddressPool.ID))
+				if pathRule.Paths == nil {
+					glog.V(5).Infof("Path Rule %+v does not have paths list", *pathRule.Name)
+					continue
+				}
+				for _, path := range *pathRule.Paths {
+					target.Path = strings.ToLower(path)
+					poolToTarget[poolName] = append(poolToTarget[poolName], target)
+				}
+			}
+		}
+	}
+	return poolToTarget
+}

--- a/pkg/brownfield/pools.go
+++ b/pkg/brownfield/pools.go
@@ -16,62 +16,46 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
-// GetManagedPools filters the given list of backend pools to the list pools that AGIC is allowed to manage.
-func GetManagedPools(pools []n.ApplicationGatewayBackendAddressPool, prohibited []*ptv1.AzureIngressProhibitedTarget, ctx PoolContext) []n.ApplicationGatewayBackendAddressPool {
-	blacklist := GetTargetBlacklist(prohibited)
-	if len(*blacklist) == 0 {
-		// There is no TargetBlacklist - AGIC will manage all configuration.
-		return pools
+// GetExistingBlacklistedPools removes the managed pools from the given list of pools; resulting in a list of pools not managed by AGIC.
+func GetExistingBlacklistedPools(prohibitedTargets []*ptv1.AzureIngressProhibitedTarget, ctx PoolContext) ([]n.ApplicationGatewayBackendAddressPool, []n.ApplicationGatewayBackendAddressPool) {
+	blacklist := GetTargetBlacklist(prohibitedTargets)
+	if blacklist == nil {
+		return []n.ApplicationGatewayBackendAddressPool{}, ctx.BackendPools
 	}
-
-	poolToTarget := ctx.getPoolToTargetsMap()
+	poolToTargets := ctx.getPoolToTargetsMap()
+	glog.V(5).Infof("Backend Pool to Targets map: %+v", poolToTargets)
 
 	// Figure out if the given BackendAddressPool is blacklisted. It will be if it has a host/path that
 	// has been referenced in a AzureIngressProhibitedTarget CRD (even if it has some other paths that are not)
 	isPoolBlacklisted := func(pool n.ApplicationGatewayBackendAddressPool) bool {
-		targetsForPool := poolToTarget[backendPoolName(*pool.Name)]
+		targetsForPool := poolToTargets[backendPoolName(*pool.Name)]
 		for _, target := range targetsForPool {
 			if target.IsBlacklisted(blacklist) {
 				logTarget(5, target, "in blacklist")
 				return true
 			}
-			logTarget(5, target, "implicitly managed")
+			logTarget(5, target, "not in blacklist")
 		}
 		return false
 	}
 
-	var managedPools []n.ApplicationGatewayBackendAddressPool
-	for _, pool := range pools {
+	var blacklistedPools []n.ApplicationGatewayBackendAddressPool
+	var nonBlacklistedPools []n.ApplicationGatewayBackendAddressPool
+	for _, pool := range ctx.BackendPools {
 		if isPoolBlacklisted(pool) {
+			blacklistedPools = append(blacklistedPools, pool)
 			glog.V(5).Infof("Backend Address Pool %s is blacklisted", *pool.Name)
 			continue
 		}
 		glog.V(5).Infof("Backend Address Pool %s is NOT blacklisted", *pool.Name)
-		managedPools = append(managedPools, pool)
+		nonBlacklistedPools = append(nonBlacklistedPools, pool)
 	}
-	return managedPools
-}
-
-// PruneManagedPools removes the managed pools from the given list of pools; resulting in a list of pools not managed by AGIC.
-func PruneManagedPools(pools []n.ApplicationGatewayBackendAddressPool, prohibitedTargets []*ptv1.AzureIngressProhibitedTarget, ctx PoolContext) []n.ApplicationGatewayBackendAddressPool {
-	managedPools := GetManagedPools(pools, prohibitedTargets, ctx)
-	if managedPools == nil {
-		return pools
-	}
-	managedByName := indexByName(managedPools)
-	var unmanagedPools []n.ApplicationGatewayBackendAddressPool
-	for _, pool := range pools {
-		if _, isManaged := managedByName[backendPoolName(*pool.Name)]; isManaged {
-			continue
-		}
-		unmanagedPools = append(unmanagedPools, pool)
-	}
-	return unmanagedPools
+	return blacklistedPools, nonBlacklistedPools
 }
 
 // MergePools merges list of lists of backend address pools into a single list, maintaining uniqueness.
 func MergePools(pools ...[]n.ApplicationGatewayBackendAddressPool) []n.ApplicationGatewayBackendAddressPool {
-	uniqPool := make(poolsByName)
+	uniqPool := make(PoolsByName)
 	for _, bucket := range pools {
 		for _, pool := range bucket {
 			uniqPool[backendPoolName(*pool.Name)] = pool
@@ -84,12 +68,43 @@ func MergePools(pools ...[]n.ApplicationGatewayBackendAddressPool) []n.Applicati
 	return merged
 }
 
-func indexByName(pools []n.ApplicationGatewayBackendAddressPool) poolsByName {
-	indexed := make(poolsByName)
+func IndexPoolsByName(pools []n.ApplicationGatewayBackendAddressPool) PoolsByName {
+	indexed := make(PoolsByName)
 	for _, pool := range pools {
 		indexed[backendPoolName(*pool.Name)] = pool
 	}
 	return indexed
+}
+
+// LogPools emits a few log lines detailing what pools are created, blacklisted, and removed from ARM.
+func LogPools(existingBlacklisted []n.ApplicationGatewayBackendAddressPool, existingNonBlacklisted []n.ApplicationGatewayBackendAddressPool, managedPools []n.ApplicationGatewayBackendAddressPool) {
+	var garbage []n.ApplicationGatewayBackendAddressPool
+
+	blacklistedSet := IndexPoolsByName(existingBlacklisted)
+	managedSet := IndexPoolsByName(managedPools)
+
+	for poolName, pool := range IndexPoolsByName(existingNonBlacklisted) {
+		_, existsInBlacklist := blacklistedSet[poolName]
+		_, existsInNewPools := managedSet[poolName]
+		if !existsInBlacklist && !existsInNewPools {
+			garbage = append(garbage, pool)
+		}
+	}
+
+	glog.V(3).Info("[brownfield] Pools AGIC created: ", getPoolNames(managedPools))
+	glog.V(3).Info("[brownfield] Existing Blacklisted Pools AGIC will retain: ", getPoolNames(existingBlacklisted))
+	glog.V(3).Info("[brownfield] Existing Pools AGIC will remove: ", getPoolNames(garbage))
+}
+
+func getPoolNames(pool []n.ApplicationGatewayBackendAddressPool) string {
+	var names []string
+	for _, p := range pool {
+		names = append(names, *p.Name)
+	}
+	if len(names) == 0 {
+		return "n/a"
+	}
+	return strings.Join(names, ", ")
 }
 
 func logTarget(verbosity glog.Level, target Target, message string) {
@@ -103,7 +118,7 @@ func logTarget(verbosity glog.Level, target Target, message string) {
 func (c PoolContext) getPoolToTargetsMap() poolToTargets {
 
 	// Index listeners by their name
-	listenersByName := make(map[listenerName]*n.ApplicationGatewayHTTPListener)
+	listenersByName := make(map[listenerName]n.ApplicationGatewayHTTPListener)
 	for _, listener := range c.Listeners {
 		listenersByName[listenerName(*listener.Name)] = listener
 	}
@@ -117,7 +132,6 @@ func (c PoolContext) getPoolToTargetsMap() poolToTargets {
 	poolToTarget := make(poolToTargets)
 
 	for _, rule := range c.RoutingRules {
-
 		listenerName := listenerName(utils.GetLastChunkOfSlashed(*rule.HTTPListener.ID))
 
 		var hostName string
@@ -128,7 +142,6 @@ func (c PoolContext) getPoolToTargetsMap() poolToTargets {
 		}
 
 		target := Target{Hostname: hostName}
-
 		if rule.URLPathMap == nil {
 			// SSL Redirects do not have BackendAddressPool
 			if rule.BackendAddressPool == nil {

--- a/pkg/brownfield/pools_test.go
+++ b/pkg/brownfield/pools_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
 )
 
-var _ = Describe("test TargetBlacklist/TargetWhitelist backend pools", func() {
+var _ = Describe("Test blacklisting backend pools", func() {
 
 	listeners := []n.ApplicationGatewayHTTPListener{
 		*fixtures.GetListener1(),

--- a/pkg/brownfield/pools_test.go
+++ b/pkg/brownfield/pools_test.go
@@ -6,11 +6,11 @@
 package brownfield
 
 import (
-	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
 )
@@ -69,6 +69,10 @@ var _ = Describe("Test blacklisting backend pools", func() {
 				fixtures.DefaultBackendPoolName: {
 					{
 						Hostname: "",
+						Path:     "",
+					},
+					{
+						Hostname: "bye.com",
 						Path:     "",
 					},
 				},

--- a/pkg/brownfield/pools_test.go
+++ b/pkg/brownfield/pools_test.go
@@ -1,0 +1,136 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
+)
+
+var _ = Describe("test TargetBlacklist/TargetWhitelist backend pools", func() {
+
+	listeners := []*n.ApplicationGatewayHTTPListener{
+		fixtures.GetListener1(),
+		fixtures.GetListener2(),
+	}
+
+	routingRules := []n.ApplicationGatewayRequestRoutingRule{
+		*fixtures.GetRequestRoutingRulePathBased(),
+		*fixtures.GetRequestRoutingRuleBasic(),
+	}
+
+	paths := []n.ApplicationGatewayURLPathMap{
+		*fixtures.GeURLPathMap(),
+	}
+
+	brownfieldContext := PoolContext{
+		Listeners:    listeners,
+		RoutingRules: routingRules,
+		PathMaps:     paths,
+	}
+
+	pool1 := fixtures.GetBackendPool1()
+	pool2 := fixtures.GetBackendPool2()
+	pool3 := fixtures.GetBackendPool3()
+
+	// Create a list of pools
+	pools := []n.ApplicationGatewayBackendAddressPool{
+		pool1, // managed
+		pool2, // managed
+		pool3, // prohibited
+	}
+
+	prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets()
+
+	Context("Test getPoolToTargetsMap", func() {
+
+		actual := brownfieldContext.getPoolToTargetsMap()
+
+		It("should have created map of pool name to list of targets", func() {
+			expected := poolToTargets{
+				fixtures.BackendAddressPoolName1: {
+					{
+						Hostname: tests.Host,
+						Path:     fixtures.PathFoo,
+					},
+
+					{
+						Hostname: tests.Host,
+						Path:     fixtures.PathBar,
+					},
+
+					{
+						Hostname: tests.Host,
+						Path:     fixtures.PathBaz,
+					},
+				},
+
+				fixtures.BackendAddressPoolName2: {
+					{
+						Hostname: tests.OtherHost,
+					},
+				},
+			}
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
+	Context("Test MergePools()", func() {
+
+		poolList0 := []n.ApplicationGatewayBackendAddressPool{
+			pool1,
+		}
+
+		poolList1 := []n.ApplicationGatewayBackendAddressPool{
+			pool1,
+			pool2,
+		}
+
+		poolList2 := []n.ApplicationGatewayBackendAddressPool{
+			pool2,
+		}
+
+		It("should be able to merge lists of pools", func() {
+			merge1 := MergePools(poolList1, poolList2)
+			Expect(len(merge1)).To(Equal(2))
+			Expect(merge1).To(ContainElement(pool1))
+			Expect(merge1).To(ContainElement(pool2))
+
+			merge2 := MergePools(poolList0, poolList2)
+			Expect(len(merge2)).To(Equal(2))
+			Expect(merge1).To(ContainElement(pool1))
+			Expect(merge1).To(ContainElement(pool2))
+		})
+	})
+
+	Context("Test GetManagedPools()", func() {
+
+		It("should get managed pools only, excluding blacklisted ones", func() {
+			actualPools := GetManagedPools(pools, prohibitedTargets, brownfieldContext)
+
+			Expect(len(actualPools)).To(Equal(1))
+			Expect(actualPools).ToNot(ContainElement(pool1))
+			Expect(actualPools).ToNot(ContainElement(pool2))
+			Expect(actualPools).To(ContainElement(pool3))
+		})
+	})
+
+	Context("Test PruneManagedPools()", func() {
+
+		It("should be able to prune the managed pools from the lists of all pools", func() {
+			actual := PruneManagedPools(pools, prohibitedTargets, brownfieldContext)
+
+			Expect(len(actual)).To(Equal(2))
+			Expect(actual).To(ContainElement(pool1))
+			Expect(actual).To(ContainElement(pool2))
+			Expect(actual).ToNot(ContainElement(pool3))
+		})
+	})
+})

--- a/pkg/brownfield/pools_test.go
+++ b/pkg/brownfield/pools_test.go
@@ -111,7 +111,7 @@ var _ = Describe("test TargetBlacklist/TargetWhitelist backend pools", func() {
 		})
 	})
 
-	Context("Test GetExistingBlacklistedPools()", func() {
+	Context("Test GetBlacklistedPools()", func() {
 
 		It("should be able to prune the managed pools from the lists of all pools", func() {
 			blacklisted, notBlacklisted := GetExistingBlacklistedPools(prohibitedTargets, brownfieldContext)

--- a/pkg/brownfield/targets_test.go
+++ b/pkg/brownfield/targets_test.go
@@ -20,9 +20,9 @@ var _ = Describe("Test blacklisting targets", func() {
 	}
 
 	Context("test GetTargetBlacklist", func() {
-		blacklist := GetTargetBlacklist(fixtures.GetProhibitedTargets())
+		blacklist := GetTargetBlacklist(fixtures.GetAzureIngressProhibitedTargets())
 		It("should have produced correct Prohibited Targets list", func() {
-			Expect(len(*blacklist)).To(Equal(2))
+			Expect(len(*blacklist)).To(Equal(4))
 
 			// Targets /fox and /bar are in the blacklist
 			for _, path := range []string{fixtures.PathFox, fixtures.PathBar} {
@@ -86,5 +86,4 @@ var _ = Describe("Test blacklisting targets", func() {
 			Expect(targetNoHost.IsBlacklisted(&blacklist)).To(BeFalse())
 		})
 	})
-
 })

--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -12,9 +12,10 @@ import (
 // PoolContext is the basket of App Gateway configs necessary to determine what settings should be
 // managed and what should be left as-is.
 type PoolContext struct {
-	Listeners    []*n.ApplicationGatewayHTTPListener
+	Listeners    []n.ApplicationGatewayHTTPListener
 	RoutingRules []n.ApplicationGatewayRequestRoutingRule
 	PathMaps     []n.ApplicationGatewayURLPathMap
+	BackendPools []n.ApplicationGatewayBackendAddressPool
 }
 
 type listenerName string
@@ -23,7 +24,7 @@ type backendPoolName string
 
 type poolToTargets map[backendPoolName][]Target
 
-type poolsByName map[backendPoolName]n.ApplicationGatewayBackendAddressPool
+type PoolsByName map[backendPoolName]n.ApplicationGatewayBackendAddressPool
 
 // TargetBlacklist is a list of Targets, which AGIC is not allowed to apply configuration for.
 type TargetBlacklist *[]Target

--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -13,11 +13,12 @@ import (
 // PoolContext is the basket of App Gateway configs necessary to determine what settings should be
 // managed and what should be left as-is.
 type PoolContext struct {
-	Listeners         []n.ApplicationGatewayHTTPListener
-	RoutingRules      []n.ApplicationGatewayRequestRoutingRule
-	PathMaps          []n.ApplicationGatewayURLPathMap
-	BackendPools      []n.ApplicationGatewayBackendAddressPool
-	ProhibitedTargets []*ptv1.AzureIngressProhibitedTarget
+	Listeners          []n.ApplicationGatewayHTTPListener
+	RoutingRules       []n.ApplicationGatewayRequestRoutingRule
+	PathMaps           []n.ApplicationGatewayURLPathMap
+	BackendPools       []n.ApplicationGatewayBackendAddressPool
+	ProhibitedTargets  []*ptv1.AzureIngressProhibitedTarget
+	DefaultBackendPool n.ApplicationGatewayBackendAddressPool
 }
 
 type listenerName string

--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -6,16 +6,18 @@
 package brownfield
 
 import (
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 )
 
 // PoolContext is the basket of App Gateway configs necessary to determine what settings should be
 // managed and what should be left as-is.
 type PoolContext struct {
-	Listeners    []n.ApplicationGatewayHTTPListener
-	RoutingRules []n.ApplicationGatewayRequestRoutingRule
-	PathMaps     []n.ApplicationGatewayURLPathMap
-	BackendPools []n.ApplicationGatewayBackendAddressPool
+	Listeners         []n.ApplicationGatewayHTTPListener
+	RoutingRules      []n.ApplicationGatewayRequestRoutingRule
+	PathMaps          []n.ApplicationGatewayURLPathMap
+	BackendPools      []n.ApplicationGatewayBackendAddressPool
+	ProhibitedTargets []*ptv1.AzureIngressProhibitedTarget
 }
 
 type listenerName string
@@ -24,7 +26,7 @@ type backendPoolName string
 
 type poolToTargets map[backendPoolName][]Target
 
-type PoolsByName map[backendPoolName]n.ApplicationGatewayBackendAddressPool
+type poolsByName map[backendPoolName]n.ApplicationGatewayBackendAddressPool
 
 // TargetBlacklist is a list of Targets, which AGIC is not allowed to apply configuration for.
 type TargetBlacklist *[]Target

--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -5,5 +5,25 @@
 
 package brownfield
 
+import (
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+)
+
+// PoolContext is the basket of App Gateway configs necessary to determine what settings should be
+// managed and what should be left as-is.
+type PoolContext struct {
+	Listeners    []*n.ApplicationGatewayHTTPListener
+	RoutingRules []n.ApplicationGatewayRequestRoutingRule
+	PathMaps     []n.ApplicationGatewayURLPathMap
+}
+
+type listenerName string
+type pathmapName string
+type backendPoolName string
+
+type poolToTargets map[backendPoolName][]Target
+
+type poolsByName map[backendPoolName]n.ApplicationGatewayBackendAddressPool
+
 // TargetBlacklist is a list of Targets, which AGIC is not allowed to apply configuration for.
 type TargetBlacklist *[]Target

--- a/pkg/tests/fixtures/http_settings.go
+++ b/pkg/tests/fixtures/http_settings.go
@@ -1,0 +1,5 @@
+package fixtures
+
+const (
+	DefaultBackendHTTPSettingsName = "DefaultBackendHTTPSettings"
+)

--- a/pkg/tests/fixtures/ips.go
+++ b/pkg/tests/fixtures/ips.go
@@ -1,0 +1,5 @@
+package fixtures
+
+const (
+	DefaultIPName = "appGatewayFrontendIP"
+)

--- a/pkg/tests/fixtures/listeners.go
+++ b/pkg/tests/fixtures/listeners.go
@@ -13,6 +13,9 @@ import (
 )
 
 const (
+	// DefaultHTTPListenerName is a string constant.
+	DefaultHTTPListenerName = "fl-80"
+
 	// Listener1 is a string constant.
 	Listener1 = "HTTPListener-PathBased"
 
@@ -46,6 +49,18 @@ func GetListener2() *n.ApplicationGatewayHTTPListener {
 			HostName:                    to.StringPtr(tests.OtherHost),
 			SslCertificate:              &n.SubResource{ID: to.StringPtr("")},
 			RequireServerNameIndication: to.BoolPtr(true),
+		},
+	}
+}
+
+// GetDefaultListener creates a new struct for use in unit tests.
+func GetDefaultListener() *n.ApplicationGatewayHTTPListener {
+	return &n.ApplicationGatewayHTTPListener{
+		Name: to.StringPtr(DefaultHTTPListenerName),
+		ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
+			FrontendIPConfiguration: &n.SubResource{ID: to.StringPtr("/x/y/z/" + DefaultIPName)},
+			FrontendPort:            &n.SubResource{ID: to.StringPtr("/x/y/z/" + DefaultPortName)},
+			Protocol:                n.HTTP,
 		},
 	}
 }

--- a/pkg/tests/fixtures/paths.go
+++ b/pkg/tests/fixtures/paths.go
@@ -6,11 +6,14 @@
 package fixtures
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 )
 
 const (
+	// DefaultPathMapName is a string constant.
+	DefaultPathMapName = "default-pathmap-name"
+
 	// PathMapName is a string constant.
 	PathMapName = "URLPathMap-1"
 
@@ -22,32 +25,32 @@ const (
 )
 
 // GeURLPathMap creates a new struct for use in unit tests.
-func GeURLPathMap() *network.ApplicationGatewayURLPathMap {
-	return &network.ApplicationGatewayURLPathMap{
+func GeURLPathMap() *n.ApplicationGatewayURLPathMap {
+	return &n.ApplicationGatewayURLPathMap{
 		Name: to.StringPtr(PathMapName),
-		ApplicationGatewayURLPathMapPropertiesFormat: &network.ApplicationGatewayURLPathMapPropertiesFormat{
+		ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 			// DefaultBackendAddressPool - Default backend address pool resource of URL path map.
-			DefaultBackendAddressPool: &network.SubResource{
+			DefaultBackendAddressPool: &n.SubResource{
 				ID: to.StringPtr(""),
 			},
 
 			// DefaultBackendHTTPSettings - Default backend http settings resource of URL path map.
-			DefaultBackendHTTPSettings: &network.SubResource{
+			DefaultBackendHTTPSettings: &n.SubResource{
 				ID: to.StringPtr(""),
 			},
 
 			// DefaultRewriteRuleSet - Default Rewrite rule set resource of URL path map.
-			DefaultRewriteRuleSet: &network.SubResource{
+			DefaultRewriteRuleSet: &n.SubResource{
 				ID: to.StringPtr(""),
 			},
 
 			// DefaultRedirectConfiguration - Default redirect configuration resource of URL path map.
-			DefaultRedirectConfiguration: &network.SubResource{
+			DefaultRedirectConfiguration: &n.SubResource{
 				ID: to.StringPtr(""),
 			},
 
 			// PathRules - Path rule of URL path map resource.
-			PathRules: &[]network.ApplicationGatewayPathRule{
+			PathRules: &[]n.ApplicationGatewayPathRule{
 				*GetPathRulePathBased(),
 				*GetPathRuleBasic(),
 			},
@@ -56,10 +59,10 @@ func GeURLPathMap() *network.ApplicationGatewayURLPathMap {
 }
 
 // GetPathRulePathBased creates a new struct for use in unit tests.
-func GetPathRulePathBased() *network.ApplicationGatewayPathRule {
-	return &network.ApplicationGatewayPathRule{
+func GetPathRulePathBased() *n.ApplicationGatewayPathRule {
+	return &n.ApplicationGatewayPathRule{
 		Name: to.StringPtr(PathRuleName),
-		ApplicationGatewayPathRulePropertiesFormat: &network.ApplicationGatewayPathRulePropertiesFormat{
+		ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 			// Paths - Path rules of URL path map.
 			Paths: &[]string{
 				PathFoo,
@@ -68,22 +71,22 @@ func GetPathRulePathBased() *network.ApplicationGatewayPathRule {
 			},
 
 			// BackendAddressPool - Backend address pool resource of URL path map path rule.
-			BackendAddressPool: &network.SubResource{
+			BackendAddressPool: &n.SubResource{
 				ID: to.StringPtr("x/y/z/" + BackendAddressPoolName1),
 			},
 
 			// BackendHTTPSettings - Backend http settings resource of URL path map path rule.
-			BackendHTTPSettings: &network.SubResource{
+			BackendHTTPSettings: &n.SubResource{
 				ID: to.StringPtr("x/y/z/BackendHTTPSettings-1"),
 			},
 
 			// RedirectConfiguration - Redirect configuration resource of URL path map path rule.
-			RedirectConfiguration: &network.SubResource{
+			RedirectConfiguration: &n.SubResource{
 				ID: to.StringPtr("x/y/z/RedirectConfiguration-1"),
 			},
 
 			// RewriteRuleSet - Rewrite rule set resource of URL path map path rule.
-			RewriteRuleSet: &network.SubResource{
+			RewriteRuleSet: &n.SubResource{
 				ID: to.StringPtr("x/y/z/RewriteRuleSet-1"),
 			},
 		},
@@ -91,32 +94,44 @@ func GetPathRulePathBased() *network.ApplicationGatewayPathRule {
 }
 
 // GetPathRuleBasic creates a new struct for use in unit tests.
-func GetPathRuleBasic() *network.ApplicationGatewayPathRule {
-	return &network.ApplicationGatewayPathRule{
+func GetPathRuleBasic() *n.ApplicationGatewayPathRule {
+	return &n.ApplicationGatewayPathRule{
 		Name: to.StringPtr(PathRuleNameBasic),
-		ApplicationGatewayPathRulePropertiesFormat: &network.ApplicationGatewayPathRulePropertiesFormat{
+		ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 			// Paths - Path rules of URL path map.
 			Paths: nil,
 
 			// BackendAddressPool - Backend address pool resource of URL path map path rule.
-			BackendAddressPool: &network.SubResource{
+			BackendAddressPool: &n.SubResource{
 				ID: to.StringPtr("x/y/z/" + BackendAddressPoolName2),
 			},
 
 			// BackendHTTPSettings - Backend http settings resource of URL path map path rule.
-			BackendHTTPSettings: &network.SubResource{
+			BackendHTTPSettings: &n.SubResource{
 				ID: to.StringPtr("x/y/z/BackendHTTPSettings-1"),
 			},
 
 			// RedirectConfiguration - Redirect configuration resource of URL path map path rule.
-			RedirectConfiguration: &network.SubResource{
+			RedirectConfiguration: &n.SubResource{
 				ID: to.StringPtr("x/y/z/RedirectConfiguration-1"),
 			},
 
 			// RewriteRuleSet - Rewrite rule set resource of URL path map path rule.
-			RewriteRuleSet: &network.SubResource{
+			RewriteRuleSet: &n.SubResource{
 				ID: to.StringPtr("x/y/z/RewriteRuleSet-1"),
 			},
+		},
+	}
+}
+
+// GetDefaultURLPathMap makes a default ApplicationGatewayURLPathMap.
+func GetDefaultURLPathMap() *n.ApplicationGatewayURLPathMap {
+	return &n.ApplicationGatewayURLPathMap{
+		Etag: to.StringPtr("*"),
+		Name: to.StringPtr(DefaultPathMapName),
+		ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
+			DefaultBackendAddressPool:  &n.SubResource{ID: to.StringPtr("/" + DefaultBackendPoolName)},
+			DefaultBackendHTTPSettings: &n.SubResource{ID: to.StringPtr("/" + DefaultBackendHTTPSettingsName)},
 		},
 	}
 }

--- a/pkg/tests/fixtures/paths.go
+++ b/pkg/tests/fixtures/paths.go
@@ -62,14 +62,14 @@ func GetPathRulePathBased() *network.ApplicationGatewayPathRule {
 		ApplicationGatewayPathRulePropertiesFormat: &network.ApplicationGatewayPathRulePropertiesFormat{
 			// Paths - Path rules of URL path map.
 			Paths: &[]string{
-				PathFoo + "/",
-				PathBar + "/**/*",
+				PathFoo,
+				PathBar,
 				PathBaz,
 			},
 
 			// BackendAddressPool - Backend address pool resource of URL path map path rule.
 			BackendAddressPool: &network.SubResource{
-				ID: to.StringPtr("x/y/z/BackendAddressPool-1"),
+				ID: to.StringPtr("x/y/z/" + BackendAddressPoolName1),
 			},
 
 			// BackendHTTPSettings - Backend http settings resource of URL path map path rule.
@@ -100,7 +100,7 @@ func GetPathRuleBasic() *network.ApplicationGatewayPathRule {
 
 			// BackendAddressPool - Backend address pool resource of URL path map path rule.
 			BackendAddressPool: &network.SubResource{
-				ID: to.StringPtr("x/y/z/BackendAddressPool-2"),
+				ID: to.StringPtr("x/y/z/" + BackendAddressPoolName2),
 			},
 
 			// BackendHTTPSettings - Backend http settings resource of URL path map path rule.

--- a/pkg/tests/fixtures/pools.go
+++ b/pkg/tests/fixtures/pools.go
@@ -11,6 +11,9 @@ import (
 )
 
 const (
+	// DefaultBackendPool is a string constant.
+	DefaultBackendPoolName = "defaultaddresspool"
+
 	// BackendAddressPoolName1 is a string constant.
 	BackendAddressPoolName1 = "BackendAddressPool-1"
 
@@ -29,6 +32,20 @@ const (
 	// IPAddress3 is a string constant.
 	IPAddress3 = "99.95.94.93"
 )
+
+// GetDefaultBackendPool creates a new struct for use in unit tests.
+func GetDefaultBackendPool() n.ApplicationGatewayBackendAddressPool {
+	return n.ApplicationGatewayBackendAddressPool{
+		Name: to.StringPtr(DefaultBackendPoolName),
+		ApplicationGatewayBackendAddressPoolPropertiesFormat: &n.ApplicationGatewayBackendAddressPoolPropertiesFormat{
+			BackendAddresses: &[]n.ApplicationGatewayBackendAddress{
+				{
+					IPAddress: to.StringPtr(IPAddress1),
+				},
+			},
+		},
+	}
+}
 
 // GetBackendPool1 creates a new struct for use in unit tests.
 func GetBackendPool1() n.ApplicationGatewayBackendAddressPool {

--- a/pkg/tests/fixtures/ports.go
+++ b/pkg/tests/fixtures/ports.go
@@ -1,0 +1,18 @@
+package fixtures
+
+import (
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+const (
+	// DefaultPortName is a string constant.
+	DefaultPortName = "fp-80"
+)
+
+// GetDefaultPort creates a struct used for unit testing.
+func GetDefaultPort() n.ApplicationGatewayFrontendPort {
+	return n.ApplicationGatewayFrontendPort{
+		Name: to.StringPtr(DefaultPortName),
+	}
+}

--- a/pkg/tests/fixtures/routing_rules.go
+++ b/pkg/tests/fixtures/routing_rules.go
@@ -20,7 +20,7 @@ func GetRequestRoutingRulePathBased() *network.ApplicationGatewayRequestRoutingR
 
 			// BackendAddressPool - Backend address pool resource of the application gateway.
 			BackendAddressPool: &network.SubResource{
-				ID: to.StringPtr("x/y/z/BackendAddressPool-1"),
+				ID: to.StringPtr("x/y/z/" + BackendAddressPoolName1),
 			},
 
 			// BackendHTTPSettings - Backend http settings resource of the application gateway.
@@ -61,7 +61,7 @@ func GetRequestRoutingRuleBasic() *network.ApplicationGatewayRequestRoutingRule 
 
 			// BackendAddressPool - Backend address pool resource of the application gateway.
 			BackendAddressPool: &network.SubResource{
-				ID: to.StringPtr("x/y/z/BackendAddressPool-2"),
+				ID: to.StringPtr("x/y/z/" + BackendAddressPoolName2),
 			},
 
 			// BackendHTTPSettings - Backend http settings resource of the application gateway.

--- a/pkg/tests/fixtures/routing_rules.go
+++ b/pkg/tests/fixtures/routing_rules.go
@@ -6,45 +6,50 @@
 package fixtures
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 )
 
+const (
+	// DefaultRequestRoutingRuleName is a string constant.
+	DefaultRequestRoutingRuleName = "rr-80"
+)
+
 // GetRequestRoutingRulePathBased creates a new struct for use in unit tests.
-func GetRequestRoutingRulePathBased() *network.ApplicationGatewayRequestRoutingRule {
-	return &network.ApplicationGatewayRequestRoutingRule{
+func GetRequestRoutingRulePathBased() *n.ApplicationGatewayRequestRoutingRule {
+	return &n.ApplicationGatewayRequestRoutingRule{
 		Name: to.StringPtr("RequestRoutingRule-1"),
-		ApplicationGatewayRequestRoutingRulePropertiesFormat: &network.ApplicationGatewayRequestRoutingRulePropertiesFormat{
+		ApplicationGatewayRequestRoutingRulePropertiesFormat: &n.ApplicationGatewayRequestRoutingRulePropertiesFormat{
 			// RuleType - Rule type. Possible values include: 'Basic', 'PathBasedRouting'
-			RuleType: network.PathBasedRouting,
+			RuleType: n.PathBasedRouting,
 
 			// BackendAddressPool - Backend address pool resource of the application gateway.
-			BackendAddressPool: &network.SubResource{
+			BackendAddressPool: &n.SubResource{
 				ID: to.StringPtr("x/y/z/" + BackendAddressPoolName1),
 			},
 
 			// BackendHTTPSettings - Backend http settings resource of the application gateway.
-			BackendHTTPSettings: &network.SubResource{
+			BackendHTTPSettings: &n.SubResource{
 				ID: to.StringPtr("x/y/z/BackendHTTPSettings-1"),
 			},
 
 			// HTTPListener - Http listener resource of the application gateway.
-			HTTPListener: &network.SubResource{
+			HTTPListener: &n.SubResource{
 				ID: to.StringPtr("x/y/z/HTTPListener-PathBased"),
 			},
 
 			// URLPathMap - URL path map resource of the application gateway.
-			URLPathMap: &network.SubResource{
+			URLPathMap: &n.SubResource{
 				ID: to.StringPtr("x/y/z/URLPathMap-1"),
 			},
 
 			// RewriteRuleSet - Rewrite Rule Set resource in Basic rule of the application gateway.
-			RewriteRuleSet: &network.SubResource{
+			RewriteRuleSet: &n.SubResource{
 				ID: to.StringPtr("x/y/z/RewriteRuleSet-1"),
 			},
 
 			// RedirectConfiguration - Redirect configuration resource of the application gateway.
-			RedirectConfiguration: &network.SubResource{
+			RedirectConfiguration: &n.SubResource{
 				ID: to.StringPtr("x/y/z/RedirectConfiguration-1"),
 			},
 		},
@@ -52,25 +57,25 @@ func GetRequestRoutingRulePathBased() *network.ApplicationGatewayRequestRoutingR
 }
 
 // GetRequestRoutingRuleBasic creates a new struct for use in unit tests.
-func GetRequestRoutingRuleBasic() *network.ApplicationGatewayRequestRoutingRule {
-	return &network.ApplicationGatewayRequestRoutingRule{
+func GetRequestRoutingRuleBasic() *n.ApplicationGatewayRequestRoutingRule {
+	return &n.ApplicationGatewayRequestRoutingRule{
 		Name: to.StringPtr("RequestRoutingRule-2"),
-		ApplicationGatewayRequestRoutingRulePropertiesFormat: &network.ApplicationGatewayRequestRoutingRulePropertiesFormat{
+		ApplicationGatewayRequestRoutingRulePropertiesFormat: &n.ApplicationGatewayRequestRoutingRulePropertiesFormat{
 			// RuleType - Rule type. Possible values include: 'Basic', 'PathBasedRouting'
-			RuleType: network.Basic,
+			RuleType: n.Basic,
 
 			// BackendAddressPool - Backend address pool resource of the application gateway.
-			BackendAddressPool: &network.SubResource{
+			BackendAddressPool: &n.SubResource{
 				ID: to.StringPtr("x/y/z/" + BackendAddressPoolName2),
 			},
 
 			// BackendHTTPSettings - Backend http settings resource of the application gateway.
-			BackendHTTPSettings: &network.SubResource{
+			BackendHTTPSettings: &n.SubResource{
 				ID: to.StringPtr("x/y/z/BackendHTTPSettings-2"),
 			},
 
 			// HTTPListener - Http listener resource of the application gateway.
-			HTTPListener: &network.SubResource{
+			HTTPListener: &n.SubResource{
 				ID: to.StringPtr("x/y/z/HTTPListener-Basic"),
 			},
 
@@ -78,13 +83,39 @@ func GetRequestRoutingRuleBasic() *network.ApplicationGatewayRequestRoutingRule 
 			URLPathMap: nil,
 
 			// RewriteRuleSet - Rewrite Rule Set resource in Basic rule of the application gateway.
-			RewriteRuleSet: &network.SubResource{
+			RewriteRuleSet: &n.SubResource{
 				ID: to.StringPtr("x/y/z/RewriteRuleSet-2"),
 			},
 
 			// RedirectConfiguration - Redirect configuration resource of the application gateway.
-			RedirectConfiguration: &network.SubResource{
+			RedirectConfiguration: &n.SubResource{
 				ID: to.StringPtr("x/y/z/RedirectConfiguration-2"),
+			},
+		},
+	}
+}
+
+// GetDefaultRoutingRule returns the default routing rule.
+func GetDefaultRoutingRule() *n.ApplicationGatewayRequestRoutingRule {
+	return &n.ApplicationGatewayRequestRoutingRule{
+		Name: to.StringPtr(DefaultRequestRoutingRuleName),
+		ApplicationGatewayRequestRoutingRulePropertiesFormat: &n.ApplicationGatewayRequestRoutingRulePropertiesFormat{
+			// RuleType - Rule type. Possible values include: 'Basic', 'PathBasedRouting'
+			RuleType: n.Basic,
+
+			// BackendAddressPool - Backend address pool resource of the application gateway.
+			BackendAddressPool: &n.SubResource{
+				ID: to.StringPtr("x/y/z/" + DefaultBackendPoolName),
+			},
+
+			// BackendHTTPSettings - Backend http settings resource of the application gateway.
+			BackendHTTPSettings: &n.SubResource{
+				ID: to.StringPtr("x/y/z/" + DefaultBackendHTTPSettingsName),
+			},
+
+			// HTTPListener - Http listener resource of the application gateway.
+			HTTPListener: &n.SubResource{
+				ID: to.StringPtr("x/y/z/" + DefaultHTTPListenerName),
 			},
 		},
 	}

--- a/pkg/tests/fixtures/targets.go
+++ b/pkg/tests/fixtures/targets.go
@@ -22,19 +22,32 @@ const (
 
 	// PathBaz is a URL path.
 	PathBaz = "/baz"
+
+	// PathForbidden is a URL path.
+	PathForbidden = "/forbidden-path"
 )
 
-// GetProhibitedTargets creates a new struct for use in unit tests.
-func GetProhibitedTargets() []*ptv1.AzureIngressProhibitedTarget {
+// GetAzureIngressProhibitedTargets creates a new struct for use in unit tests.
+func GetAzureIngressProhibitedTargets() []*ptv1.AzureIngressProhibitedTarget {
 	return []*ptv1.AzureIngressProhibitedTarget{
 		{
 			Spec: ptv1.AzureIngressProhibitedTargetSpec{
-				IP:       IPAddress1,
 				Hostname: tests.Host,
-				Port:     443,
 				Paths: []string{
 					PathFox,
 					PathBar,
+				},
+			},
+		},
+		{
+			Spec: ptv1.AzureIngressProhibitedTargetSpec{
+				Hostname: tests.OtherHost,
+			},
+		},
+		{
+			Spec: ptv1.AzureIngressProhibitedTargetSpec{
+				Paths: []string{
+					PathForbidden,
 				},
 			},
 		},


### PR DESCRIPTION
This PR introduces (a partial implementation of) brownfield deployment.
The strategy is described in [a proposal here](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/proposals/config_ownership_crd.md).


### Overview 
The overall goal is to define certain targets (think `domain/url`) via the `AzureIngressProhibitedTarget` CRD that are blacklisted, which AGIC will not mutate or overwrite. These will be retained as they exist in App Gateway.

This would allow an administrator to *manually* configure some settings on Application Gateway, while allowing the ingress controller to set others.

### Changes
  - this PR implements target blacklist for backend pools only
  - using feature flag to guard these changes (until they are fully fleshed out and tested): `cbCtx.EnvVariables.EnableBrownfieldDeployment`
  - adding to package `brownfield`:
    - `GetExistingBlacklistedPools` - given a list of existing backend pools (from App Gateway) - get the list of those AGIC should retain as part of the config and should not change
    - `MergePools` - merges list of blacklisted and newly created pools into a new one - to be applied to App Gateway


### Overall strategy:

1. Get the list of existing backend pools from App Gateway
2. From the existing list - get the ones blacklisted - these we will not change - will retain as-is
3. Filter Ingress resource to HTTP rules AGIC is allowed to manage
4. Construct backend pools for managed targets only
5. Merge the output 2 and 4 - apply onto App Gateway