### PR TITLE
brownfield: Certificates

### DIFF
--- a/pkg/brownfield/certificates.go
+++ b/pkg/brownfield/certificates.go
@@ -1,0 +1,104 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"strings"
+
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/golang/glog"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
+)
+
+type certName string
+type certsByName map[certName]n.ApplicationGatewaySslCertificate
+
+// GetBlacklistedCertificates filters the given list of certificates to the list of certs that AGIC is allowed to manage.
+// A certificate is considered blacklisted when it is associated with a blacklisted listener.
+func (er ExistingResources) GetBlacklistedCertificates() ([]n.ApplicationGatewaySslCertificate, []n.ApplicationGatewaySslCertificate) {
+	blacklistedCertSet := er.getBlacklistedCertSet()
+	var nonBlacklisted []n.ApplicationGatewaySslCertificate
+	var blacklisted []n.ApplicationGatewaySslCertificate
+	for _, cert := range er.Certificates {
+		// Is the certificate associated with a blacklisted listener?
+		if _, exists := blacklistedCertSet[certName(*cert.Name)]; exists {
+			glog.V(5).Infof("[brownfield] Certificate %s is blacklisted", certName(*cert.Name))
+			blacklisted = append(blacklisted, cert)
+			continue
+		}
+		glog.V(5).Infof("[brownfield] Certificate %s is not blacklisted", certName(*cert.Name))
+		nonBlacklisted = append(nonBlacklisted, cert)
+	}
+	return blacklisted, nonBlacklisted
+}
+
+// MergeCerts merges list of lists of certs into a single list, maintaining uniqueness.
+func MergeCerts(certBuckets ...[]n.ApplicationGatewaySslCertificate) []n.ApplicationGatewaySslCertificate {
+	uniq := make(certsByName)
+	for _, bucket := range certBuckets {
+		for _, cert := range bucket {
+			uniq[certName(*cert.Name)] = cert
+		}
+	}
+	var merged []n.ApplicationGatewaySslCertificate
+	for _, cert := range uniq {
+		merged = append(merged, cert)
+	}
+	return merged
+}
+
+// LogCertificates emits a few log lines detailing what certificates are created, blacklisted, and removed from ARM.
+func LogCertificates(existingBlacklisted []n.ApplicationGatewaySslCertificate, existingNonBlacklisted []n.ApplicationGatewaySslCertificate, managedCertificates []n.ApplicationGatewaySslCertificate) {
+	var garbage []n.ApplicationGatewaySslCertificate
+
+	blacklistedSet := indexCertificatesByName(existingBlacklisted)
+	managedSet := indexCertificatesByName(managedCertificates)
+
+	for CertificateName, Certificate := range indexCertificatesByName(existingNonBlacklisted) {
+		_, existsInBlacklist := blacklistedSet[CertificateName]
+		_, existsInNewCertificates := managedSet[CertificateName]
+		if !existsInBlacklist && !existsInNewCertificates {
+			garbage = append(garbage, Certificate)
+		}
+	}
+
+	glog.V(3).Info("[brownfield] Certificates AGIC created: ", getCertificateNames(managedCertificates))
+	glog.V(3).Info("[brownfield] Existing Blacklisted Certificates AGIC will retain: ", getCertificateNames(existingBlacklisted))
+	glog.V(3).Info("[brownfield] Existing Certificates AGIC will remove: ", getCertificateNames(garbage))
+}
+
+func getCertificateNames(certificates []n.ApplicationGatewaySslCertificate) string {
+	var names []string
+	for _, certificate := range certificates {
+		names = append(names, *certificate.Name)
+	}
+	if len(names) == 0 {
+		return "n/a"
+	}
+	return strings.Join(names, ", ")
+}
+
+func indexCertificatesByName(certificates []n.ApplicationGatewaySslCertificate) certsByName {
+	indexed := make(certsByName)
+	for _, cert := range certificates {
+		indexed[certName(*cert.Name)] = cert
+	}
+	return indexed
+}
+
+func (er ExistingResources) getBlacklistedCertSet() map[certName]interface{} {
+	// Get the list of blacklisted listeners, from which we can determine what certificates should be blacklisted.
+	existingBlacklistedListeners, _ := er.GetBlacklistedListeners()
+	blacklistedCertSet := make(map[certName]interface{})
+	for _, listener := range existingBlacklistedListeners {
+		if listener.SslCertificate != nil && listener.SslCertificate.ID != nil {
+			certName := certName(utils.GetLastChunkOfSlashed(*listener.SslCertificate.ID))
+			blacklistedCertSet[certName] = nil
+		}
+	}
+	return blacklistedCertSet
+}

--- a/pkg/brownfield/certificates_test.go
+++ b/pkg/brownfield/certificates_test.go
@@ -1,0 +1,65 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	ptv1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
+)
+
+var _ = Describe("Test blacklist certificates", func() {
+
+	appGw := fixtures.GetAppGateway()
+
+	cert1 := (*appGw.SslCertificates)[0]
+	cert2 := (*appGw.SslCertificates)[1]
+	cert3 := (*appGw.SslCertificates)[2]
+
+	Context("Test GetBlacklistedCertificates() with a blacklist", func() {
+		It("should create a list of blacklisted and non blacklisted certificates", func() {
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets() // Host: "bye.com", Paths: [/fox, /bar]
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			blacklisted, nonBlacklisted := er.GetBlacklistedCertificates()
+			Expect(len(blacklisted)).To(Equal(3))
+			Expect(len(nonBlacklisted)).To(Equal(0))
+
+			Expect(blacklisted).To(ContainElement(cert1))
+			Expect(blacklisted).To(ContainElement(cert2))
+			Expect(blacklisted).To(ContainElement(cert3))
+		})
+	})
+
+	Context("Test GetBlacklistedCertificates() with a blacklist with wild card", func() {
+		It("should create a list of blacklisted and non blacklisted certificates", func() {
+			wildcard := &ptv1.AzureIngressProhibitedTarget{
+				Spec: ptv1.AzureIngressProhibitedTargetSpec{},
+			}
+			prohibitedTargets := append(fixtures.GetAzureIngressProhibitedTargets(), wildcard)
+
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			blacklisted, nonBlacklisted := er.GetBlacklistedCertificates()
+			Expect(len(blacklisted)).To(Equal(3))
+			Expect(len(nonBlacklisted)).To(Equal(0))
+		})
+	})
+
+	Context("Test getBlacklistedCertSet()", func() {
+		It("should create a set of blacklisted certificates", func() {
+			prohibitedTargets := fixtures.GetAzureIngressProhibitedTargets()
+			er := NewExistingResources(appGw, prohibitedTargets, nil)
+			set := er.getBlacklistedCertSet()
+			Expect(len(set)).To(Equal(3))
+			_, exists := set[fixtures.CertificateName1]
+			Expect(exists).To(BeTrue())
+			_, exists = set[fixtures.CertificateName3]
+			Expect(exists).To(BeTrue())
+		})
+	})
+
+})


### PR DESCRIPTION
This PR depends on https://github.com/Azure/application-gateway-kubernetes-ingress/pull/374 and https://github.com/Azure/application-gateway-kubernetes-ingress/pull/381, and is a small piece of https://github.com/Azure/application-gateway-kubernetes-ingress/pull/369

We leverage the `GetBlacklistedListeners()` introduced in https://github.com/Azure/application-gateway-kubernetes-ingress/pull/381 to determine what `SSL Sertificates` are also blacklisted.