### PR TITLE
ingress: Add sorter for deterministic ARM config

### DIFF
--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -8,13 +8,14 @@ package k8scontext
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/eapache/channels"
 	"github.com/golang/glog"
-	v1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
+	"github.com/knative/pkg/apis/istio/v1alpha3"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -30,6 +31,7 @@ import (
 	istio_versioned "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned"
 	istio_externalversions "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/informers/externalversions"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
@@ -233,6 +235,10 @@ func (c *Context) ListHTTPIngresses() []*v1beta1.Ingress {
 			ingressList = append(ingressList, ingress)
 		}
 	}
+	// Sorting the return list ensures that the iterations over this list and
+	// subsequently created structs have deterministic order. This increases
+	// cache hits, and lowers the load on ARM.
+	sort.Sort(sorter.ByIngressUID(ingressList))
 	return ingressList
 }
 

--- a/pkg/sorter/ingress.go
+++ b/pkg/sorter/ingress.go
@@ -1,0 +1,23 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package sorter
+
+import (
+	"k8s.io/api/extensions/v1beta1"
+)
+
+// ByIngressUID is a facility to sort slices of Kubernetes Ingress by their UID
+type ByIngressUID []*v1beta1.Ingress
+
+func (a ByIngressUID) Len() int      { return len(a) }
+func (a ByIngressUID) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ByIngressUID) Less(i, j int) bool {
+	return getIngressUID(a[i]) < getIngressUID(a[j])
+}
+
+func getIngressUID(ingress *v1beta1.Ingress) string {
+	return string(ingress.UID)
+}


### PR DESCRIPTION
This PR ensures the results of `k8scontext.ListHTTPIngresses()` (a list of Kubernetes Ingress resources) is sorted.

This increases cache hits, lowers the number of times we have to post new config to ARM.