### PR TITLE
annotation: add use-private-ip annotation

### DIFF
--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -37,6 +37,9 @@ const (
 	// SslRedirectKey defines the key for defining with SSL redirect should be turned on for an HTTP endpoint.
 	SslRedirectKey = ApplicationGatewayPrefix + "/ssl-redirect"
 
+	// UsePrivateIP defines the key to use private ip with the ingress.
+	UsePrivateIPKey = ApplicationGatewayPrefix + "/use-private-ip"
+
 	// IngressClassKey defines the key of the annotation which needs to be set in order to specify
 	// that this is an ingress resource meant for the application gateway ingress controller.
 	IngressClassKey = "kubernetes.io/ingress.class"
@@ -98,6 +101,11 @@ func ConnectionDrainingTimeout(ing *v1beta1.Ingress) (int32, error) {
 // IsCookieBasedAffinity provides value to enable/disable cookie based affinity for client connection.
 func IsCookieBasedAffinity(ing *v1beta1.Ingress) (bool, error) {
 	return parseBool(ing, CookieBasedAffinityKey)
+}
+
+// UsePrivateIP specifies whether to use private IP with the ingress
+func UsePrivateIP(ing *v1beta1.Ingress) (bool, error) {
+	return parseBool(ing, UsePrivateIPKey)
 }
 
 func parseBool(ing *v1beta1.Ingress, name string) (bool, error) {

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -259,7 +259,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		// Test the listener.
 		appGwIdentifier := Identifier{}
 		frontendPortID := appGwIdentifier.frontendPortID(generateFrontendPortName(80))
-		listenerName := generateListenerName(listenerIdentifier{80, domainName})
+		listenerName := generateListenerName(listenerIdentifier{80, domainName, false})
 		listener := &n.ApplicationGatewayHTTPListener{
 			Etag: to.StringPtr("*"),
 			Name: &listenerName,
@@ -275,7 +275,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	}
 
 	baseRequestRoutingRulesChecker := func(appGW *n.ApplicationGatewayPropertiesFormat, listener int32, host string) {
-		Expect(*((*appGW.RequestRoutingRules)[0].Name)).To(Equal(generateRequestRoutingRuleName(listenerIdentifier{listener, host})))
+		Expect(*((*appGW.RequestRoutingRules)[0].Name)).To(Equal(generateRequestRoutingRuleName(listenerIdentifier{listener, host, false})))
 		Expect((*appGW.RequestRoutingRules)[0].RuleType).To(Equal(n.PathBasedRouting))
 	}
 
@@ -288,7 +288,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	}
 
 	baseURLPathMapsChecker := func(appGW *n.ApplicationGatewayPropertiesFormat, listener int32, host string) {
-		Expect(*((*appGW.URLPathMaps)[0].Name)).To(Equal(generateURLPathMapName(listenerIdentifier{listener, host})))
+		Expect(*((*appGW.URLPathMaps)[0].Name)).To(Equal(generateURLPathMapName(listenerIdentifier{listener, host, false})))
 		// Check the `pathRule` stored within the `urlPathMap`.
 		Expect(len(*((*appGW.URLPathMaps)[0].PathRules))).To(Equal(1), "Expected one path based rule, but got: %d", len(*((*appGW.URLPathMaps)[0].PathRules)))
 
@@ -626,7 +626,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 				}
 
 				frontendPortID := appGwIdentifier.frontendPortID(generateFrontendPortName(443))
-				httpsListenerName := generateListenerName(listenerIdentifier{443, domainName})
+				httpsListenerName := generateListenerName(listenerIdentifier{443, domainName, false})
 				sslCert := appGwIdentifier.sslCertificateID(secretID.secretFullName())
 				httpsListener := &n.ApplicationGatewayHTTPListener{
 					Etag: to.StringPtr("*"),

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -156,7 +156,9 @@ func generateBackendID(ingress *v1beta1.Ingress, rule *v1beta1.IngressRule, path
 }
 
 func generateListenerID(rule *v1beta1.IngressRule,
-	protocol n.ApplicationGatewayProtocol, overridePort *int32) listenerIdentifier {
+	protocol n.ApplicationGatewayProtocol,
+	overridePort *int32,
+	usePrivateIP bool) listenerIdentifier {
 	frontendPort := int32(80)
 	if protocol == n.HTTPS {
 		frontendPort = int32(443)
@@ -167,6 +169,7 @@ func generateListenerID(rule *v1beta1.IngressRule,
 	listenerID := listenerIdentifier{
 		FrontendPort: frontendPort,
 		HostName:     rule.Host,
+		UsePrivateIP: usePrivateIP,
 	}
 	return listenerID
 }

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -172,4 +172,34 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			// Expected(exiter.Status(), ShouldEqual, 3)
 		})
 	})
+	Context("create a new App Gateway HTTP Listener with Private Ip when usePrivateIP annotation is present", func() {
+		listener80Private := listenerIdentifier{
+			FrontendPort: int32(80),
+			HostName:     tests.Host,
+			UsePrivateIP: true,
+		}
+		It("should have usePrivateIP true", func() {
+			Expect(listener80Private.UsePrivateIP).To(Equal(true))
+		})
+		It("should create a App Gwy listener with private IP", func() {
+			certs := newCertsFixture()
+			cb := newConfigBuilderFixture(&certs)
+			listener := cb.newListener(listener80Private, n.ApplicationGatewayProtocol("Https"), envVariables)
+			expectedName := agPrefix + "fl-bye.com-80"
+
+			expected := n.ApplicationGatewayHTTPListener{
+				Etag: to.StringPtr("*"),
+				Name: to.StringPtr(expectedName),
+				ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
+					// TODO: expose this to external configuration
+					FrontendIPConfiguration: resourceRef(tests.IPID2),
+					FrontendPort:            resourceRef(cb.appGwIdentifier.frontendPortID(generateFrontendPortName(80))),
+					Protocol:                n.ApplicationGatewayProtocol("Https"),
+					HostName:                to.StringPtr(tests.Host),
+				},
+			}
+
+			Expect(listener).To(Equal(expected))
+		})
+	})
 })

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -49,6 +49,7 @@ type serviceBackendPortPair struct {
 type listenerIdentifier struct {
 	FrontendPort int32
 	HostName     string
+	UsePrivateIP bool
 }
 
 type serviceIdentifier struct {

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -38,6 +38,8 @@ func (c *appGwConfigBuilder) getURLPathMaps(cbCtx *ConfigBuilderContext) map[lis
 	for _, ingress := range cbCtx.IngressList {
 		defaultAddressPoolID := c.appGwIdentifier.addressPoolID(defaultBackendAddressPoolName)
 		defaultHTTPSettingsID := c.appGwIdentifier.httpSettingsID(defaultBackendHTTPSettingsName)
+		usePrivateIP, _ := annotations.UsePrivateIP(ingress)
+		usePrivateIP = usePrivateIP || cbCtx.EnvVariables.UsePrivateIP == "true"
 
 		var wildcardRule *v1beta1.IngressRule
 		wildcardRule = nil
@@ -81,10 +83,10 @@ func (c *appGwConfigBuilder) getURLPathMaps(cbCtx *ConfigBuilderContext) map[lis
 				continue
 			}
 
-			listenerHTTPID := generateListenerID(rule, n.HTTP, nil)
+			listenerHTTPID := generateListenerID(rule, n.HTTP, nil, usePrivateIP)
 			_, httpAvailable := httpListenersMap[listenerHTTPID]
 
-			listenerHTTPSID := generateListenerID(rule, n.HTTPS, nil)
+			listenerHTTPSID := generateListenerID(rule, n.HTTPS, nil, usePrivateIP)
 			_, httpsAvailable := httpListenersMap[listenerHTTPSID]
 
 			if httpAvailable {


### PR DESCRIPTION
This PR adds `/use-private-ip: true` annotation along with supporting usePrivateIP at controller level.

This will have a follow-up PRs
1) for pruning ingress with this annotation when private IP is not present on the Application Gateway
2) documentation