### PR TITLE
pipelines: merge with current index file in helm repo

### DIFF
--- a/helm/release.sh
+++ b/helm/release.sh
@@ -24,7 +24,7 @@ helm package ingress-azure --version "$TAG"
 
 INDEX_FILE_URL="$HELM_REPO_URL/index.yaml"
 echo " - check if helm index [$INDEX_FILE_URL] exists in helm repo [$HELM_REPO_URL]"
-status_code=$(curl -s --http1.0 --head $INDEX_FILE_URL | head -n 1 | awk '{print $2}')
+status_code=$(curl -s --head $INDEX_FILE_URL | head -n 1 | awk '{print $2}')
 
 if [ $status_code -eq "200" ]; then
   echo " - get current helm index from helm repo [$HELM_REPO_URL]"

--- a/helm/release.sh
+++ b/helm/release.sh
@@ -4,6 +4,9 @@ set -eauo pipefail
 
 TAG=${1:-$(git describe --abbrev=0 --tags)}
 
+HELM_GIT_REPO_URL="https://azure.github.io/application-gateway-kubernetes-ingress/helm"
+HELM_REPO_URL=${2:-$HELM_GIT_REPO_URL}
+
 echo " - tagging with [$TAG]"
 TGZ_FILE=(ingress-azure-$TAG.tgz)
 
@@ -19,8 +22,20 @@ cat ingress-azure/values-template.yaml | sed "s/XXVERSIONXX/$TAG/g" > ingress-az
 echo " - running helm package"
 helm package ingress-azure --version "$TAG"
 
-echo " - updating helm repo index"
-helm repo index . --url https://azure.github.io/application-gateway-kubernetes-ingress/helm
+INDEX_FILE_URL="$HELM_REPO_URL/index.yaml"
+echo " - check if helm index [$INDEX_FILE_URL] exists in helm repo [$HELM_REPO_URL]"
+status_code=$(curl -s --http1.0 --head $INDEX_FILE_URL | head -n 1 | awk '{print $2}')
+
+if [ $status_code -eq "200" ]; then
+  echo " - get current helm index from helm repo [$HELM_REPO_URL]"
+  curl -s -S $INDEX_FILE_URL -o previous_index.yaml > /dev/null
+
+  echo " - merging with existing helm repo index"
+  helm repo index . --url $HELM_REPO_URL --merge previous_index.yaml
+else
+  echo " - creating a new helm repo index"
+  helm repo index . --url $HELM_REPO_URL
+fi
 
 
 echo " - done!"


### PR DESCRIPTION
Since, we are moving helm `index` and `gz` files to storage, they will not be pushed to github.

In future, when we run the `helm repo index` command, it will not take care of the `gz` present on the storage and will omit them in the new index file.

Solution is to pull the old index file and merge using `helm repo index --merge`