### PR TITLE
events: skip pod and endpoints events when unrelated to ingress

### DIFF
--- a/pkg/controller/should_process.go
+++ b/pkg/controller/should_process.go
@@ -6,21 +6,23 @@
 package controller
 
 import (
+	"fmt"
+
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	v1 "k8s.io/api/core/v1"
 )
 
 // ShouldProcess determines whether to process an event.
-func (c AppGwIngressController) ShouldProcess(event events.Event) bool {
+func (c AppGwIngressController) ShouldProcess(event events.Event) (bool, string) {
 	if pod, ok := event.Value.(*v1.Pod); ok {
 		// this pod is not used by any ingress, skip any event for this
-		return c.k8sContext.IsPodReferencedByAnyIngress(pod)
+		return c.k8sContext.IsPodReferencedByAnyIngress(pod), fmt.Sprintf("Skipping pod %s/%s as it is not used by any ingress", pod.Namespace, pod.Name)
 	}
 
 	if endpoints, ok := event.Value.(*v1.Endpoints); ok {
 		// this pod is not used by any ingress, skip any event for this
-		return c.k8sContext.IsEndpointReferencedByAnyIngress(endpoints)
+		return c.k8sContext.IsEndpointReferencedByAnyIngress(endpoints), fmt.Sprintf("Skipping endpoints %s/%s as it is not used by any ingress", endpoints.Namespace, endpoints.Name)
 	}
 
-	return true
+	return true, ""
 }

--- a/pkg/controller/should_process.go
+++ b/pkg/controller/should_process.go
@@ -1,0 +1,26 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package controller
+
+import (
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+	v1 "k8s.io/api/core/v1"
+)
+
+// ShouldProcess determines whether to process an event.
+func (c AppGwIngressController) ShouldProcess(event events.Event) bool {
+	if pod, ok := event.Value.(*v1.Pod); ok {
+		// this pod is not used by any ingress, skip any event for this
+		return c.k8sContext.IsPodReferencedByAnyIngress(pod)
+	}
+
+	if endpoints, ok := event.Value.(*v1.Endpoints); ok {
+		// this pod is not used by any ingress, skip any event for this
+		return c.k8sContext.IsEndpointReferencedByAnyIngress(endpoints)
+	}
+
+	return true
+}

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -353,7 +353,7 @@ func NewIngressTestFixture(namespace string, ingressName string) v1beta1.Ingress
 								{
 									Path: "/hi",
 									Backend: v1beta1.IngressBackend{
-										ServiceName: "hello-world",
+										ServiceName: ServiceName,
 										ServicePort: intstr.IntOrString{
 											Type:   intstr.Int,
 											IntVal: 80,
@@ -376,7 +376,7 @@ func NewPodTestFixture(namespace string, podName string) v1.Pod {
 			Name:      podName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app": "pod",
+				SelectorKey: SelectorValue,
 			},
 		},
 		Spec: v1.PodSpec{},

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -298,6 +298,10 @@ func NewServiceFixture(servicePorts ...v1.ServicePort) *v1.Service {
 // NewEndpointsFixture makes a new endpoint for testing
 func NewEndpointsFixture() *v1.Endpoints {
 	return &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceName,
+			Namespace: Namespace,
+		},
 		Subsets: []v1.EndpointSubset{
 			{
 				// IP addresses which offer the related ports that are marked as ready. These endpoints

--- a/pkg/worker/fake.go
+++ b/pkg/worker/fake.go
@@ -19,6 +19,11 @@ func (fp FakeProcessor) Process(event events.Event) error {
 	return fp.processFunc(event)
 }
 
+// ShouldProcess will return true
+func (fp FakeProcessor) ShouldProcess(event events.Event) bool {
+	return true
+}
+
 // NewFakeProcessor returns a fake processor struct.
 func NewFakeProcessor(process func(events.Event) error) FakeProcessor {
 	return FakeProcessor{

--- a/pkg/worker/fake.go
+++ b/pkg/worker/fake.go
@@ -20,8 +20,8 @@ func (fp FakeProcessor) Process(event events.Event) error {
 }
 
 // ShouldProcess will return true
-func (fp FakeProcessor) ShouldProcess(event events.Event) bool {
-	return true
+func (fp FakeProcessor) ShouldProcess(event events.Event) (bool, string) {
+	return true, ""
 }
 
 // NewFakeProcessor returns a fake processor struct.

--- a/pkg/worker/types.go
+++ b/pkg/worker/types.go
@@ -12,6 +12,7 @@ import (
 // EventProcessor provides a mechanism to act on events in the internal queue.
 type EventProcessor interface {
 	Process(events.Event) error
+	ShouldProcess(events.Event) bool
 }
 
 // Worker listens on the eventChannel and runs the EventProcessor.Process

--- a/pkg/worker/types.go
+++ b/pkg/worker/types.go
@@ -12,7 +12,7 @@ import (
 // EventProcessor provides a mechanism to act on events in the internal queue.
 type EventProcessor interface {
 	Process(events.Event) error
-	ShouldProcess(events.Event) bool
+	ShouldProcess(events.Event) (bool, string)
 }
 
 // Worker listens on the eventChannel and runs the EventProcessor.Process

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -42,8 +42,8 @@ func (w *Worker) Run(eventChannel *channels.RingChannel, stopChannel chan struct
 					glog.V(5).Infof("Received event: %s", jsonEvent)
 				}
 
-				if !w.ShouldProcess(event){
-					glog.V(5).Infof("Skipping event")
+				if shouldProcess, reason := w.ShouldProcess(event); !shouldProcess {
+					glog.V(5).Infof("Skipping event: %s", reason)
 					continue
 				}
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -42,6 +42,11 @@ func (w *Worker) Run(eventChannel *channels.RingChannel, stopChannel chan struct
 					glog.V(5).Infof("Received event: %s", jsonEvent)
 				}
 
+				if !w.ShouldProcess(event){
+					glog.V(5).Infof("Skipping event")
+					continue
+				}
+
 				// Use callback to process event.
 				if err := w.Process(event); err != nil {
 					glog.Error("Processing event failed:", err)


### PR DESCRIPTION
This PR aims to the reduce the churn in the events. Events relate to Pod or Endpoints updates which can be occurring at 1 per sec. This hurts when users are in process of manually updating the gateway and then the controller overwrites the changes.
This PR will be followed by using `Etag` when calling `PUT` on Gateway.