### PR TITLE
brownfield: Rename variables to clarify the origin of the config

### DIFF
--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -27,11 +27,11 @@ const (
 )
 
 func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(cbCtx *ConfigBuilderContext) error {
-	httpSettings, _, _, err := c.getBackendsAndSettingsMap(cbCtx)
-	if httpSettings != nil {
-		sort.Sort(sorter.BySettingsName(*httpSettings))
+	agicHTTPSettings, _, _, err := c.getBackendsAndSettingsMap(cbCtx)
+	if agicHTTPSettings != nil {
+		sort.Sort(sorter.BySettingsName(*agicHTTPSettings))
 	}
-	c.appGw.BackendHTTPSettingsCollection = httpSettings
+	c.appGw.BackendHTTPSettingsCollection = agicHTTPSettings
 	return err
 }
 

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -22,12 +22,12 @@ import (
 func (c *appGwConfigBuilder) HealthProbesCollection(cbCtx *ConfigBuilderContext) error {
 	healthProbeCollection, _ := c.newProbesMap(cbCtx)
 	glog.V(5).Infof("Will create %d App Gateway probes.", len(healthProbeCollection))
-	probes := make([]n.ApplicationGatewayProbe, 0, len(healthProbeCollection))
+	agicCreatedProbes := make([]n.ApplicationGatewayProbe, 0, len(healthProbeCollection))
 	for _, probe := range healthProbeCollection {
-		probes = append(probes, probe)
+		agicCreatedProbes = append(agicCreatedProbes, probe)
 	}
-	sort.Sort(sorter.ByHealthProbeName(probes))
-	c.appGw.Probes = &probes
+	sort.Sort(sorter.ByHealthProbeName(agicCreatedProbes))
+	c.appGw.Probes = &agicCreatedProbes
 	return nil
 }
 


### PR DESCRIPTION
Renaming the variables to indicate that these are created by AGIC.

This is a tiny PR to remove some of the load from https://github.com/Azure/application-gateway-kubernetes-ingress/pull/369