### PR TITLE
configbuilder: Remove unnecessary methods

### DIFF
--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -49,7 +49,7 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 	if cbCtx.EnableBrownfieldDeployment {
 		er := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, defaultPool)
 
-		// Pools we obtained from App Gateway - we segment them into ones AGIC is and is not allowed to change.
+		// Split the existing pools we obtained from App Gateway into ones AGIC is and is not allowed to change.
 		existingBlacklisted, existingNonBlacklisted := er.GetBlacklistedPools()
 
 		brownfield.LogPools(existingBlacklisted, existingNonBlacklisted, agicCreatedPools)

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -46,19 +46,11 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 		agicCreatedPools = append(agicCreatedPools, *managedPool)
 	}
 
-	if cbCtx.EnvVariables.EnableBrownfieldDeployment == "true" {
-		// These are existing resources we obtain from App Gateway
-		existingBrownfieldCtx := brownfield.PoolContext{
-			Listeners:          c.getExistingListeners(),
-			RoutingRules:       c.getExistingRoutingRules(),
-			PathMaps:           c.getExistingPathMaps(),
-			BackendPools:       c.getExistingBackendPools(),
-			ProhibitedTargets:  cbCtx.ProhibitedTargets,
-			DefaultBackendPool: *defaultPool,
-		}
+	if cbCtx.EnableBrownfieldDeployment {
+		er := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, defaultPool)
 
 		// Pools we obtained from App Gateway - we segment them into ones AGIC is and is not allowed to change.
-		existingBlacklisted, existingNonBlacklisted := existingBrownfieldCtx.GetBlacklistedPools()
+		existingBlacklisted, existingNonBlacklisted := er.GetBlacklistedPools()
 
 		brownfield.LogPools(existingBlacklisted, existingNonBlacklisted, agicCreatedPools)
 

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -179,31 +179,3 @@ func (c *appGwConfigBuilder) addTags() {
 	// Identify the App Gateway as being exclusively managed by a Kubernetes Ingress.
 	c.appGw.Tags[managedByK8sIngress] = to.StringPtr(fmt.Sprintf("%s/%s/%s", version.Version, version.GitCommit, version.BuildDate))
 }
-
-func (c *appGwConfigBuilder) getExistingBackendPools() []n.ApplicationGatewayBackendAddressPool {
-	if c.appGw.BackendAddressPools == nil {
-		return []n.ApplicationGatewayBackendAddressPool{}
-	}
-	return *c.appGw.BackendAddressPools
-}
-
-func (c *appGwConfigBuilder) getExistingListeners() []n.ApplicationGatewayHTTPListener {
-	if c.appGw.HTTPListeners == nil {
-		return []n.ApplicationGatewayHTTPListener{}
-	}
-	return *c.appGw.HTTPListeners
-}
-
-func (c *appGwConfigBuilder) getExistingRoutingRules() []n.ApplicationGatewayRequestRoutingRule {
-	if c.appGw.RequestRoutingRules == nil {
-		return []n.ApplicationGatewayRequestRoutingRule{}
-	}
-	return *c.appGw.RequestRoutingRules
-}
-
-func (c *appGwConfigBuilder) getExistingPathMaps() []n.ApplicationGatewayURLPathMap {
-	if c.appGw.URLPathMaps == nil {
-		return []n.ApplicationGatewayURLPathMap{}
-	}
-	return *c.appGw.URLPathMaps
-}


### PR DESCRIPTION
Removing `ConfigBuilder` helper functions in lieu of using ones provided by `ExistingResources` (and introduced with https://github.com/Azure/application-gateway-kubernetes-ingress/pull/376)

This depends on https://github.com/Azure/application-gateway-kubernetes-ingress/pull/385