### PR TITLE
brownfield: Adding new ExistingResources struct

### DIFF
--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -31,3 +31,78 @@ type poolsByName map[backendPoolName]n.ApplicationGatewayBackendAddressPool
 
 // TargetBlacklist is a list of Targets, which AGIC is not allowed to apply configuration for.
 type TargetBlacklist *[]Target
+
+// ExistingResources is used in brownfield deployments and
+// holds a copy of the existing App Gateway config, based
+// on which AGIC will determine what should be retained and
+// what config should be discarded or overwritten.
+type ExistingResources struct {
+	BackendPools       []n.ApplicationGatewayBackendAddressPool
+	Certificates       []n.ApplicationGatewaySslCertificate
+	RoutingRules       []n.ApplicationGatewayRequestRoutingRule
+	Listeners          []n.ApplicationGatewayHTTPListener
+	URLPathMaps        []n.ApplicationGatewayURLPathMap
+	HTTPSettings       []n.ApplicationGatewayBackendHTTPSettings
+	Ports              []n.ApplicationGatewayFrontendPort
+	Probes             []n.ApplicationGatewayProbe
+	ProhibitedTargets  []*ptv1.AzureIngressProhibitedTarget
+	DefaultBackendPool *n.ApplicationGatewayBackendAddressPool
+
+	listenersByName map[listenerName]n.ApplicationGatewayHTTPListener
+}
+
+// NewExistingResources creates a new ExistingResources struct.
+func NewExistingResources(appGw n.ApplicationGateway, prohibitedTargets []*ptv1.AzureIngressProhibitedTarget, defaultPool *n.ApplicationGatewayBackendAddressPool) ExistingResources {
+	var allExistingSettings []n.ApplicationGatewayBackendHTTPSettings
+	if appGw.BackendHTTPSettingsCollection != nil {
+		allExistingSettings = *appGw.BackendHTTPSettingsCollection
+	}
+
+	var allExistingRequestRoutingRules []n.ApplicationGatewayRequestRoutingRule
+	if appGw.RequestRoutingRules != nil {
+		allExistingRequestRoutingRules = *appGw.RequestRoutingRules
+	}
+
+	var allExistingListeners []n.ApplicationGatewayHTTPListener
+	if appGw.HTTPListeners != nil {
+		allExistingListeners = *appGw.HTTPListeners
+	}
+
+	var allExistingURLPathMap []n.ApplicationGatewayURLPathMap
+	if appGw.URLPathMaps != nil {
+		allExistingURLPathMap = *appGw.URLPathMaps
+	}
+
+	var allExistingPorts []n.ApplicationGatewayFrontendPort
+	if appGw.FrontendPorts != nil {
+		allExistingPorts = *appGw.FrontendPorts
+	}
+
+	var allExistingCertificates []n.ApplicationGatewaySslCertificate
+	if appGw.SslCertificates != nil {
+		allExistingCertificates = *appGw.SslCertificates
+	}
+
+	var allExistingHealthProbes []n.ApplicationGatewayProbe
+	if appGw.Probes != nil {
+		allExistingHealthProbes = *appGw.Probes
+	}
+
+	var allExistingBackendPools []n.ApplicationGatewayBackendAddressPool
+	if appGw.BackendAddressPools != nil {
+		allExistingBackendPools = *appGw.BackendAddressPools
+	}
+
+	return ExistingResources{
+		BackendPools:       allExistingBackendPools,
+		Certificates:       allExistingCertificates,
+		RoutingRules:       allExistingRequestRoutingRules,
+		Listeners:          allExistingListeners,
+		URLPathMaps:        allExistingURLPathMap,
+		HTTPSettings:       allExistingSettings,
+		Ports:              allExistingPorts,
+		Probes:             allExistingHealthProbes,
+		ProhibitedTargets:  prohibitedTargets,
+		DefaultBackendPool: defaultPool,
+	}
+}


### PR DESCRIPTION
The `ExistingResources` struct will become the core class around which brownfield deployment will revolve as illustrated in the following PR, containing the entire feature: https://github.com/Azure/application-gateway-kubernetes-ingress/pull/369

ExistingResources is used in brownfield deployments and holds a copy of the existing App Gateway config, based on which AGIC will determine what should be retained and what config should be discarded or overwritten.