### PR TITLE
brownfield: HTTP Listeners

### DIFF
--- a/pkg/brownfield/listeners.go
+++ b/pkg/brownfield/listeners.go
@@ -6,10 +6,86 @@
 package brownfield
 
 import (
+	"strings"
+
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/golang/glog"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
 type listenersByName map[listenerName]n.ApplicationGatewayHTTPListener
+
+// GetBlacklistedListeners filters the given list of health probes to the list Probes that AGIC is allowed to manage.
+func (er ExistingResources) GetBlacklistedListeners() ([]n.ApplicationGatewayHTTPListener, []n.ApplicationGatewayHTTPListener) {
+	blacklistedListenersSet := er.getBlacklistedListenersSet()
+	var blacklisted, nonBlacklisted []n.ApplicationGatewayHTTPListener
+	for _, listener := range er.Listeners {
+		listenerNm := listenerName(*listener.Name)
+		if _, exists := blacklistedListenersSet[listenerNm]; exists {
+			glog.V(5).Infof("[brownfield] Listener %s is blacklisted", listenerNm)
+			blacklisted = append(blacklisted, listener)
+			continue
+		}
+		glog.V(5).Infof("[brownfield] Listener %s is not blacklisted", listenerNm)
+		nonBlacklisted = append(nonBlacklisted, listener)
+	}
+	return blacklisted, nonBlacklisted
+}
+
+// MergeListeners merges list of lists of listeners into a single list, maintaining uniqueness.
+func MergeListeners(listenerBuckets ...[]n.ApplicationGatewayHTTPListener) []n.ApplicationGatewayHTTPListener {
+	uniq := make(listenersByName)
+	for _, bucket := range listenerBuckets {
+		for _, listener := range bucket {
+			uniq[listenerName(*listener.Name)] = listener
+		}
+	}
+	var merged []n.ApplicationGatewayHTTPListener
+	for _, listener := range uniq {
+		merged = append(merged, listener)
+	}
+	return merged
+}
+
+// LogListeners emits a few log lines detailing what Listeners are created, blacklisted, and removed from ARM.
+func LogListeners(existingBlacklisted []n.ApplicationGatewayHTTPListener, existingNonBlacklisted []n.ApplicationGatewayHTTPListener, managedListeners []n.ApplicationGatewayHTTPListener) {
+	var garbage []n.ApplicationGatewayHTTPListener
+
+	blacklistedSet := indexListenersByName(existingBlacklisted)
+	managedSet := indexListenersByName(managedListeners)
+
+	for listenerName, listener := range indexListenersByName(existingNonBlacklisted) {
+		_, existsInBlacklist := blacklistedSet[listenerName]
+		_, existsInNewListeners := managedSet[listenerName]
+		if !existsInBlacklist && !existsInNewListeners {
+			garbage = append(garbage, listener)
+		}
+	}
+
+	glog.V(3).Info("[brownfield] Listeners AGIC created: ", getListenerNames(managedListeners))
+	glog.V(3).Info("[brownfield] Existing Blacklisted Listeners AGIC will retain: ", getListenerNames(existingBlacklisted))
+	glog.V(3).Info("[brownfield] Existing Listeners AGIC will remove: ", getListenerNames(garbage))
+}
+
+func getListenerNames(listeners []n.ApplicationGatewayHTTPListener) string {
+	var names []string
+	for _, p := range listeners {
+		names = append(names, *p.Name)
+	}
+	if len(names) == 0 {
+		return "n/a"
+	}
+	return strings.Join(names, ", ")
+}
+
+func indexListenersByName(listeners []n.ApplicationGatewayHTTPListener) listenersByName {
+	indexed := make(listenersByName)
+	for _, listener := range listeners {
+		indexed[listenerName(*listener.Name)] = listener
+	}
+	return indexed
+}
 
 // getListenersByName indexes listeners by their name
 func (er *ExistingResources) getListenersByName() listenersByName {
@@ -22,4 +98,16 @@ func (er *ExistingResources) getListenersByName() listenersByName {
 	}
 	er.listenersByName = listenersByName
 	return listenersByName
+}
+
+func (er ExistingResources) getBlacklistedListenersSet() map[listenerName]interface{} {
+	blacklistedRoutingRules, _ := er.GetBlacklistedRoutingRules()
+	blacklistedListenersSet := make(map[listenerName]interface{})
+	for _, rule := range blacklistedRoutingRules {
+		if rule.HTTPListener != nil && rule.HTTPListener.ID != nil {
+			listenerName := listenerName(utils.GetLastChunkOfSlashed(*rule.HTTPListener.ID))
+			blacklistedListenersSet[listenerName] = nil
+		}
+	}
+	return blacklistedListenersSet
 }

--- a/pkg/brownfield/listeners_test.go
+++ b/pkg/brownfield/listeners_test.go
@@ -1,0 +1,117 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
+)
+
+var _ = Describe("Test blacklist listeners", func() {
+
+	appGw := fixtures.GetAppGateway()
+	defaultListener := (*appGw.HTTPListeners)[0]
+	listener1 := (*appGw.HTTPListeners)[1]
+	listener2 := (*appGw.HTTPListeners)[2]
+	listener3 := (*appGw.HTTPListeners)[3]
+
+	Context("Test GetBlacklistedListeners() with a blacklist", func() {
+		It("should create a list of blacklisted and non blacklisted listeners", func() {
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets() // Host: "bye.com", Paths: [/fox, /bar]
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			blacklisted, nonBlacklisted := er.GetBlacklistedListeners()
+
+			Expect(len(blacklisted)).To(Equal(3))
+			Expect(blacklisted).To(ContainElement(listener1))
+			Expect(blacklisted).To(ContainElement(listener2))
+			Expect(blacklisted).To(ContainElement(listener3))
+
+			Expect(len(nonBlacklisted)).To(Equal(1))
+			Expect(nonBlacklisted).To(ContainElement(defaultListener))
+		})
+	})
+
+	Context("Test GetBlacklistedListeners() with a blacklist no paths", func() {
+		It("should create a list of blacklisted and non blacklisted listeners", func() {
+			prohibitedTargets := []*ptv1.AzureIngressProhibitedTarget{
+				{
+					Spec: ptv1.AzureIngressProhibitedTargetSpec{
+						Hostname: tests.Host,
+					},
+				},
+			}
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+
+			blacklisted, nonBlacklisted := er.GetBlacklistedListeners()
+
+			Expect(len(blacklisted)).To(Equal(1))
+			Expect(blacklisted).To(ContainElement(listener2))
+
+			Expect(len(nonBlacklisted)).To(Equal(3))
+			Expect(nonBlacklisted).To(ContainElement(defaultListener))
+			Expect(nonBlacklisted).To(ContainElement(listener1))
+			Expect(nonBlacklisted).To(ContainElement(listener3))
+		})
+	})
+
+	Context("Test GetBlacklistedListeners() with a blacklist with a wildcard", func() {
+		It("should create a list of blacklisted and non blacklisted listeners", func() {
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets()                    // Host: "bye.com", Paths: [/fox, /bar]
+			prohibitedTargets = append(prohibitedTargets, &ptv1.AzureIngressProhibitedTarget{}) // Host: '', Path: []
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			blacklisted, nonBlacklisted := er.GetBlacklistedListeners()
+
+			Expect(len(blacklisted)).To(Equal(4))
+			Expect(blacklisted).To(ContainElement(listener1))
+			Expect(blacklisted).To(ContainElement(listener2))
+			Expect(blacklisted).To(ContainElement(listener3))
+
+			Expect(len(nonBlacklisted)).To(Equal(0))
+		})
+	})
+
+	Context("Test getBlacklistedListenersSet()", func() {
+		It("should create a set of blacklisted listeners", func() {
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets()
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			set := er.getBlacklistedListenersSet()
+			Expect(len(set)).To(Equal(3))
+			_, exists := set[fixtures.HTTPListenerPathBased1]
+			Expect(exists).To(BeTrue())
+			_, exists = set[fixtures.HTTPListenerPathBased2]
+			Expect(exists).To(BeTrue())
+			_, exists = set[fixtures.HTTPListenerNameBasic]
+			Expect(exists).To(BeTrue())
+		})
+	})
+
+	Context("Test getBlacklistedListenersSet()", func() {
+		It("should create a set of blacklisted listeners", func() {
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets()
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			er.listenersByName = nil
+			listenersByName := er.getListenersByName()
+			Expect(er.listenersByName).ToNot(BeNil())
+
+			Expect(len(er.listenersByName)).To(Equal(4))
+			Expect(len(listenersByName)).To(Equal(4))
+
+			_, exists := listenersByName[fixtures.HTTPListenerPathBased1]
+			Expect(exists).To(BeTrue())
+			_, exists = listenersByName[fixtures.HTTPListenerPathBased2]
+			Expect(exists).To(BeTrue())
+			_, exists = listenersByName[fixtures.HTTPListenerNameBasic]
+			Expect(exists).To(BeTrue())
+			_, exists = listenersByName[fixtures.DefaultHTTPListenerName]
+			Expect(exists).To(BeTrue())
+		})
+	})
+
+})


### PR DESCRIPTION
This PR depends on https://github.com/Azure/application-gateway-kubernetes-ingress/pull/374 and is a small piece of https://github.com/Azure/application-gateway-kubernetes-ingress/pull/369

We leverage the `GetBlacklistedRoutingRules()` introduced in https://github.com/Azure/application-gateway-kubernetes-ingress/pull/374  to determine what `HTTP Listeners` are also blacklisted.