### PR TITLE
Reuse ConfigBuilderContext to simplify

### DIFF
--- a/pkg/appgw/certificates.go
+++ b/pkg/appgw/certificates.go
@@ -20,10 +20,10 @@ import (
 )
 
 // getSslCertificates obtains all SSL Certificates for the given Ingress object.
-func (c *appGwConfigBuilder) getSslCertificates(ingressList []*v1beta1.Ingress) *[]n.ApplicationGatewaySslCertificate {
+func (c *appGwConfigBuilder) getSslCertificates(cbCtx *ConfigBuilderContext) *[]n.ApplicationGatewaySslCertificate {
 	secretIDCertificateMap := make(map[secretIdentifier]*string)
 
-	for _, ingress := range ingressList {
+	for _, ingress := range cbCtx.IngressList {
 		for k, v := range c.getSecretToCertificateMap(ingress) {
 			secretIDCertificateMap[k] = v
 		}

--- a/pkg/appgw/frontend_ports.go
+++ b/pkg/appgw/frontend_ports.go
@@ -10,14 +10,13 @@ import (
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
-	"k8s.io/api/extensions/v1beta1"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 )
 
-func (c *appGwConfigBuilder) getFrontendPorts(ingressList []*v1beta1.Ingress) *[]n.ApplicationGatewayFrontendPort {
+func (c *appGwConfigBuilder) getFrontendPorts(cbCtx *ConfigBuilderContext) *[]n.ApplicationGatewayFrontendPort {
 	allPorts := make(map[int32]interface{})
-	for _, ingress := range ingressList {
+	for _, ingress := range cbCtx.IngressList {
 		fePorts, _ := c.processIngressRules(ingress)
 		for port := range fePorts {
 			allPorts[port] = nil

--- a/pkg/appgw/frontend_ports_test.go
+++ b/pkg/appgw/frontend_ports_test.go
@@ -22,7 +22,11 @@ var _ = Describe("Process ingress rules", func() {
 			tests.NewIngressFixture(),
 		}
 
-		ports := cb.getFrontendPorts(ingressList)
+		cbCtx := ConfigBuilderContext{
+			IngressList: ingressList,
+		}
+
+		ports := cb.getFrontendPorts(&cbCtx)
 
 		It("should have correct count of ports", func() {
 			Expect(len(*ports)).To(Equal(2))

--- a/pkg/appgw/http_listeners.go
+++ b/pkg/appgw/http_listeners.go
@@ -7,14 +7,14 @@ package appgw
 
 func (c *appGwConfigBuilder) Listeners(cbCtx *ConfigBuilderContext) error {
 
-	c.appGw.SslCertificates = c.getSslCertificates(cbCtx.IngressList)
-	c.appGw.FrontendPorts = c.getFrontendPorts(cbCtx.IngressList)
+	c.appGw.SslCertificates = c.getSslCertificates(cbCtx)
+	c.appGw.FrontendPorts = c.getFrontendPorts(cbCtx)
 	c.appGw.HTTPListeners, _ = c.getListeners(cbCtx)
 
 	// App Gateway Rules can be configured to redirect HTTP traffic to HTTPS URLs.
 	// In this step here we create the redirection configurations. These configs are attached to request routing rules
 	// in the RequestRoutingRules step, which must be executed after Listeners.
-	c.appGw.RedirectConfigurations = c.getRedirectConfigurations(cbCtx.IngressList)
+	c.appGw.RedirectConfigurations = c.getRedirectConfigurations(cbCtx)
 
 	return nil
 }

--- a/pkg/appgw/redirects.go
+++ b/pkg/appgw/redirects.go
@@ -8,19 +8,19 @@ package appgw
 import (
 	"sort"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
-	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 )
 
 // getRedirectConfigurations creates App Gateway redirect configuration based on Ingress annotations.
-func (c *appGwConfigBuilder) getRedirectConfigurations(ingressList []*v1beta1.Ingress) *[]n.ApplicationGatewayRedirectConfiguration {
+func (c *appGwConfigBuilder) getRedirectConfigurations(cbCtx *ConfigBuilderContext) *[]n.ApplicationGatewayRedirectConfiguration {
 	var redirectConfigs []n.ApplicationGatewayRedirectConfiguration
 
 	// Iterate over all possible Listeners (generated from the K8s Ingress configurations)
-	for listenerID, listenerConfig := range c.getListenerConfigs(ingressList) {
+	for listenerID, listenerConfig := range c.getListenerConfigs(cbCtx.IngressList) {
 		isHTTPS := listenerConfig.Protocol == n.HTTPS
 		// What if multiple namespaces have a redirect configured?
 		hasSslRedirect := listenerConfig.SslRedirectConfigurationName != ""

--- a/pkg/appgw/redirects_test.go
+++ b/pkg/appgw/redirects_test.go
@@ -8,13 +8,14 @@ package appgw
 import (
 	"fmt"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
 var _ = Describe("Test SSL Redirect Annotations", func() {
@@ -47,7 +48,10 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 	Context("Test RequestRoutingRules with TLS and with SSL Redirect Annotation", func() {
 		ingress := tests.NewIngressFixture()
 		ingressList := []*v1beta1.Ingress{ingress}
-		actualRedirects := cb.getRedirectConfigurations(ingressList)
+		cbCtx := ConfigBuilderContext{
+			IngressList: ingressList,
+		}
+		actualRedirects := cb.getRedirectConfigurations(&cbCtx)
 		expectedRedirect := n.ApplicationGatewayRedirectConfiguration{
 			ApplicationGatewayRedirectConfigurationPropertiesFormat: &n.ApplicationGatewayRedirectConfigurationPropertiesFormat{
 				RedirectType: "Permanent",
@@ -93,7 +97,10 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		ingress := tests.NewIngressFixture()
 		ingress.Spec.TLS = nil
 		ingressList := []*v1beta1.Ingress{ingress}
-		actualRedirects := cb.getRedirectConfigurations(ingressList)
+		cbCtx := ConfigBuilderContext{
+			IngressList: ingressList,
+		}
+		actualRedirects := cb.getRedirectConfigurations(&cbCtx)
 
 		// Run this to link the listeners and the redirect config
 		_, actualListeners := cb.processIngressRules(ingress)
@@ -115,7 +122,10 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		ingress := tests.NewIngressFixture()
 		delete(ingress.Annotations, annotations.SslRedirectKey)
 		ingressList := []*v1beta1.Ingress{ingress}
-		actualRedirects := cb.getRedirectConfigurations(ingressList)
+		cbCtx := ConfigBuilderContext{
+			IngressList: ingressList,
+		}
+		actualRedirects := cb.getRedirectConfigurations(&cbCtx)
 
 		// Run this to link the listeners and the redirect config
 		_, actualListeners := cb.processIngressRules(ingress)


### PR DESCRIPTION
This is a small chunk from https://github.com/Azure/application-gateway-kubernetes-ingress/pull/345

Moving this here so https://github.com/Azure/application-gateway-kubernetes-ingress/pull/345 can thin out a bit.

In this PR we reuse `ConfigBuilderContext` instead of passing the` Ingres`s list around (which is a subset of `ConfigBuilderContext` struct)