### PR TITLE
brownfield: Routing Rules

### DIFF
--- a/pkg/brownfield/listeners.go
+++ b/pkg/brownfield/listeners.go
@@ -1,0 +1,25 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+)
+
+type listenersByName map[listenerName]n.ApplicationGatewayHTTPListener
+
+// getListenersByName indexes listeners by their name
+func (er *ExistingResources) getListenersByName() listenersByName {
+	if er.listenersByName != nil {
+		return er.listenersByName
+	}
+	listenersByName := make(listenersByName)
+	for _, listener := range er.Listeners {
+		listenersByName[listenerName(listenerName(*listener.Name))] = listener
+	}
+	er.listenersByName = listenersByName
+	return listenersByName
+}

--- a/pkg/brownfield/pathmaps.go
+++ b/pkg/brownfield/pathmaps.go
@@ -1,0 +1,116 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"strings"
+
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/golang/glog"
+)
+
+type urlPathMapName string
+type pathmapToTargets map[urlPathMapName][]Target
+type pathMapsByName map[urlPathMapName]n.ApplicationGatewayURLPathMap
+
+// GetBlacklistedPathMaps filters the given list of routing pathMaps to the list pathMaps that AGIC is allowed to manage.
+func (er ExistingResources) GetBlacklistedPathMaps() ([]n.ApplicationGatewayURLPathMap, []n.ApplicationGatewayURLPathMap) {
+
+	blacklist := GetTargetBlacklist(er.ProhibitedTargets)
+	if blacklist == nil {
+		return nil, er.URLPathMaps
+	}
+	_, pathMapToTargets := er.getRuleToTargets()
+	glog.V(5).Infof("PathMap to Targets map: %+v", pathMapToTargets)
+
+	// Figure out if the given BackendAddressPathMap is blacklisted. It will be if it has a host/path that
+	// has been referenced in a AzureIngressProhibitedTarget CRD (even if it has some other paths that are not)
+	isBlacklisted := func(pathMap n.ApplicationGatewayURLPathMap) bool {
+		targetsForPathMap := pathMapToTargets[urlPathMapName(*pathMap.Name)]
+		for _, target := range targetsForPathMap {
+			if target.IsBlacklisted(blacklist) {
+				glog.V(5).Infof("Routing PathMap %s is blacklisted", *pathMap.Name)
+				return true
+			}
+		}
+		glog.V(5).Infof("Routing PathMap %s is NOT blacklisted", *pathMap.Name)
+		return false
+	}
+
+	var blacklistedPathMaps []n.ApplicationGatewayURLPathMap
+	var nonBlacklistedPathMaps []n.ApplicationGatewayURLPathMap
+	for _, pathMap := range er.URLPathMaps {
+		if isBlacklisted(pathMap) {
+			blacklistedPathMaps = append(blacklistedPathMaps, pathMap)
+			continue
+		}
+		nonBlacklistedPathMaps = append(nonBlacklistedPathMaps, pathMap)
+	}
+	return blacklistedPathMaps, nonBlacklistedPathMaps
+}
+
+// MergePathMaps merges list of lists of pathMaps into a single list, maintaining uniqueness.
+func MergePathMaps(pathMapBuckets ...[]n.ApplicationGatewayURLPathMap) []n.ApplicationGatewayURLPathMap {
+	uniq := make(pathMapsByName)
+	for _, bucket := range pathMapBuckets {
+		for _, pathMap := range bucket {
+			uniq[urlPathMapName(*pathMap.Name)] = pathMap
+		}
+	}
+	var merged []n.ApplicationGatewayURLPathMap
+	for _, pathMap := range uniq {
+		merged = append(merged, pathMap)
+	}
+	return merged
+}
+
+// LogPathMaps emits a few log lines detailing what pathMaps are created, blacklisted, and removed from ARM.
+func LogPathMaps(existingBlacklisted []n.ApplicationGatewayURLPathMap, existingNonBlacklisted []n.ApplicationGatewayURLPathMap, managedPathMaps []n.ApplicationGatewayURLPathMap) {
+	var garbage []n.ApplicationGatewayURLPathMap
+
+	blacklistedSet := indexPathMapsByName(existingBlacklisted)
+	managedSet := indexPathMapsByName(managedPathMaps)
+
+	for pathMapName, pathMap := range indexPathMapsByName(existingNonBlacklisted) {
+		_, existsInBlacklist := blacklistedSet[pathMapName]
+		_, existsInNewPathMaps := managedSet[pathMapName]
+		if !existsInBlacklist && !existsInNewPathMaps {
+			garbage = append(garbage, pathMap)
+		}
+	}
+
+	glog.V(3).Info("[brownfield] PathMaps AGIC created: ", getPathMapNames(managedPathMaps))
+	glog.V(3).Info("[brownfield] Existing Blacklisted PathMaps AGIC will retain: ", getPathMapNames(existingBlacklisted))
+	glog.V(3).Info("[brownfield] Existing PathMaps AGIC will remove: ", getPathMapNames(garbage))
+}
+
+func getPathMapNames(pathMaps []n.ApplicationGatewayURLPathMap) string {
+	var names []string
+	for _, pathMap := range pathMaps {
+		names = append(names, *pathMap.Name)
+	}
+	if len(names) == 0 {
+		return "n/a"
+	}
+	return strings.Join(names, ", ")
+}
+
+func indexPathMapsByName(pathMaps []n.ApplicationGatewayURLPathMap) pathMapsByName {
+	indexed := make(pathMapsByName)
+	for _, pathMap := range pathMaps {
+		indexed[urlPathMapName(*pathMap.Name)] = pathMap
+	}
+	return indexed
+}
+
+func (er ExistingResources) getURLPathMapsByName() pathMapsByName {
+	// Index URLPathMaps by the path map name
+	urlpathMapsByName := make(pathMapsByName)
+	for _, pm := range er.URLPathMaps {
+		urlpathMapsByName[urlPathMapName(*pm.Name)] = pm
+	}
+	return urlpathMapsByName
+}

--- a/pkg/brownfield/pathmaps.go
+++ b/pkg/brownfield/pathmaps.go
@@ -107,10 +107,15 @@ func indexPathMapsByName(pathMaps []n.ApplicationGatewayURLPathMap) pathMapsByNa
 }
 
 func (er ExistingResources) getURLPathMapsByName() pathMapsByName {
+	if er.urlPathMapsByName != nil {
+		return er.urlPathMapsByName
+	}
 	// Index URLPathMaps by the path map name
 	urlpathMapsByName := make(pathMapsByName)
 	for _, pm := range er.URLPathMaps {
 		urlpathMapsByName[urlPathMapName(*pm.Name)] = pm
 	}
+
+	er.urlPathMapsByName = urlpathMapsByName
 	return urlpathMapsByName
 }

--- a/pkg/brownfield/pathmaps_test.go
+++ b/pkg/brownfield/pathmaps_test.go
@@ -23,7 +23,6 @@ var _ = Describe("Test blacklisting path maps", func() {
 
 	Context("Test GetBlacklistedHTTPSettings() with a blacklist", func() {
 		It("should create a list of blacklisted and non blacklisted path maps", func() {
-			// Blacklisted targets: Host: "bye.com", Paths: [/fox, /bar]
 			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets()
 			er := NewExistingResources(appGw, prohibitedTargets, nil)
 

--- a/pkg/brownfield/pathmaps_test.go
+++ b/pkg/brownfield/pathmaps_test.go
@@ -1,0 +1,58 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
+)
+
+var _ = Describe("Test blacklisting path maps", func() {
+
+	appGw := fixtures.GetAppGateway()
+
+	pathMap1 := (*appGw.URLPathMaps)[0]
+	pathMap2 := (*appGw.URLPathMaps)[1]
+	pathMap3 := (*appGw.URLPathMaps)[2]
+
+	Context("Test GetBlacklistedHTTPSettings() with a blacklist", func() {
+		It("should create a list of blacklisted and non blacklisted path maps", func() {
+			// Blacklisted targets: Host: "bye.com", Paths: [/fox, /bar]
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets()
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+
+			blacklisted, nonBlacklisted := er.GetBlacklistedPathMaps()
+			Expect(len(blacklisted)).To(Equal(2))
+			Expect(blacklisted).To(ContainElement(pathMap2))
+			Expect(blacklisted).To(ContainElement(pathMap3))
+
+			Expect(len(nonBlacklisted)).To(Equal(1))
+			Expect(nonBlacklisted).To(ContainElement(pathMap1))
+		})
+	})
+
+	Context("Test GetBlacklistedHTTPSettings() with a blacklist with a wild card", func() {
+		It("should create a list of blacklisted and non blacklisted path maps", func() {
+			wildcard := &ptv1.AzureIngressProhibitedTarget{
+				Spec: ptv1.AzureIngressProhibitedTargetSpec{},
+			}
+			prohibitedTargets := append(fixtures.GetAzureIngressProhibitedTargets(), wildcard)
+
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			blacklisted, nonBlacklisted := er.GetBlacklistedPathMaps()
+			Expect(len(blacklisted)).To(Equal(2))
+			Expect(blacklisted).To(ContainElement(pathMap2))
+			Expect(blacklisted).To(ContainElement(pathMap3))
+
+			// One HTTP Setting is not associated with a listener, so we can't blacklist it.
+			Expect(len(nonBlacklisted)).To(Equal(1))
+			Expect(nonBlacklisted).To(ContainElement(pathMap1))
+		})
+	})
+})

--- a/pkg/brownfield/routing_rules.go
+++ b/pkg/brownfield/routing_rules.go
@@ -1,0 +1,175 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"github.com/Azure/go-autorest/autorest/to"
+	"strings"
+
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/golang/glog"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
+)
+
+type ruleName string
+type rulesByName map[ruleName]n.ApplicationGatewayRequestRoutingRule
+type ruleToTargets map[ruleName][]Target
+
+// GetBlacklistedRoutingRules filters the given list of routing rules to the list rules that AGIC is allowed to manage.
+func (er ExistingResources) GetBlacklistedRoutingRules() ([]n.ApplicationGatewayRequestRoutingRule, []n.ApplicationGatewayRequestRoutingRule) {
+
+	// TODO(draychev): make a method of ExistingResources
+	blacklist := GetTargetBlacklist(er.ProhibitedTargets)
+	if blacklist == nil {
+		return nil, er.RoutingRules
+	}
+	ruleToTargets, _ := er.getRuleToTargets()
+	glog.V(5).Infof("[brownfield] Rule to Targets map: %+v", ruleToTargets)
+
+	// Figure out if the given routing rule is blacklisted. It will be if it has a host/path that
+	// has been referenced in a AzureIngressProhibitedTarget CRD (even if it has some other paths that are not)
+	isBlacklisted := func(rule n.ApplicationGatewayRequestRoutingRule) bool {
+		targetsForRule := ruleToTargets[ruleName(*rule.Name)]
+		for _, target := range targetsForRule {
+			if target.IsBlacklisted(blacklist) {
+				glog.V(5).Infof("[brownfield] Routing Rule %s is blacklisted", *rule.Name)
+				return true
+			}
+		}
+		glog.V(5).Infof("[brownfield] Routing Rule %s is NOT blacklisted", *rule.Name)
+		return false
+	}
+
+	var blacklistedRules []n.ApplicationGatewayRequestRoutingRule
+	var nonBlacklistedRules []n.ApplicationGatewayRequestRoutingRule
+	for _, rule := range er.RoutingRules {
+		if isBlacklisted(rule) {
+			blacklistedRules = append(blacklistedRules, rule)
+			continue
+		}
+		nonBlacklistedRules = append(nonBlacklistedRules, rule)
+	}
+	return blacklistedRules, nonBlacklistedRules
+}
+
+// MergeRules merges list of lists of rules into a single list, maintaining uniqueness.
+func MergeRules(ruleBuckets ...[]n.ApplicationGatewayRequestRoutingRule) []n.ApplicationGatewayRequestRoutingRule {
+	uniq := make(rulesByName)
+	for _, bucket := range ruleBuckets {
+		for _, rule := range bucket {
+			uniq[ruleName(*rule.Name)] = rule
+		}
+	}
+	var merged []n.ApplicationGatewayRequestRoutingRule
+	for _, rule := range uniq {
+		merged = append(merged, rule)
+	}
+	return merged
+}
+
+// LogRules emits a few log lines detailing what rules are created, blacklisted, and removed from ARM.
+func LogRules(existingBlacklisted []n.ApplicationGatewayRequestRoutingRule, existingNonBlacklisted []n.ApplicationGatewayRequestRoutingRule, managedRules []n.ApplicationGatewayRequestRoutingRule) {
+	var garbage []n.ApplicationGatewayRequestRoutingRule
+
+	blacklistedSet := indexRulesByName(existingBlacklisted)
+	managedSet := indexRulesByName(managedRules)
+
+	for ruleName, rule := range indexRulesByName(existingNonBlacklisted) {
+		_, existsInBlacklist := blacklistedSet[ruleName]
+		_, existsInNewRules := managedSet[ruleName]
+		if !existsInBlacklist && !existsInNewRules {
+			garbage = append(garbage, rule)
+		}
+	}
+
+	glog.V(3).Info("[brownfield] Rules AGIC created: ", getRuleNames(managedRules))
+	glog.V(3).Info("[brownfield] Existing Blacklisted Rules AGIC will retain: ", getRuleNames(existingBlacklisted))
+	glog.V(3).Info("[brownfield] Existing Rules AGIC will remove: ", getRuleNames(garbage))
+}
+
+func getRuleNames(cert []n.ApplicationGatewayRequestRoutingRule) string {
+	var names []string
+	for _, p := range cert {
+		names = append(names, *p.Name)
+	}
+	if len(names) == 0 {
+		return "n/a"
+	}
+	return strings.Join(names, ", ")
+}
+
+func indexRulesByName(rules []n.ApplicationGatewayRequestRoutingRule) rulesByName {
+	indexed := make(rulesByName)
+	for _, rule := range rules {
+		indexed[ruleName(*rule.Name)] = rule
+	}
+	return indexed
+}
+
+func (er ExistingResources) getHostNameForRoutingRule(rule n.ApplicationGatewayRequestRoutingRule) *string {
+	listenerName := listenerName(utils.GetLastChunkOfSlashed(*rule.HTTPListener.ID))
+	if listener, found := er.getListenersByName()[listenerName]; !found {
+		return nil
+	} else if listener.HostName != nil {
+		return listener.HostName
+	}
+	return to.StringPtr("")
+}
+
+// getRuleToTargets creates a map from backend pool to targets this backend pool is responsible for.
+// We rely on the configuration that AGIC has already constructed: Frontend Listener, Routing Rules, etc.
+// We use the Listener to obtain the target hostname, the RoutingRule to get the URL etc.
+func (er ExistingResources) getRuleToTargets() (ruleToTargets, pathmapToTargets) {
+	ruleToTargets := make(ruleToTargets)
+	pathMapToTargets := make(pathmapToTargets)
+
+	// Index URLPathMaps by the path map name
+	pathNameToPath := make(map[urlPathMapName]n.ApplicationGatewayURLPathMap)
+	for _, pm := range er.URLPathMaps {
+		pathNameToPath[urlPathMapName(*pm.Name)] = pm
+	}
+
+	for _, rule := range er.RoutingRules {
+		if rule.HTTPListener == nil || rule.HTTPListener.ID == nil {
+			continue
+		}
+		ruleNm := ruleName(*rule.Name)
+		hostName := er.getHostNameForRoutingRule(rule)
+		if hostName == nil {
+			continue
+		}
+
+		if rule.URLPathMap == nil {
+			// SSL Redirects do not have BackendAddressPool
+			target := Target{
+				Hostname: *hostName,
+				// Path deliberately omitted
+			}
+			ruleToTargets[ruleNm] = append(ruleToTargets[ruleNm], target)
+			continue
+		}
+		// Follow the path map
+		pathMapName := urlPathMapName(utils.GetLastChunkOfSlashed(*rule.URLPathMap.ID))
+
+		for _, pathRule := range *pathNameToPath[pathMapName].PathRules {
+			if pathRule.Paths == nil {
+				glog.V(5).Infof("[brownfield] Path Rule %+v does not have paths list", *pathRule.Name)
+				continue
+			}
+
+			for _, path := range *pathRule.Paths {
+				target := Target{
+					Hostname: *hostName,
+					Path:     strings.ToLower(path),
+				}
+				ruleToTargets[ruleNm] = append(ruleToTargets[ruleNm], target)
+				pathMapToTargets[pathMapName] = append(pathMapToTargets[pathMapName], target)
+			}
+		}
+	}
+	return ruleToTargets, pathMapToTargets
+}

--- a/pkg/brownfield/routing_rules.go
+++ b/pkg/brownfield/routing_rules.go
@@ -143,13 +143,15 @@ func (er ExistingResources) getRuleToTargets() (ruleToTargets, pathmapToTargets)
 			continue
 		}
 
+		// Regardless of whether we have a URL PathMap or not. This matches the default backend pool.
+		target := Target{
+			Hostname: *hostName,
+			// Path deliberately omitted
+		}
+		ruleToTargets[ruleNm] = append(ruleToTargets[ruleNm], target)
+
 		if rule.URLPathMap == nil {
 			// SSL Redirects do not have BackendAddressPool
-			target := Target{
-				Hostname: *hostName,
-				// Path deliberately omitted
-			}
-			ruleToTargets[ruleNm] = append(ruleToTargets[ruleNm], target)
 			continue
 		}
 		// Follow the path map

--- a/pkg/brownfield/routing_rules_test.go
+++ b/pkg/brownfield/routing_rules_test.go
@@ -1,0 +1,75 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
+)
+
+var _ = Describe("Test blacklist request routing rules", func() {
+	appGw := fixtures.GetAppGateway()
+
+	ruleDefault := (*appGw.RequestRoutingRules)[0]
+	ruleBasic := (*appGw.RequestRoutingRules)[1]
+	rulePathBased1 := (*appGw.RequestRoutingRules)[2]
+	rulePathBased2 := (*appGw.RequestRoutingRules)[3]
+
+	Context("Test getRoutingRuleToTargetsMap()", func() {
+		It("should create a map of routing rules to targets", func() {
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets() // Host: "bye.com", Paths: [/fox, /bar]
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			ruleToTargets, pathMapToTargets := er.getRuleToTargets()
+			Expect(len(ruleToTargets)).To(Equal(2))
+			Expect(len(pathMapToTargets)).To(Equal(2))
+
+			targetFox := Target{Hostname: tests.OtherHost, Path: fixtures.PathFox}
+			targetFoo := Target{Hostname: tests.Host, Path: fixtures.PathFoo}
+			targetBar := Target{Hostname: tests.Host, Path: fixtures.PathBar}
+			targetBaz := Target{Hostname: tests.Host, Path: fixtures.PathBaz}
+
+			Expect(ruleToTargets[fixtures.RequestRoutingRuleName2]).To(ContainElement(targetFox))
+			Expect(ruleToTargets[fixtures.RequestRoutingRuleName1]).To(ContainElement(targetFoo))
+			Expect(ruleToTargets[fixtures.RequestRoutingRuleName1]).To(ContainElement(targetBar))
+			Expect(ruleToTargets[fixtures.RequestRoutingRuleName1]).To(ContainElement(targetBaz))
+		})
+	})
+
+	Context("Test GetBlacklistedRoutingRules() with a blacklist", func() {
+		It("should create a list of blacklisted and non blacklisted request routing rules", func() {
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets() // Host: "bye.com", Paths: [/fox, /bar]
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			blacklisted, nonBlacklisted := er.GetBlacklistedRoutingRules()
+
+			Expect(len(blacklisted)).To(Equal(3))
+			Expect(blacklisted).To(ContainElement(rulePathBased1))
+			Expect(blacklisted).To(ContainElement(rulePathBased2))
+			Expect(blacklisted).To(ContainElement(ruleBasic))
+
+			Expect(len(nonBlacklisted)).To(Equal(1))
+			Expect(nonBlacklisted).To(ContainElement(ruleDefault))
+
+		})
+	})
+
+	Context("Test GetBlacklistedRoutingRules() with a blacklist with a wild card", func() {
+		It("should create a list of blacklisted and non blacklisted request routing rules", func() {
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets() // Host: "bye.com", Paths: [/fox, /bar]
+			prohibitedTargets = append(prohibitedTargets, &v1.AzureIngressProhibitedTarget{})
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			blacklisted, nonBlacklisted := er.GetBlacklistedRoutingRules()
+			Expect(len(blacklisted)).To(Equal(3))
+			Expect(len(nonBlacklisted)).To(Equal(1))
+
+			Expect(blacklisted).To(ContainElement(ruleBasic))
+			Expect(blacklisted).To(ContainElement(rulePathBased1))
+		})
+	})
+})

--- a/pkg/brownfield/routing_rules_test.go
+++ b/pkg/brownfield/routing_rules_test.go
@@ -84,6 +84,8 @@ var _ = Describe("Test blacklist request routing rules", func() {
 
 			Expect(blacklisted).To(ContainElement(ruleBasic))
 			Expect(blacklisted).To(ContainElement(rulePathBased1))
+			Expect(blacklisted).To(ContainElement(rulePathBased2))
+			Expect(blacklisted).To(ContainElement(ruleDefault))
 		})
 	})
 })

--- a/pkg/brownfield/routing_rules_test.go
+++ b/pkg/brownfield/routing_rules_test.go
@@ -26,19 +26,30 @@ var _ = Describe("Test blacklist request routing rules", func() {
 		It("should create a map of routing rules to targets", func() {
 			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets() // Host: "bye.com", Paths: [/fox, /bar]
 			er := NewExistingResources(appGw, prohibitedTargets, nil)
+
 			ruleToTargets, pathMapToTargets := er.getRuleToTargets()
+
 			Expect(len(ruleToTargets)).To(Equal(2))
 			Expect(len(pathMapToTargets)).To(Equal(2))
 
-			targetFox := Target{Hostname: tests.OtherHost, Path: fixtures.PathFox}
 			targetFoo := Target{Hostname: tests.Host, Path: fixtures.PathFoo}
 			targetBar := Target{Hostname: tests.Host, Path: fixtures.PathBar}
 			targetBaz := Target{Hostname: tests.Host, Path: fixtures.PathBaz}
+			targetHostNoPath := Target{Hostname: tests.Host}
 
-			Expect(ruleToTargets[fixtures.RequestRoutingRuleName2]).To(ContainElement(targetFox))
+			Expect(len(ruleToTargets[fixtures.RequestRoutingRuleName1])).To(Equal(4))
 			Expect(ruleToTargets[fixtures.RequestRoutingRuleName1]).To(ContainElement(targetFoo))
 			Expect(ruleToTargets[fixtures.RequestRoutingRuleName1]).To(ContainElement(targetBar))
 			Expect(ruleToTargets[fixtures.RequestRoutingRuleName1]).To(ContainElement(targetBaz))
+			Expect(ruleToTargets[fixtures.RequestRoutingRuleName1]).To(ContainElement(targetHostNoPath))
+
+			targetFox := Target{Hostname: tests.OtherHost, Path: fixtures.PathFox}
+			targetOtherHostNoPath := Target{Hostname: tests.OtherHost}
+
+			Expect(len(ruleToTargets[fixtures.RequestRoutingRuleName2])).To(Equal(3))
+			Expect(ruleToTargets[fixtures.RequestRoutingRuleName2]).To(ContainElement(targetFox))
+			Expect(ruleToTargets[fixtures.RequestRoutingRuleName2]).To(ContainElement(targetOtherHostNoPath))
+
 		})
 	})
 

--- a/pkg/brownfield/routing_rules_test.go
+++ b/pkg/brownfield/routing_rules_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	v1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
 )
@@ -29,7 +29,7 @@ var _ = Describe("Test blacklist request routing rules", func() {
 
 			ruleToTargets, pathMapToTargets := er.getRuleToTargets()
 
-			Expect(len(ruleToTargets)).To(Equal(2))
+			Expect(len(ruleToTargets)).To(Equal(3))
 			Expect(len(pathMapToTargets)).To(Equal(2))
 
 			targetFoo := Target{Hostname: tests.Host, Path: fixtures.PathFoo}
@@ -73,11 +73,14 @@ var _ = Describe("Test blacklist request routing rules", func() {
 	Context("Test GetBlacklistedRoutingRules() with a blacklist with a wild card", func() {
 		It("should create a list of blacklisted and non blacklisted request routing rules", func() {
 			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets() // Host: "bye.com", Paths: [/fox, /bar]
-			prohibitedTargets = append(prohibitedTargets, &v1.AzureIngressProhibitedTarget{})
+			wildcard := &ptv1.AzureIngressProhibitedTarget{}
+			prohibitedTargets = append(prohibitedTargets, wildcard)
 			er := NewExistingResources(appGw, prohibitedTargets, nil)
+
 			blacklisted, nonBlacklisted := er.GetBlacklistedRoutingRules()
-			Expect(len(blacklisted)).To(Equal(3))
-			Expect(len(nonBlacklisted)).To(Equal(1))
+
+			Expect(len(blacklisted)).To(Equal(4))
+			Expect(len(nonBlacklisted)).To(Equal(0))
 
 			Expect(blacklisted).To(ContainElement(ruleBasic))
 			Expect(blacklisted).To(ContainElement(rulePathBased1))

--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -48,7 +48,9 @@ type ExistingResources struct {
 	ProhibitedTargets  []*ptv1.AzureIngressProhibitedTarget
 	DefaultBackendPool *n.ApplicationGatewayBackendAddressPool
 
-	listenersByName map[listenerName]n.ApplicationGatewayHTTPListener
+	// Cache helper structs
+	listenersByName   map[listenerName]n.ApplicationGatewayHTTPListener
+	urlPathMapsByName pathMapsByName
 }
 
 // NewExistingResources creates a new ExistingResources struct.

--- a/pkg/tests/fixtures/app_gateway.go
+++ b/pkg/tests/fixtures/app_gateway.go
@@ -24,9 +24,10 @@ func GetAppGateway() n.ApplicationGateway {
 			},
 
 			HTTPListeners: &[]n.ApplicationGatewayHTTPListener{
+				*GetDefaultListener(),
+				*GetListenerBasic(),
 				*GetListenerPathBased1(),
 				*GetListenerPathBased2(),
-				*GetListenerBasic(),
 			},
 
 			SslCertificates: &[]n.ApplicationGatewaySslCertificate{


### PR DESCRIPTION
This PR is a small piece of https://github.com/Azure/application-gateway-kubernetes-ingress/pull/369, but it is the heart of https://github.com/Azure/application-gateway-kubernetes-ingress/pull/369.

The primary goal of this PR is to add:
  - `GetBlacklistedPathMaps()`
  - `GetBlacklistedRoutingRules()`

Based on these two lists we can determine whether any of the other App Gateway resources are blacklisted or not (since everything else is in one way or another linked to a `RoutingRule`)