### PR TITLE
Log App Gateway config to file w/ feature flag APPGW_ENABLE_SAVE_CONF

### DIFF
--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -90,13 +90,13 @@ func (c AppGwIngressController) Process(event eventqueue.QueuedEvent) error {
 	if err != nil {
 		// Reset cache
 		c.configCache = nil
-		configJSON, _ := c.dumpSanitizedJSON(&appGw)
+		configJSON, _ := c.dumpSanitizedJSON(&appGw, cbCtx)
 		glog.Errorf("Failed applying App Gwy configuration: %s -- %s", err, string(configJSON))
 		return err
 	}
 	// Wait until deployment finshes and save the error message
 	err = appGwFuture.WaitForCompletionRef(ctx, c.appGwClient.BaseClient.Client)
-	configJSON, _ := c.dumpSanitizedJSON(&appGw)
+	configJSON, _ := c.dumpSanitizedJSON(&appGw, cbCtx)
 	glog.V(5).Info(string(configJSON))
 
 	// We keep this at log level 1 to show some heartbeat in the logs. Without this it is way too quiet.

--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -84,19 +84,21 @@ func (c AppGwIngressController) Process(event eventqueue.QueuedEvent) error {
 	glog.V(3).Info("BEGIN ApplicationGateway deployment")
 	defer glog.V(3).Info("END ApplicationGateway deployment")
 
+	logToFile := cbCtx.EnvVariables.EnableSaveConfigToFile == "true"
+
 	deploymentStart := time.Now()
 	// Initiate deployment
 	appGwFuture, err := c.appGwClient.CreateOrUpdate(ctx, c.appGwIdentifier.ResourceGroup, c.appGwIdentifier.AppGwName, *generatedAppGw)
 	if err != nil {
 		// Reset cache
 		c.configCache = nil
-		configJSON, _ := c.dumpSanitizedJSON(&appGw, cbCtx)
+		configJSON, _ := c.dumpSanitizedJSON(&appGw, logToFile)
 		glog.Errorf("Failed applying App Gwy configuration: %s -- %s", err, string(configJSON))
 		return err
 	}
 	// Wait until deployment finshes and save the error message
 	err = appGwFuture.WaitForCompletionRef(ctx, c.appGwClient.BaseClient.Client)
-	configJSON, _ := c.dumpSanitizedJSON(&appGw, cbCtx)
+	configJSON, _ := c.dumpSanitizedJSON(&appGw, logToFile)
 	glog.V(5).Info(string(configJSON))
 
 	// We keep this at log level 1 to show some heartbeat in the logs. Without this it is way too quiet.

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -39,6 +39,9 @@ const (
 
 	// EnableIstioIntegrationVarName is a feature flag enabling observation of Istio specific CRDs
 	EnableIstioIntegrationVarName = "APPGW_ENABLE_ISTIO_INTEGRATION"
+
+	// EnableSaveConfigToFileVarName is a feature flag, which enables saving the App Gwy config to disk.
+	EnableSaveConfigToFileVarName = "APPGW_ENABLE_SAVE_CONFIG_TO_FILE"
 )
 
 // EnvVariables is a struct storing values for environment variables.
@@ -52,6 +55,7 @@ type EnvVariables struct {
 	VerbosityLevel             string
 	EnableBrownfieldDeployment string
 	EnableIstioIntegration     string
+	EnableSaveConfigToFile     string
 }
 
 // GetEnv returns values for defined environment variables for Ingress Controller.
@@ -66,6 +70,7 @@ func GetEnv() EnvVariables {
 		VerbosityLevel:             os.Getenv(VerbosityLevelVarName),
 		EnableBrownfieldDeployment: os.Getenv(EnableBrownfieldDeploymentVarName),
 		EnableIstioIntegration:     os.Getenv(EnableIstioIntegrationVarName),
+		EnableSaveConfigToFile:     os.Getenv(EnableSaveConfigToFileVarName),
 	}
 
 	return env

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -39,6 +39,9 @@ fi
 # Print Version
 ./bin/appgw-ingress --version || true
 
+# Feature Flags
+export APPGW_ENABLE_SAVE_CONFIG_TO_FILE="true"
+
 # Run
 ./bin/appgw-ingress \
     --in-cluster=false \


### PR DESCRIPTION
This PR introduces the ability to log App Gateway config to a file. 
This is enabled with env variable `APPGW_ENABLE_SAVE_CONF="true"`

The Gateway config is sanitized:
  - it will *not* include secrets
  - the etags are deliberately kept for debugging

Motivation for this change:  it proves very helpful to see actual config logged, perhaps diff between different posts to see what has changed etc.