### PR TITLE
Simplify Target{} Struct

### DIFF
--- a/pkg/brownfield/ingress_test.go
+++ b/pkg/brownfield/ingress_test.go
@@ -6,13 +6,12 @@
 package brownfield
 
 import (
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
-	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
 )
 
@@ -109,16 +108,16 @@ var _ = Describe("test pruning Ingress based on white/white lists", func() {
 	Context("Test canManage()", func() {
 		blacklist := []Target{{
 			Hostname: tests.Host,
-			Path:     to.StringPtr(fixtures.PathFox),
+			Path:     fixtures.PathFox,
 		}}
 
 		It("should have properly identified the ingress rules AGIC is NOT allowed to manage", func() {
-			actual := canManage(tests.Host, to.StringPtr(fixtures.PathFox), &blacklist)
+			actual := canManage(tests.Host, fixtures.PathFox, &blacklist)
 			Expect(actual).To(BeFalse())
 		})
 
 		It("should have properly identified the ingress rules AGIC is allowed to manage", func() {
-			actual := canManage(tests.Host, to.StringPtr(fixtures.PathBaz), &blacklist)
+			actual := canManage(tests.Host, fixtures.PathBaz, &blacklist)
 			Expect(actual).To(BeTrue())
 		})
 	})

--- a/pkg/brownfield/targets.go
+++ b/pkg/brownfield/targets.go
@@ -6,18 +6,15 @@
 package brownfield
 
 import (
-	"encoding/json"
 	"strings"
-
-	"github.com/Azure/go-autorest/autorest/to"
 
 	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
 )
 
 // Target uniquely identifies a subset of App Gateway configuration, which AGIC will manage or be prohibited from managing.
 type Target struct {
-	Hostname string
-	Path     *string
+	Hostname string `json:"Hostname,omitempty"`
+	Path     string `json:"Path,omitempty"`
 }
 
 // IsBlacklisted figures out whether a given Target objects in a list of blacklisted targets.
@@ -29,16 +26,7 @@ func (t Target) IsBlacklisted(blacklist *[]Target) bool {
 		// AGIC is allowed to create and modify App Gwy config for blank host.
 		hostIsSame := blTarget.Hostname == "" || strings.ToLower(t.Hostname) == strings.ToLower(blTarget.Hostname)
 
-		// Set defaults to blank string, so we can compare strings even if nulls.
-		targetPath, blacklistPath := "", ""
-		if t.Path != nil {
-			targetPath = *t.Path
-		}
-		if blTarget.Path != nil {
-			blacklistPath = *blTarget.Path
-		}
-
-		pathIsSame := blacklistPath == "" || strings.ToLower(targetPath) == strings.ToLower(blacklistPath)
+		pathIsSame := blTarget.Path == "" || strings.ToLower(t.Path) == strings.ToLower(blTarget.Path)
 
 		// With this version we keep things as simple as possible: match host and exact path to determine
 		// whether given target is in the blacklist. Ideally this would be URL Path set overlap operation,
@@ -56,17 +44,6 @@ type prettyTarget struct {
 	Path     string `json:"Path,omitempty"`
 }
 
-// MarshalJSON converts the Target object to a JSON byte array.
-func (t Target) MarshalJSON() ([]byte, error) {
-	pt := prettyTarget{
-		Hostname: t.Hostname,
-	}
-	if t.Path != nil {
-		pt.Path = *t.Path
-	}
-	return json.Marshal(pt)
-}
-
 // GetTargetBlacklist returns the list of Targets given a list ProhibitedTarget CRDs.
 func GetTargetBlacklist(prohibitedTargets []*ptv1.AzureIngressProhibitedTarget) TargetBlacklist {
 	var target []Target
@@ -74,13 +51,12 @@ func GetTargetBlacklist(prohibitedTargets []*ptv1.AzureIngressProhibitedTarget) 
 		if len(prohibitedTarget.Spec.Paths) == 0 {
 			target = append(target, Target{
 				Hostname: prohibitedTarget.Spec.Hostname,
-				Path:     nil,
 			})
 		}
 		for _, path := range prohibitedTarget.Spec.Paths {
 			target = append(target, Target{
 				Hostname: prohibitedTarget.Spec.Hostname,
-				Path:     to.StringPtr(strings.ToLower(path)),
+				Path:     strings.ToLower(path),
 			})
 		}
 	}

--- a/pkg/brownfield/targets_test.go
+++ b/pkg/brownfield/targets_test.go
@@ -6,7 +6,6 @@
 package brownfield
 
 import (
-	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -27,10 +26,10 @@ var _ = Describe("Test blacklisting targets", func() {
 
 			// Targets /fox and /bar are in the blacklist
 			for _, path := range []string{fixtures.PathFox, fixtures.PathBar} {
-				expected.Path = to.StringPtr(path)
+				expected.Path = path
 				Expect(*blacklist).To(ContainElement(expected))
 			}
-			expected.Path = to.StringPtr(fixtures.PathFoo)
+			expected.Path = fixtures.PathFoo
 			Expect(*blacklist).ToNot(ContainElement(expected))
 		})
 	})
@@ -38,12 +37,12 @@ var _ = Describe("Test blacklisting targets", func() {
 	Context("Test IsBlacklisted", func() {
 		targetInBlacklist := Target{
 			Hostname: tests.Host,
-			Path:     to.StringPtr(fixtures.PathBar),
+			Path:     fixtures.PathBar,
 		}
 
 		targetInBlacklistNoHost := Target{
 			Hostname: tests.Host,
-			Path:     to.StringPtr("/xyz"),
+			Path:     "/xyz",
 		}
 
 		targetNoPaths := Target{
@@ -52,27 +51,27 @@ var _ = Describe("Test blacklisting targets", func() {
 
 		targetNonExistentPath := Target{
 			Hostname: tests.Host,
-			Path:     to.StringPtr(fixtures.PathBar + "Non-Existent-Path"),
+			Path:     fixtures.PathBar + "Non-Existent-Path",
 		}
 
 		targetNoHost := Target{
-			Path: to.StringPtr(fixtures.PathBar),
+			Path: fixtures.PathBar,
 		}
 
 		blacklist := []Target{
 			{
 				Hostname: tests.Host,
-				Path:     to.StringPtr(fixtures.PathFoo),
+				Path:     fixtures.PathFoo,
 			},
 			{
 				Hostname: tests.Host,
-				Path:     to.StringPtr(fixtures.PathBar),
+				Path:     fixtures.PathBar,
 			},
 			{
 				Hostname: "other-host-no-paths",
 			},
 			{
-				Path: to.StringPtr("/xyz"),
+				Path: "/xyz",
 			},
 		}
 


### PR DESCRIPTION
The `Target` struct is unnecessarily complex. Let's simplify it.
This PR is a small piece of https://github.com/Azure/application-gateway-kubernetes-ingress/pull/345