### PR TITLE
Prune Ingress Rules based on  AzureIngress{Managed,Prohibited}Target CRDs

### DIFF
--- a/pkg/appgw/types.go
+++ b/pkg/appgw/types.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 
-	mtv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressmanagedtarget/v1"
 	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
 )
 
@@ -20,7 +19,6 @@ import (
 type ConfigBuilderContext struct {
 	IngressList          []*v1beta1.Ingress
 	ServiceList          []*v1.Service
-	ManagedTargets       []*mtv1.AzureIngressManagedTarget
 	ProhibitedTargets    []*ptv1.AzureIngressProhibitedTarget
 	EnvVariables         environment.EnvVariables
 	IstioGateways        []*v1alpha3.Gateway

--- a/pkg/appgw/types.go
+++ b/pkg/appgw/types.go
@@ -1,3 +1,8 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
 package appgw
 
 import (

--- a/pkg/brownfield/brownfield_suite_test.go
+++ b/pkg/brownfield/brownfield_suite_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestAppgw(t *testing.T) {
+func TestApplicationGatewayKubernetesIngress(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Brownfield Deployment Tests")
+	RunSpecs(t, "ApplicationGatewayKubernetesIngress Suite")
 }

--- a/pkg/brownfield/brownfield_test.go
+++ b/pkg/brownfield/brownfield_test.go
@@ -1,0 +1,18 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAppgw(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Brownfield Deployment Tests")
+}

--- a/pkg/brownfield/ingress.go
+++ b/pkg/brownfield/ingress.go
@@ -62,15 +62,12 @@ func PruneIngressRules(ing *v1beta1.Ingress, prohibitedTargets []*ptv1.AzureIngr
 
 // canManage determines whether the target identified by the given host & path should be managed by AGIC.
 func canManage(host string, path *string, blacklist TargetBlacklist) bool {
-	target := Target{
-		Hostname: host,
-	}
-	if path != nil {
-		target.Path = path
-	}
-
 	if blacklist == nil || len(*blacklist) == 0 {
 		return true
+	}
+	target := Target{Hostname: host}
+	if path != nil {
+		target.Path = path
 	}
 	targetJSON, _ := target.MarshalJSON()
 	if target.IsBlacklisted(blacklist) {

--- a/pkg/brownfield/ingress.go
+++ b/pkg/brownfield/ingress.go
@@ -62,7 +62,13 @@ func PruneIngressRules(ing *v1beta1.Ingress, prohibitedTargets []*ptv1.AzureIngr
 
 // canManage determines whether the target identified by the given host & path should be managed by AGIC.
 func canManage(host string, path *string, blacklist TargetBlacklist) bool {
-	target := rulePathToTarget(host, path)
+	target := Target{
+		Hostname: host,
+	}
+	if path != nil {
+		target.Path = path
+	}
+
 	if blacklist == nil || len(*blacklist) == 0 {
 		return true
 	}

--- a/pkg/brownfield/ingress.go
+++ b/pkg/brownfield/ingress.go
@@ -12,8 +12,8 @@ import (
 	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
 )
 
-// PruneIngressRules mutates the ingress struct to remove targets, which AGIC should not create configuration for.
-func PruneIngressRules(ing *v1beta1.Ingress, prohibitedTargets []*ptv1.AzureIngressProhibitedTarget, managedTargets []*mtv1.AzureIngressManagedTarget) {
+// PruneIngressRules transforms the given ingress struct to remove targets, which AGIC should not create configuration for.
+func PruneIngressRules(ing *v1beta1.Ingress, prohibitedTargets []*ptv1.AzureIngressProhibitedTarget, managedTargets []*mtv1.AzureIngressManagedTarget) []v1beta1.IngressRule {
 	blacklist := GetTargetBlacklist(prohibitedTargets)
 	whitelist := GetTargetWhitelist(managedTargets)
 
@@ -49,5 +49,5 @@ func PruneIngressRules(ing *v1beta1.Ingress, prohibitedTargets []*ptv1.AzureIngr
 		}
 	}
 
-	ing.Spec.Rules = rules
+	return rules
 }

--- a/pkg/brownfield/ingress.go
+++ b/pkg/brownfield/ingress.go
@@ -1,0 +1,53 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"k8s.io/api/extensions/v1beta1"
+
+	mtv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressmanagedtarget/v1"
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+)
+
+// PruneIngressRules mutates the ingress struct to remove targets, which AGIC should not create configuration for.
+func PruneIngressRules(ing *v1beta1.Ingress, prohibitedTargets []*ptv1.AzureIngressProhibitedTarget, managedTargets []*mtv1.AzureIngressManagedTarget) {
+	blacklist := GetTargetBlacklist(prohibitedTargets)
+	whitelist := GetTargetWhitelist(managedTargets)
+
+	var rules []v1beta1.IngressRule
+
+	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
+
+		if rule.HTTP.Paths == nil {
+			if shouldManage(rule.Host, nil, blacklist, whitelist) {
+				rules = append(rules, rule)
+			}
+			continue // to next rule
+		}
+
+		newRule := v1beta1.IngressRule{
+			Host: rule.Host,
+			IngressRuleValue: v1beta1.IngressRuleValue{
+				HTTP: &v1beta1.HTTPIngressRuleValue{
+					Paths: []v1beta1.HTTPIngressPath{},
+				},
+			},
+		}
+		for _, path := range rule.HTTP.Paths {
+			if shouldManage(rule.Host, &path.Path, blacklist, whitelist) {
+				newRule.HTTP.Paths = append(newRule.HTTP.Paths, path)
+			}
+		}
+		if len(newRule.HTTP.Paths) > 0 {
+			rules = append(rules, newRule)
+		}
+	}
+
+	ing.Spec.Rules = rules
+}

--- a/pkg/brownfield/ingress.go
+++ b/pkg/brownfield/ingress.go
@@ -6,16 +6,24 @@
 package brownfield
 
 import (
+	"github.com/golang/glog"
 	"k8s.io/api/extensions/v1beta1"
 
-	mtv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressmanagedtarget/v1"
 	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
 )
 
 // PruneIngressRules transforms the given ingress struct to remove targets, which AGIC should not create configuration for.
-func PruneIngressRules(ing *v1beta1.Ingress, prohibitedTargets []*ptv1.AzureIngressProhibitedTarget, managedTargets []*mtv1.AzureIngressManagedTarget) []v1beta1.IngressRule {
+func PruneIngressRules(ing *v1beta1.Ingress, prohibitedTargets []*ptv1.AzureIngressProhibitedTarget) []v1beta1.IngressRule {
+
+	if ing.Spec.Rules == nil || len(ing.Spec.Rules) == 0 {
+		return ing.Spec.Rules
+	}
+
 	blacklist := GetTargetBlacklist(prohibitedTargets)
-	whitelist := GetTargetWhitelist(managedTargets)
+
+	if blacklist == nil || len(*blacklist) == 0 {
+		return ing.Spec.Rules
+	}
 
 	var rules []v1beta1.IngressRule
 
@@ -25,7 +33,7 @@ func PruneIngressRules(ing *v1beta1.Ingress, prohibitedTargets []*ptv1.AzureIngr
 		}
 
 		if rule.HTTP.Paths == nil {
-			if shouldManage(rule.Host, nil, blacklist, whitelist) {
+			if canManage(rule.Host, nil, blacklist) {
 				rules = append(rules, rule)
 			}
 			continue // to next rule
@@ -40,7 +48,7 @@ func PruneIngressRules(ing *v1beta1.Ingress, prohibitedTargets []*ptv1.AzureIngr
 			},
 		}
 		for _, path := range rule.HTTP.Paths {
-			if shouldManage(rule.Host, &path.Path, blacklist, whitelist) {
+			if canManage(rule.Host, &path.Path, blacklist) {
 				newRule.HTTP.Paths = append(newRule.HTTP.Paths, path)
 			}
 		}
@@ -50,4 +58,19 @@ func PruneIngressRules(ing *v1beta1.Ingress, prohibitedTargets []*ptv1.AzureIngr
 	}
 
 	return rules
+}
+
+// canManage determines whether the target identified by the given host & path should be managed by AGIC.
+func canManage(host string, path *string, blacklist TargetBlacklist) bool {
+	target := rulePathToTarget(host, path)
+	if blacklist == nil || len(*blacklist) == 0 {
+		return true
+	}
+	targetJSON, _ := target.MarshalJSON()
+	if target.IsBlacklisted(blacklist) {
+		glog.V(5).Infof("Target is in blacklist. Ignore: %s", string(targetJSON))
+		return false
+	}
+	glog.V(5).Infof("Target is not in blacklist. Keep: %s", string(targetJSON))
+	return true
 }

--- a/pkg/brownfield/ingress_test.go
+++ b/pkg/brownfield/ingress_test.go
@@ -1,0 +1,133 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
+)
+
+var _ = Describe("test pruning Ingress based on white/white lists", func() {
+
+	Context("Test PruneIngressRules()", func() {
+		prohibited := fixtures.GetProhibitedTargets()
+		managed := fixtures.GetManagedTargets()
+
+		ingress := v1beta1.Ingress{
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						// Rule with no Paths
+						Host: tests.OtherHost,
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{},
+						},
+					},
+					{
+						// Rule with Paths
+						Host: tests.Host,
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: fixtures.PathFoo,
+										Backend: v1beta1.IngressBackend{
+											ServiceName: tests.ServiceName,
+											ServicePort: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 80,
+											},
+										},
+									},
+									{
+										Path: fixtures.PathFox,
+										Backend: v1beta1.IngressBackend{
+											ServiceName: tests.ServiceName,
+											ServicePort: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 443,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		PruneIngressRules(&ingress, prohibited, managed)
+
+		expected := v1beta1.Ingress{
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						// Should have kept the rule with no Paths
+						Host: tests.OtherHost,
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{},
+						},
+					},
+					{
+						// Should have kept one of the Paths of this Rule
+						Host: tests.Host,
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: fixtures.PathFoo,
+										Backend: v1beta1.IngressBackend{
+											ServiceName: tests.ServiceName,
+											ServicePort: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 80,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		It("should have trimmed the ingress rules to what AGIC is allowed to manage", func() {
+			Expect(ingress.Spec.Rules).To(Equal(expected.Spec.Rules))
+		})
+	})
+
+	Context("Test shouldManage()", func() {
+		blacklist := []Target{{
+			Hostname: tests.Host,
+			Port:     80,
+			Path:     to.StringPtr(fixtures.PathFox),
+		}}
+		whitelist := []Target{{
+			Hostname: tests.Host,
+			Port:     8090,
+			Path:     to.StringPtr(fixtures.PathBaz),
+		}}
+
+		It("should have properly identified the ingress rules AGIC is NOT allowed to manage", func() {
+			actual := shouldManage(tests.Host, to.StringPtr(fixtures.PathFox), &blacklist, &whitelist)
+			Expect(actual).To(BeFalse())
+		})
+
+		It("should have properly identified the ingress rules AGIC is allowed to manage", func() {
+			actual := shouldManage(tests.Host, to.StringPtr(fixtures.PathBaz), &blacklist, &whitelist)
+			Expect(actual).To(BeTrue())
+		})
+	})
+
+})

--- a/pkg/brownfield/ingress_test.go
+++ b/pkg/brownfield/ingress_test.go
@@ -109,7 +109,6 @@ var _ = Describe("test pruning Ingress based on white/white lists", func() {
 	Context("Test canManage()", func() {
 		blacklist := []Target{{
 			Hostname: tests.Host,
-			Port:     80,
 			Path:     to.StringPtr(fixtures.PathFox),
 		}}
 

--- a/pkg/brownfield/ingress_test.go
+++ b/pkg/brownfield/ingress_test.go
@@ -66,7 +66,7 @@ var _ = Describe("test pruning Ingress based on white/white lists", func() {
 			},
 		}
 
-		PruneIngressRules(&ingress, prohibited, managed)
+		actualRules := PruneIngressRules(&ingress, prohibited, managed)
 
 		expected := v1beta1.Ingress{
 			Spec: v1beta1.IngressSpec{
@@ -103,7 +103,7 @@ var _ = Describe("test pruning Ingress based on white/white lists", func() {
 		}
 
 		It("should have trimmed the ingress rules to what AGIC is allowed to manage", func() {
-			Expect(ingress.Spec.Rules).To(Equal(expected.Spec.Rules))
+			Expect(actualRules).To(Equal(expected.Spec.Rules))
 		})
 	})
 

--- a/pkg/brownfield/ingress_test.go
+++ b/pkg/brownfield/ingress_test.go
@@ -20,7 +20,6 @@ var _ = Describe("test pruning Ingress based on white/white lists", func() {
 
 	Context("Test PruneIngressRules()", func() {
 		prohibited := fixtures.GetProhibitedTargets()
-		managed := fixtures.GetManagedTargets()
 
 		ingress := v1beta1.Ingress{
 			Spec: v1beta1.IngressSpec{
@@ -66,7 +65,7 @@ var _ = Describe("test pruning Ingress based on white/white lists", func() {
 			},
 		}
 
-		actualRules := PruneIngressRules(&ingress, prohibited, managed)
+		actualRules := PruneIngressRules(&ingress, prohibited)
 
 		expected := v1beta1.Ingress{
 			Spec: v1beta1.IngressSpec{
@@ -107,25 +106,20 @@ var _ = Describe("test pruning Ingress based on white/white lists", func() {
 		})
 	})
 
-	Context("Test shouldManage()", func() {
+	Context("Test canManage()", func() {
 		blacklist := []Target{{
 			Hostname: tests.Host,
 			Port:     80,
 			Path:     to.StringPtr(fixtures.PathFox),
 		}}
-		whitelist := []Target{{
-			Hostname: tests.Host,
-			Port:     8090,
-			Path:     to.StringPtr(fixtures.PathBaz),
-		}}
 
 		It("should have properly identified the ingress rules AGIC is NOT allowed to manage", func() {
-			actual := shouldManage(tests.Host, to.StringPtr(fixtures.PathFox), &blacklist, &whitelist)
+			actual := canManage(tests.Host, to.StringPtr(fixtures.PathFox), &blacklist)
 			Expect(actual).To(BeFalse())
 		})
 
 		It("should have properly identified the ingress rules AGIC is allowed to manage", func() {
-			actual := shouldManage(tests.Host, to.StringPtr(fixtures.PathBaz), &blacklist, &whitelist)
+			actual := canManage(tests.Host, to.StringPtr(fixtures.PathBaz), &blacklist)
 			Expect(actual).To(BeTrue())
 		})
 	})

--- a/pkg/brownfield/targets.go
+++ b/pkg/brownfield/targets.go
@@ -40,6 +40,9 @@ func (t Target) IsBlacklisted(blacklist *[]Target) bool {
 
 		pathIsSame := strings.ToLower(targetPath) == strings.ToLower(blacklistPath)
 
+		// With this version we keep things as simple as possible: match host and exact path to determine
+		// whether given target is in the blacklist. Ideally this would be URL Path set overlap operation,
+		// which we deliberately leave for a later time.
 		if hostIsSame && pathIsSame {
 			return true // Found it
 		}

--- a/pkg/brownfield/targets.go
+++ b/pkg/brownfield/targets.go
@@ -38,7 +38,7 @@ func (t Target) IsBlacklisted(blacklist *[]Target) bool {
 			blacklistPath = *blTarget.Path
 		}
 
-		pathIsSame := strings.ToLower(targetPath) == strings.ToLower(blacklistPath)
+		pathIsSame := blTarget.Path == "" || strings.ToLower(targetPath) == strings.ToLower(blacklistPath)
 
 		// With this version we keep things as simple as possible: match host and exact path to determine
 		// whether given target is in the blacklist. Ideally this would be URL Path set overlap operation,

--- a/pkg/brownfield/targets.go
+++ b/pkg/brownfield/targets.go
@@ -7,12 +7,10 @@ package brownfield
 
 import (
 	"encoding/json"
-	"github.com/golang/glog"
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/to"
 
-	mtv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressmanagedtarget/v1"
 	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
 )
 
@@ -23,24 +21,24 @@ type Target struct {
 	Path     *string
 }
 
-// IsIn figures out whether a given Target objects in a list of Target objects.
-func (t Target) IsIn(targetList *[]Target) bool {
-	for _, otherTarget := range *targetList {
-		hostIsSame := strings.ToLower(t.Hostname) == strings.ToLower(otherTarget.Hostname)
+// IsBlacklisted figures out whether a given Target objects in a list of blacklisted targets.
+func (t Target) IsBlacklisted(blacklist *[]Target) bool {
+	for _, blTarget := range *blacklist {
+		hostIsSame := strings.ToLower(t.Hostname) == strings.ToLower(blTarget.Hostname)
 
 		// If one of the ports is not defined (0) - ignore port comparison
-		portIsSame := t.Port == otherTarget.Port || t.Port == 0 || otherTarget.Port == 0
+		portIsSame := t.Port == blTarget.Port || t.Port == 0 || blTarget.Port == 0
 
 		// Set defaults to blank string, so we can compare strings even if nulls.
-		pathA, pathB := "", ""
+		targetPath, blacklistPath := "", ""
 		if t.Path != nil {
-			pathA = *t.Path
+			targetPath = *t.Path
 		}
-		if otherTarget.Path != nil {
-			pathB = *otherTarget.Path
+		if blTarget.Path != nil {
+			blacklistPath = *blTarget.Path
 		}
 
-		if hostIsSame && portIsSame && pathA == pathB {
+		if hostIsSame && portIsSame && pathsOverlap(targetPath, blacklistPath) {
 			// Found it
 			return true
 		}
@@ -48,6 +46,38 @@ func (t Target) IsIn(targetList *[]Target) bool {
 
 	// Did not find it
 	return false
+}
+
+// pathsOverlap determines whether 2 paths have any overlap.
+// Example:  /a/b  and /a/b/c overlap;  /a/b and /a/x don't overlap.
+func pathsOverlap(needle string, haystack string) bool {
+	needle = NormalizePath(needle)
+	haystack = NormalizePath(haystack)
+
+	if needle == haystack {
+		return true
+	}
+
+	needleChunks := strings.Split(needle, "/")
+	haystackChunks := strings.Split(haystack, "/")
+
+	for idx := 0; idx <= int(max(len(needleChunks), len(haystackChunks))); idx++ {
+		if len(needleChunks) == idx || len(haystackChunks) == idx {
+			return true
+		}
+
+		if needleChunks[idx] != haystackChunks[idx] {
+			return false
+		}
+	}
+	return true
+}
+
+func max(x, y int) int {
+	if x > y {
+		return x
+	}
+	return y
 }
 
 // prettyTarget is used for pretty-printing the Target struct for debugging purposes.
@@ -91,29 +121,7 @@ func GetTargetBlacklist(prohibitedTargets []*ptv1.AzureIngressProhibitedTarget) 
 	return &target
 }
 
-// GetTargetWhitelist returns the list of Targets given a list ManagedTarget CRDs.
-func GetTargetWhitelist(managedTargets []*mtv1.AzureIngressManagedTarget) TargetWhitelist {
-	var target []Target
-	for _, managedTarget := range managedTargets {
-		if len(managedTarget.Spec.Paths) == 0 {
-			target = append(target, Target{
-				Hostname: managedTarget.Spec.Hostname,
-				Port:     managedTarget.Spec.Port,
-				Path:     nil,
-			})
-		}
-		for _, path := range managedTarget.Spec.Paths {
-			target = append(target, Target{
-				Hostname: managedTarget.Spec.Hostname,
-				Port:     managedTarget.Spec.Port,
-				Path:     to.StringPtr(NormalizePath(path)),
-			})
-		}
-	}
-	return &target
-}
-
-// NormalizePath re-formats the path string so that we can discovere semantically identical paths.
+// NormalizePath re-formats the path string so that we can discover semantically identical paths.
 func NormalizePath(path string) string {
 	trimmed, prevTrimmed := "", path
 	cutset := "*/"
@@ -121,37 +129,7 @@ func NormalizePath(path string) string {
 		prevTrimmed = trimmed
 		trimmed = strings.TrimRight(path, cutset)
 	}
-	return trimmed
-}
-
-// shouldManage determines whether the target identified by the given host & path should be managed by AGIC.
-func shouldManage(host string, path *string, blacklist TargetBlacklist, whitelist TargetWhitelist) bool {
-
-	target := rulePathToTarget(host, path)
-
-	// Apply Blacklist first to remove explicitly forbidden targets.
-	if blacklist != nil && len(*blacklist) > 0 {
-		targetJSON, _ := target.MarshalJSON()
-		if target.IsIn(blacklist) {
-			glog.V(5).Infof("Target is in blacklist. Ignore: %s", string(targetJSON))
-			return false
-		}
-		glog.V(5).Infof("Target is not in blacklist. Keep: %s", string(targetJSON))
-		return true
-	}
-
-	if whitelist != nil && len(*whitelist) > 0 {
-		targetJSON, _ := target.MarshalJSON()
-		if target.IsIn(whitelist) {
-			glog.V(5).Infof("Target is in the whitelist. Keep: %s", string(targetJSON))
-			return true
-		}
-		glog.V(5).Infof("Target is not in the whitelist. Ignore: %s", string(targetJSON))
-		return false
-	}
-
-	//There's neither blacklist nor whitelist - keep it
-	return true
+	return strings.ToLower(trimmed)
 }
 
 // rulePathToTarget constructs a Target struct based on the host and path provided

--- a/pkg/brownfield/targets.go
+++ b/pkg/brownfield/targets.go
@@ -38,7 +38,7 @@ func (t Target) IsBlacklisted(blacklist *[]Target) bool {
 			blacklistPath = *blTarget.Path
 		}
 
-		pathIsSame := blTarget.Path == "" || strings.ToLower(targetPath) == strings.ToLower(blacklistPath)
+		pathIsSame := blacklistPath == "" || strings.ToLower(targetPath) == strings.ToLower(blacklistPath)
 
 		// With this version we keep things as simple as possible: match host and exact path to determine
 		// whether given target is in the blacklist. Ideally this would be URL Path set overlap operation,

--- a/pkg/brownfield/targets.go
+++ b/pkg/brownfield/targets.go
@@ -1,0 +1,167 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"encoding/json"
+	"github.com/golang/glog"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest/to"
+
+	mtv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressmanagedtarget/v1"
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+)
+
+// Target uniquely identifies a subset of App Gateway configuration, which AGIC will manage or be prohibited from managing.
+type Target struct {
+	Hostname string
+	Port     int32
+	Path     *string
+}
+
+// IsIn figures out whether a given Target objects in a list of Target objects.
+func (t Target) IsIn(targetList *[]Target) bool {
+	for _, otherTarget := range *targetList {
+		hostIsSame := strings.ToLower(t.Hostname) == strings.ToLower(otherTarget.Hostname)
+
+		// If one of the ports is not defined (0) - ignore port comparison
+		portIsSame := t.Port == otherTarget.Port || t.Port == 0 || otherTarget.Port == 0
+
+		// Set defaults to blank string, so we can compare strings even if nulls.
+		pathA, pathB := "", ""
+		if t.Path != nil {
+			pathA = *t.Path
+		}
+		if otherTarget.Path != nil {
+			pathB = *otherTarget.Path
+		}
+
+		if hostIsSame && portIsSame && pathA == pathB {
+			// Found it
+			return true
+		}
+	}
+
+	// Did not find it
+	return false
+}
+
+// prettyTarget is used for pretty-printing the Target struct for debugging purposes.
+type prettyTarget struct {
+	Hostname string `json:"Hostname"`
+	Port     int32  `json:"Port"`
+	Path     string `json:"Path,omitempty"`
+}
+
+// MarshalJSON converts the Target object to a JSON byte array.
+func (t Target) MarshalJSON() ([]byte, error) {
+	pt := prettyTarget{
+		Hostname: t.Hostname,
+		Port:     t.Port,
+	}
+	if t.Path != nil {
+		pt.Path = *t.Path
+	}
+	return json.Marshal(pt)
+}
+
+// GetTargetBlacklist returns the list of Targets given a list ProhibitedTarget CRDs.
+func GetTargetBlacklist(prohibitedTargets []*ptv1.AzureIngressProhibitedTarget) TargetBlacklist {
+	var target []Target
+	for _, prohibitedTarget := range prohibitedTargets {
+		if len(prohibitedTarget.Spec.Paths) == 0 {
+			target = append(target, Target{
+				Hostname: prohibitedTarget.Spec.Hostname,
+				Port:     prohibitedTarget.Spec.Port,
+				Path:     nil,
+			})
+		}
+		for _, path := range prohibitedTarget.Spec.Paths {
+			target = append(target, Target{
+				Hostname: prohibitedTarget.Spec.Hostname,
+				Port:     prohibitedTarget.Spec.Port,
+				Path:     to.StringPtr(NormalizePath(path)),
+			})
+		}
+	}
+	return &target
+}
+
+// GetTargetWhitelist returns the list of Targets given a list ManagedTarget CRDs.
+func GetTargetWhitelist(managedTargets []*mtv1.AzureIngressManagedTarget) TargetWhitelist {
+	var target []Target
+	for _, managedTarget := range managedTargets {
+		if len(managedTarget.Spec.Paths) == 0 {
+			target = append(target, Target{
+				Hostname: managedTarget.Spec.Hostname,
+				Port:     managedTarget.Spec.Port,
+				Path:     nil,
+			})
+		}
+		for _, path := range managedTarget.Spec.Paths {
+			target = append(target, Target{
+				Hostname: managedTarget.Spec.Hostname,
+				Port:     managedTarget.Spec.Port,
+				Path:     to.StringPtr(NormalizePath(path)),
+			})
+		}
+	}
+	return &target
+}
+
+// NormalizePath re-formats the path string so that we can discovere semantically identical paths.
+func NormalizePath(path string) string {
+	trimmed, prevTrimmed := "", path
+	cutset := "*/"
+	for trimmed != prevTrimmed {
+		prevTrimmed = trimmed
+		trimmed = strings.TrimRight(path, cutset)
+	}
+	return trimmed
+}
+
+// shouldManage determines whether the target identified by the given host & path should be managed by AGIC.
+func shouldManage(host string, path *string, blacklist TargetBlacklist, whitelist TargetWhitelist) bool {
+
+	target := rulePathToTarget(host, path)
+
+	// Apply Blacklist first to remove explicitly forbidden targets.
+	if blacklist != nil && len(*blacklist) > 0 {
+		targetJSON, _ := target.MarshalJSON()
+		if target.IsIn(blacklist) {
+			glog.V(5).Infof("Target is in blacklist. Ignore: %s", string(targetJSON))
+			return false
+		}
+		glog.V(5).Infof("Target is not in blacklist. Keep: %s", string(targetJSON))
+		return true
+	}
+
+	if whitelist != nil && len(*whitelist) > 0 {
+		targetJSON, _ := target.MarshalJSON()
+		if target.IsIn(whitelist) {
+			glog.V(5).Infof("Target is in the whitelist. Keep: %s", string(targetJSON))
+			return true
+		}
+		glog.V(5).Infof("Target is not in the whitelist. Ignore: %s", string(targetJSON))
+		return false
+	}
+
+	//There's neither blacklist nor whitelist - keep it
+	return true
+}
+
+// rulePathToTarget constructs a Target struct based on the host and path provided
+// TODO(draychev): Add port number to enable port-specific target management.
+func rulePathToTarget(host string, path *string) *Target {
+	target := Target{
+		Hostname: host,
+	}
+	if path != nil {
+		target.Path = path
+	}
+	return &target
+}

--- a/pkg/brownfield/targets_test.go
+++ b/pkg/brownfield/targets_test.go
@@ -1,0 +1,115 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
+)
+
+var _ = Describe("test TargetBlacklist/TargetWhitelist health probes", func() {
+
+	expected := Target{
+		Hostname: tests.Host,
+		Port:     443,
+	}
+
+	Context("Test normalizing permit/prohibit URL paths", func() {
+		actual := NormalizePath("*//*hello/**/*//")
+		It("should have exactly 1 record", func() {
+			Expect(actual).To(Equal("*//*hello"))
+		})
+	})
+
+	Context("test GetTargetWhitelist", func() {
+		whitelist := GetTargetWhitelist(fixtures.GetManagedTargets())
+		It("Should have produced correct Managed Targets list", func() {
+			Expect(len(*whitelist)).To(Equal(3))
+			for _, path := range []string{fixtures.PathFoo, fixtures.PathBar, fixtures.PathBaz} {
+				expected.Path = to.StringPtr(path)
+				Expect(*whitelist).To(ContainElement(expected))
+			}
+			expected.Path = to.StringPtr(fixtures.PathFox)
+			Expect(*whitelist).ToNot(ContainElement(expected))
+
+		})
+	})
+
+	Context("test GetTargetBlacklist", func() {
+		blacklist := GetTargetBlacklist(fixtures.GetProhibitedTargets())
+		It("should have produced correct Prohibited Targets list", func() {
+			Expect(len(*blacklist)).To(Equal(2))
+
+			// Targets /fox and /bar are in the blacklist
+			for _, path := range []string{fixtures.PathFox, fixtures.PathBar} {
+				expected.Path = to.StringPtr(path)
+				Expect(*blacklist).To(ContainElement(expected))
+			}
+			expected.Path = to.StringPtr(fixtures.PathFoo)
+			Expect(*blacklist).ToNot(ContainElement(expected))
+		})
+	})
+
+	Context("Test IsIn", func() {
+		t1 := Target{
+			Hostname: tests.Host,
+			Port:     443,
+			Path:     to.StringPtr(fixtures.PathBar),
+		}
+
+		t2 := Target{
+			Hostname: tests.Host,
+			Port:     9898,
+			Path:     to.StringPtr("/xyz"),
+		}
+
+		targetNoPort := Target{
+			Hostname: tests.Host,
+			Path:     to.StringPtr(fixtures.PathBar),
+		}
+
+		targetNoPaths := Target{
+			Hostname: "other-host-no-paths",
+			Port:     123,
+		}
+
+		targetNonExistentPath := Target{
+			Hostname: tests.Host,
+			Port:     443,
+			Path:     to.StringPtr(fixtures.PathBar + "Non-Existent-Path"),
+		}
+
+		targetList := []Target{
+			{
+				Hostname: tests.Host,
+				Port:     443,
+				Path:     to.StringPtr(fixtures.PathFoo),
+			},
+			{
+				Hostname: tests.Host,
+				Port:     443,
+				Path:     to.StringPtr(fixtures.PathBar),
+			},
+			{
+				Hostname: "other-host-no-paths",
+				Port:     123,
+			},
+		}
+
+		It("Should be able to find a new Target in an existing list of Targets", func() {
+			Expect(t1.IsIn(&targetList)).To(BeTrue())
+			Expect(t2.IsIn(&targetList)).To(BeFalse())
+			Expect(targetNoPort.IsIn(&targetList)).To(BeTrue())
+			Expect(targetNoPaths.IsIn(&targetList)).To(BeTrue())
+			Expect(targetNonExistentPath.IsIn(&targetList)).To(BeFalse())
+		})
+	})
+
+})

--- a/pkg/brownfield/targets_test.go
+++ b/pkg/brownfield/targets_test.go
@@ -18,15 +18,7 @@ var _ = Describe("Test blacklisting targets", func() {
 
 	expected := Target{
 		Hostname: tests.Host,
-		Port:     443,
 	}
-
-	Context("Test normalizing permit/prohibit URL paths", func() {
-		actual := NormalizePath("*//*heLLo/**/*//")
-		It("should have exactly 1 record", func() {
-			Expect(actual).To(Equal("*//*hello"))
-		})
-	})
 
 	Context("test GetTargetBlacklist", func() {
 		blacklist := GetTargetBlacklist(fixtures.GetProhibitedTargets())
@@ -46,106 +38,54 @@ var _ = Describe("Test blacklisting targets", func() {
 	Context("Test IsBlacklisted", func() {
 		targetInBlacklist := Target{
 			Hostname: tests.Host,
-			Port:     443,
 			Path:     to.StringPtr(fixtures.PathBar),
 		}
 
-		targetPartialPathInBlacklist := Target{
+		targetInBlacklistNoHost := Target{
 			Hostname: tests.Host,
-			Port:     443,
-			Path:     to.StringPtr("/path/with/"),
-		}
-
-		targetPartialPathNotInBlacklist := Target{
-			Hostname: tests.Host,
-			Port:     443,
-			Path:     to.StringPtr("/path/with/XXX/"),
-		}
-
-		targetNotInList := Target{
-			Hostname: tests.Host,
-			Port:     9898,
 			Path:     to.StringPtr("/xyz"),
-		}
-
-		targetNoPort := Target{
-			Hostname: tests.Host,
-			Path:     to.StringPtr(fixtures.PathBar),
 		}
 
 		targetNoPaths := Target{
 			Hostname: "other-host-no-paths",
-			Port:     123,
 		}
 
 		targetNonExistentPath := Target{
 			Hostname: tests.Host,
-			Port:     443,
 			Path:     to.StringPtr(fixtures.PathBar + "Non-Existent-Path"),
 		}
 
 		targetNoHost := Target{
-			Port: 443,
 			Path: to.StringPtr(fixtures.PathBar),
 		}
 
 		blacklist := []Target{
 			{
 				Hostname: tests.Host,
-				Port:     443,
 				Path:     to.StringPtr(fixtures.PathFoo),
 			},
 			{
 				Hostname: tests.Host,
-				Port:     443,
 				Path:     to.StringPtr(fixtures.PathBar),
 			},
 			{
-				Hostname: tests.Host,
-				Port:     443,
-				Path:     to.StringPtr("/path/with/high/specificity/*"),
+				Hostname: "other-host-no-paths",
 			},
 			{
-				Hostname: "other-host-no-paths",
-				Port:     123,
+				Path: to.StringPtr("/xyz"),
 			},
 		}
 
 		It("Should be able to find a new Target in an existing list of Targets", func() {
 			// Blacklisted targets
 			Expect(targetInBlacklist.IsBlacklisted(&blacklist)).To(BeTrue())
-			Expect(targetPartialPathInBlacklist.IsBlacklisted(&blacklist)).To(BeTrue())
+			Expect(targetInBlacklistNoHost.IsBlacklisted(&blacklist)).To(BeTrue())
 
 			// Non-blacklisted targets
-			Expect(targetPartialPathNotInBlacklist.IsBlacklisted(&blacklist)).To(BeFalse())
-			Expect(targetNotInList.IsBlacklisted(&blacklist)).To(BeFalse())
-			Expect(targetNoPort.IsBlacklisted(&blacklist)).To(BeTrue())
 			Expect(targetNoPaths.IsBlacklisted(&blacklist)).To(BeTrue())
 			Expect(targetNonExistentPath.IsBlacklisted(&blacklist)).To(BeFalse())
 			Expect(targetNoHost.IsBlacklisted(&blacklist)).To(BeFalse())
 		})
-	})
-
-	Context("", func() {
-
-		It("Should be able to determine that a needle is in a haystack", func() {
-			needle := "/a/b/c/d/e/f/g/*"
-			haystack := "/a/b/*"
-			Expect(pathsOverlap(needle, haystack)).To(BeTrue())
-		})
-
-		It("Should be to determine that a needle is covering the entire haystack", func() {
-			needle := "/a/b/c"
-			haystack := "/a/b/c/d/e/f/g/*"
-			Expect(pathsOverlap(needle, haystack)).To(BeTrue())
-		})
-
-		It("Should be able to determine that the needle is not in the haystack", func() {
-			needle := "/a/b/c"
-			haystack := "/x/y/z/*"
-			Expect(pathsOverlap(needle, haystack)).To(BeFalse())
-		})
-
 	})
 
 })

--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -1,0 +1,12 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+// TargetBlacklist is a list of Targets, which AGIC is not allowed to apply configuration for.
+type TargetBlacklist *[]Target
+
+// TargetWhitelist is a list of Targets, which AGIC is allowed to apply configuration for.
+type TargetWhitelist *[]Target

--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -7,6 +7,3 @@ package brownfield
 
 // TargetBlacklist is a list of Targets, which AGIC is not allowed to apply configuration for.
 type TargetBlacklist *[]Target
-
-// TargetWhitelist is a list of Targets, which AGIC is allowed to apply configuration for.
-type TargetWhitelist *[]Target

--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -36,7 +36,6 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	cbCtx := &appgw.ConfigBuilderContext{
 		ServiceList:          c.k8sContext.ListServices(),
 		IngressList:          c.k8sContext.ListHTTPIngresses(),
-		ManagedTargets:       c.k8sContext.ListAzureIngressManagedTargets(),
 		ProhibitedTargets:    c.k8sContext.ListAzureProhibitedTargets(),
 		IstioGateways:        c.k8sContext.ListIstioGateways(),
 		IstioVirtualServices: c.k8sContext.ListIstioVirtualServices(),
@@ -47,7 +46,7 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	if cbCtx.EnvVariables.EnableBrownfieldDeployment == "true" {
 		for idx, ingress := range cbCtx.IngressList {
 			glog.V(5).Infof("Original Ingress[%d] Rules: %+v", idx, ingress.Spec.Rules)
-			cbCtx.IngressList[0].Spec.Rules = brownfield.PruneIngressRules(ingress, cbCtx.ProhibitedTargets, cbCtx.ManagedTargets)
+			cbCtx.IngressList[idx].Spec.Rules = brownfield.PruneIngressRules(ingress, cbCtx.ProhibitedTargets)
 			glog.V(5).Infof("Sanitized Ingress[%d] Rules: %+v", idx, ingress.Spec.Rules)
 		}
 	}

--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -47,7 +47,7 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	if cbCtx.EnvVariables.EnableBrownfieldDeployment == "true" {
 		for idx, ingress := range cbCtx.IngressList {
 			glog.V(5).Infof("Original Ingress[%d] Rules: %+v", idx, ingress.Spec.Rules)
-			brownfield.PruneIngressRules(ingress, cbCtx.ProhibitedTargets, cbCtx.ManagedTargets)
+			cbCtx.IngressList[0].Spec.Rules = brownfield.PruneIngressRules(ingress, cbCtx.ProhibitedTargets, cbCtx.ManagedTargets)
 			glog.V(5).Infof("Sanitized Ingress[%d] Rules: %+v", idx, ingress.Spec.Rules)
 		}
 	}

--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -16,6 +16,7 @@ import (
 	"github.com/golang/glog"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/brownfield"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 )
@@ -33,7 +34,6 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	}
 
 	cbCtx := &appgw.ConfigBuilderContext{
-		// Get all Services
 		ServiceList:          c.k8sContext.ListServices(),
 		IngressList:          c.k8sContext.ListHTTPIngresses(),
 		ManagedTargets:       c.k8sContext.ListAzureIngressManagedTargets(),
@@ -41,6 +41,15 @@ func (c AppGwIngressController) Process(event events.Event) error {
 		IstioGateways:        c.k8sContext.ListIstioGateways(),
 		IstioVirtualServices: c.k8sContext.ListIstioVirtualServices(),
 		EnvVariables:         environment.GetEnv(),
+	}
+
+	// Mutate the list of Ingresses by removing ones that AGIC should not be creating configuration.
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment == "true" {
+		for idx, ingress := range cbCtx.IngressList {
+			glog.V(5).Infof("Original Ingress[%d] Rules: %+v", idx, ingress.Spec.Rules)
+			brownfield.PruneIngressRules(ingress, cbCtx.ProhibitedTargets, cbCtx.ManagedTargets)
+			glog.V(5).Infof("Sanitized Ingress[%d] Rules: %+v", idx, ingress.Spec.Rules)
+		}
 	}
 
 	if cbCtx.EnvVariables.EnableIstioIntegration == "true" {


### PR DESCRIPTION
This PR introduces (a partial implementation of) brownfield deployment.
 This is a the first part of https://github.com/Azure/application-gateway-kubernetes-ingress/pull/345.

In this PR we trim the rules of the Ingress resource down to what AGIS is allowed to configure App Gwy for.

The strategy is described in [a proposal here](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/proposals/config_ownership_crd.md).