### PR TITLE
brownfield: HTTP Settings

### DIFF
--- a/pkg/brownfield/http_settings.go
+++ b/pkg/brownfield/http_settings.go
@@ -95,5 +95,24 @@ func (er ExistingResources) getBlacklistedSettingsSet() map[settingName]interfac
 			blacklistedSettingsSet[settingName] = nil
 		}
 	}
+
+	blacklistedPathMaps, _ := er.GetBlacklistedPathMaps()
+	for _, pathMap := range blacklistedPathMaps {
+		if pathMap.DefaultBackendAddressPool != nil && pathMap.DefaultBackendAddressPool.ID != nil {
+			settingName := settingName(utils.GetLastChunkOfSlashed(*pathMap.DefaultBackendHTTPSettings.ID))
+			blacklistedSettingsSet[settingName] = nil
+		}
+		if pathMap.PathRules == nil {
+			glog.Errorf("PathMap %s does not have PathRules", *pathMap.Name)
+			continue
+		}
+		for _, rule := range *pathMap.PathRules {
+			if rule.BackendAddressPool != nil && rule.BackendAddressPool.ID != nil {
+				settingName := settingName(utils.GetLastChunkOfSlashed(*rule.BackendHTTPSettings.ID))
+				blacklistedSettingsSet[settingName] = nil
+			}
+		}
+	}
+
 	return blacklistedSettingsSet
 }

--- a/pkg/brownfield/http_settings.go
+++ b/pkg/brownfield/http_settings.go
@@ -1,0 +1,99 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"strings"
+
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/golang/glog"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
+)
+
+type settingName string
+type settingsByName map[settingName]n.ApplicationGatewayBackendHTTPSettings
+
+// GetBlacklistedHTTPSettings filters the given list of routing pathMaps to the list pathMaps that AGIC is allowed to manage.
+// HTTP Setting is blacklisted when it is associated with a Routing Rule that is blacklisted.
+func (er ExistingResources) GetBlacklistedHTTPSettings() ([]n.ApplicationGatewayBackendHTTPSettings, []n.ApplicationGatewayBackendHTTPSettings) {
+	blacklistedSettingsSet := er.getBlacklistedSettingsSet()
+	var blacklisted []n.ApplicationGatewayBackendHTTPSettings
+	var nonBlacklisted []n.ApplicationGatewayBackendHTTPSettings
+	for _, setting := range er.HTTPSettings {
+		if _, isBlacklisted := blacklistedSettingsSet[settingName(*setting.Name)]; isBlacklisted {
+			blacklisted = append(blacklisted, setting)
+			glog.V(5).Infof("HTTP Setting %s is blacklisted", *setting.Name)
+			continue
+		}
+		glog.V(5).Infof("HTTP Setting %s is NOT blacklisted", *setting.Name)
+		nonBlacklisted = append(nonBlacklisted, setting)
+	}
+	return blacklisted, nonBlacklisted
+}
+
+// MergeHTTPSettings merges list of lists of HTTP Settings into a single list, maintaining uniqueness.
+func MergeHTTPSettings(settingBuckets ...[]n.ApplicationGatewayBackendHTTPSettings) []n.ApplicationGatewayBackendHTTPSettings {
+	uniq := make(map[string]n.ApplicationGatewayBackendHTTPSettings)
+	for _, bucket := range settingBuckets {
+		for _, setting := range bucket {
+			uniq[*setting.Name] = setting
+		}
+	}
+	var merged []n.ApplicationGatewayBackendHTTPSettings
+	for _, setting := range uniq {
+		merged = append(merged, setting)
+	}
+	return merged
+}
+
+// LogHTTPSettings emits a few log lines detailing what settings are created, blacklisted, and removed from ARM.
+func LogHTTPSettings(existingBlacklisted []n.ApplicationGatewayBackendHTTPSettings, existingNonBlacklisted []n.ApplicationGatewayBackendHTTPSettings, managedSettings []n.ApplicationGatewayBackendHTTPSettings) {
+	var garbage []n.ApplicationGatewayBackendHTTPSettings
+
+	blacklistedSet := indexSettingsByName(existingBlacklisted)
+	managedSet := indexSettingsByName(managedSettings)
+
+	for settingName, setting := range indexSettingsByName(existingNonBlacklisted) {
+		_, existsInBlacklist := blacklistedSet[settingName]
+		_, existsInNewSettings := managedSet[settingName]
+		if !existsInBlacklist && !existsInNewSettings {
+			garbage = append(garbage, setting)
+		}
+	}
+
+	glog.V(3).Info("[brownfield] HTTP Settings AGIC created: ", getSettingNames(managedSettings))
+	glog.V(3).Info("[brownfield] Existing Blacklisted HTTP Settings AGIC will retain: ", getSettingNames(existingBlacklisted))
+	glog.V(3).Info("[brownfield] Existing HTTP Settings AGIC will remove: ", getSettingNames(garbage))
+}
+
+func indexSettingsByName(settings []n.ApplicationGatewayBackendHTTPSettings) settingsByName {
+	settingsByName := make(settingsByName)
+	for _, setting := range settings {
+		settingsByName[settingName(*setting.Name)] = setting
+	}
+	return settingsByName
+}
+
+func getSettingNames(settings []n.ApplicationGatewayBackendHTTPSettings) string {
+	var names []string
+	for _, setting := range settings {
+		names = append(names, *setting.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+func (er ExistingResources) getBlacklistedSettingsSet() map[settingName]interface{} {
+	blacklistedRoutingRules, _ := er.GetBlacklistedRoutingRules()
+	blacklistedSettingsSet := make(map[settingName]interface{})
+	for _, rule := range blacklistedRoutingRules {
+		if rule.BackendHTTPSettings != nil && rule.BackendHTTPSettings.ID != nil {
+			settingName := settingName(utils.GetLastChunkOfSlashed(*rule.BackendHTTPSettings.ID))
+			blacklistedSettingsSet[settingName] = nil
+		}
+	}
+	return blacklistedSettingsSet
+}

--- a/pkg/brownfield/http_settings_test.go
+++ b/pkg/brownfield/http_settings_test.go
@@ -1,0 +1,68 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
+)
+
+var _ = Describe("Test blacklisting HTTP settings", func() {
+
+	appGw := fixtures.GetAppGateway()
+
+	sett1 := (*appGw.BackendHTTPSettingsCollection)[0]
+	sett2 := (*appGw.BackendHTTPSettingsCollection)[1]
+	sett3 := (*appGw.BackendHTTPSettingsCollection)[2]
+
+	Context("Test GetBlacklistedHTTPSettings() with a blacklist", func() {
+		It("should create a list of blacklisted and non blacklisted settings", func() {
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets() // Host: "bye.com", Paths: [/fox, /bar]
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+
+			blacklisted, nonBlacklisted := er.GetBlacklistedHTTPSettings()
+			Expect(len(blacklisted)).To(Equal(2))
+			Expect(len(nonBlacklisted)).To(Equal(1))
+
+			Expect(blacklisted).To(ContainElement(sett1))
+			Expect(blacklisted).To(ContainElement(sett2))
+
+			Expect(nonBlacklisted).To(ContainElement(sett3))
+		})
+	})
+
+	Context("Test GetBlacklistedHTTPSettings() with a blacklist with wild card", func() {
+		It("should create a list of blacklisted and non blacklisted settings", func() {
+			wildcard := &ptv1.AzureIngressProhibitedTarget{
+				Spec: ptv1.AzureIngressProhibitedTargetSpec{},
+			}
+			prohibitedTargets := append(fixtures.GetAzureIngressProhibitedTargets(), wildcard)
+
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			blacklisted, nonBlacklisted := er.GetBlacklistedHTTPSettings()
+			Expect(len(blacklisted)).To(Equal(2))
+
+			// One HTTP Setting is not associated with a listener, so we can't blacklist it.
+			Expect(len(nonBlacklisted)).To(Equal(1))
+		})
+	})
+
+	Context("Test getBlacklistedSettingsSet()", func() {
+		It("should create a set of blacklisted settings", func() {
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets()
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			set := er.getBlacklistedSettingsSet()
+			Expect(len(set)).To(Equal(2))
+			_, exists := set[fixtures.BackendHTTPSettingsName1]
+			Expect(exists).To(BeTrue())
+			_, exists = set[fixtures.BackendHTTPSettingsName2]
+			Expect(exists).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
This PR depends on https://github.com/Azure/application-gateway-kubernetes-ingress/pull/374 and is a small piece of https://github.com/Azure/application-gateway-kubernetes-ingress/pull/369

We leverage the `GetBlacklistedRoutingRules()` introduced in https://github.com/Azure/application-gateway-kubernetes-ingress/pull/374 to determine what `HTTP Settings` are also blacklisted.