### PR TITLE
context: Log found Managed/Prohibited Targets within the Lister functions

### DIFF
--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -41,21 +41,7 @@ func (c AppGwIngressController) Process(event eventqueue.QueuedEvent) error {
 		IstioGateways:     c.k8sContext.ListIstioGateways(),
 		EnvVariables:      environment.GetEnv(),
 	}
-	{
-		var managedTargets []string
-		for _, target := range cbCtx.ManagedTargets {
-			managedTargets = append(managedTargets, fmt.Sprintf("%s/%s", target.Namespace, target.Name))
-		}
-		glog.V(5).Infof("AzureIngressManagedTargets: %+v", strings.Join(managedTargets, ","))
-	}
-	{
-		var prohibitedTargets []string
-		for _, target := range cbCtx.ProhibitedTargets {
-			prohibitedTargets = append(prohibitedTargets, fmt.Sprintf("%s/%s", target.Namespace, target.Name))
-		}
 
-		glog.V(5).Infof("AzureIngressProhibitedTargets: %+v", strings.Join(prohibitedTargets, ","))
-	}
 	if cbCtx.EnvVariables.EnableIstioIntegration == "true" {
 		var gatewaysInfo []string
 		for _, gateway := range cbCtx.IstioGateways {

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -8,6 +8,7 @@ package k8scontext
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
@@ -241,6 +242,13 @@ func (c *Context) ListAzureIngressManagedTargets() []*managedv1.AzureIngressMana
 	for _, obj := range c.Caches.AzureIngressManagedLocation.List() {
 		targets = append(targets, obj.(*managedv1.AzureIngressManagedTarget))
 	}
+
+	var managedTargets []string
+	for _, target := range targets {
+		managedTargets = append(managedTargets, fmt.Sprintf("%s/%s", target.Namespace, target.Name))
+	}
+	glog.V(5).Infof("AzureIngressManagedTargets: %+v", strings.Join(managedTargets, ","))
+
 	return targets
 }
 
@@ -250,6 +258,14 @@ func (c *Context) ListAzureProhibitedTargets() []*prohibitedv1.AzureIngressProhi
 	for _, obj := range c.Caches.AzureIngressProhibitedLocation.List() {
 		targets = append(targets, obj.(*prohibitedv1.AzureIngressProhibitedTarget))
 	}
+
+	var prohibitedTargets []string
+	for _, target := range targets {
+		prohibitedTargets = append(prohibitedTargets, fmt.Sprintf("%s/%s", target.Namespace, target.Name))
+	}
+
+	glog.V(5).Infof("AzureIngressProhibitedTargets: %+v", strings.Join(prohibitedTargets, ","))
+
 	return targets
 }
 

--- a/pkg/tests/fixtures/paths.go
+++ b/pkg/tests/fixtures/paths.go
@@ -12,10 +12,10 @@ import (
 
 const (
 	// PathMapName is a string constant.
-	PathMapName       = "URLPathMap-1"
+	PathMapName = "URLPathMap-1"
 
 	// PathRuleName is a string constant.
-	PathRuleName      = "PathRule-1"
+	PathRuleName = "PathRule-1"
 
 	// PathRuleNameBasic is a string constant.
 	PathRuleNameBasic = "PathRule-Basic"

--- a/pkg/tests/fixtures/pools.go
+++ b/pkg/tests/fixtures/pools.go
@@ -20,7 +20,6 @@ const (
 	// BackendAddressPoolName3 is a string constant.
 	BackendAddressPoolName3 = "BackendAddressPool-3"
 
-
 	// IPAddress1 is a string constant.
 	IPAddress1 = "1.2.3.4"
 
@@ -29,7 +28,6 @@ const (
 
 	// IPAddress3 is a string constant.
 	IPAddress3 = "99.95.94.93"
-
 )
 
 // GetBackendPool1 creates a new struct for use in unit tests.


### PR DESCRIPTION
This PR continues the trend of cleaning up `process.go` and moves the logging of `AzureIngressManagedTargets` and `AzureIngressProhibitedTargets` into the appropriate Lister functions within `context.go`

These log statements are at verbose level and for debug purposes.