### PR TITLE
brownfield: Backend Address Pools

### DIFF
--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -46,19 +46,11 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 		agicCreatedPools = append(agicCreatedPools, *managedPool)
 	}
 
-	if cbCtx.EnvVariables.EnableBrownfieldDeployment == "true" {
-		// These are existing resources we obtain from App Gateway
-		existingBrownfieldCtx := brownfield.PoolContext{
-			Listeners:          c.getExistingListeners(),
-			RoutingRules:       c.getExistingRoutingRules(),
-			PathMaps:           c.getExistingPathMaps(),
-			BackendPools:       c.getExistingBackendPools(),
-			ProhibitedTargets:  cbCtx.ProhibitedTargets,
-			DefaultBackendPool: *defaultPool,
-		}
+	if cbCtx.EnableBrownfieldDeployment {
+		er := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, defaultPool)
 
-		// Pools we obtained from App Gateway - we segment them into ones AGIC is and is not allowed to change.
-		existingBlacklisted, existingNonBlacklisted := existingBrownfieldCtx.GetBlacklistedPools()
+		// Split the existing pools we obtained from App Gateway into ones AGIC is and is not allowed to change.
+		existingBlacklisted, existingNonBlacklisted := er.GetBlacklistedPools()
 
 		brownfield.LogPools(existingBlacklisted, existingNonBlacklisted, agicCreatedPools)
 

--- a/pkg/brownfield/pools.go
+++ b/pkg/brownfield/pools.go
@@ -97,5 +97,24 @@ func (er ExistingResources) getBlacklistedPoolsSet() map[backendPoolName]interfa
 			blacklistedPoolsSet[poolName] = nil
 		}
 	}
+
+	blacklistedPathMaps, _ := er.GetBlacklistedPathMaps()
+	for _, pathMap := range blacklistedPathMaps {
+		if pathMap.DefaultBackendAddressPool != nil && pathMap.DefaultBackendAddressPool.ID != nil {
+			poolName := backendPoolName(utils.GetLastChunkOfSlashed(*pathMap.DefaultBackendAddressPool.ID))
+			blacklistedPoolsSet[poolName] = nil
+		}
+		if pathMap.PathRules == nil {
+			glog.Errorf("PathMap %s does not have PathRules", *pathMap.Name)
+			continue
+		}
+		for _, rule := range *pathMap.PathRules {
+			if rule.BackendAddressPool != nil && rule.BackendAddressPool.ID != nil {
+				poolName := backendPoolName(utils.GetLastChunkOfSlashed(*rule.BackendAddressPool.ID))
+				blacklistedPoolsSet[poolName] = nil
+			}
+		}
+	}
+
 	return blacklistedPoolsSet
 }

--- a/pkg/brownfield/pools.go
+++ b/pkg/brownfield/pools.go
@@ -6,7 +6,6 @@
 package brownfield
 
 import (
-	"encoding/json"
 	"strings"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
@@ -15,38 +14,21 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
+type backendPoolName string
+type poolsByName map[backendPoolName]n.ApplicationGatewayBackendAddressPool
+
 // GetBlacklistedPools removes the managed pools from the given list of pools; resulting in a list of pools not managed by AGIC.
-func (ctx PoolContext) GetBlacklistedPools() ([]n.ApplicationGatewayBackendAddressPool, []n.ApplicationGatewayBackendAddressPool) {
-	blacklist := GetTargetBlacklist(ctx.ProhibitedTargets)
-	if blacklist == nil {
-		return []n.ApplicationGatewayBackendAddressPool{}, ctx.BackendPools
-	}
-	poolToTargets := ctx.getPoolToTargetsMap()
-	glog.V(5).Infof("Backend Pool to Targets map: %+v", poolToTargets)
-
-	// Figure out if the given BackendAddressPool is blacklisted. It will be if it has a host/path that
-	// has been referenced in a AzureIngressProhibitedTarget CRD (even if it has some other paths that are not)
-	isPoolBlacklisted := func(pool n.ApplicationGatewayBackendAddressPool) bool {
-		targetsForPool := poolToTargets[backendPoolName(*pool.Name)]
-		for _, target := range targetsForPool {
-			if target.IsBlacklisted(blacklist) {
-				logTarget(5, target, "in blacklist")
-				return true
-			}
-			logTarget(5, target, "not in blacklist")
-		}
-		return false
-	}
-
+func (er ExistingResources) GetBlacklistedPools() ([]n.ApplicationGatewayBackendAddressPool, []n.ApplicationGatewayBackendAddressPool) {
+	blacklistedPoolsSet := er.getBlacklistedPoolsSet()
 	var blacklistedPools []n.ApplicationGatewayBackendAddressPool
 	var nonBlacklistedPools []n.ApplicationGatewayBackendAddressPool
-	for _, pool := range ctx.BackendPools {
-		if isPoolBlacklisted(pool) {
+	for _, pool := range er.BackendPools {
+		if _, isBlacklisted := blacklistedPoolsSet[backendPoolName(*pool.Name)]; isBlacklisted {
 			blacklistedPools = append(blacklistedPools, pool)
-			glog.V(5).Infof("Backend Address Pool %s is blacklisted", *pool.Name)
+			glog.V(5).Infof("[brownfield] Backend Address Pool %s is blacklisted", *pool.Name)
 			continue
 		}
-		glog.V(5).Infof("Backend Address Pool %s is NOT blacklisted", *pool.Name)
+		glog.V(5).Infof("[brownfield] Backend Address Pool %s is NOT blacklisted", *pool.Name)
 		nonBlacklistedPools = append(nonBlacklistedPools, pool)
 	}
 	return blacklistedPools, nonBlacklistedPools
@@ -106,80 +88,14 @@ func getPoolNames(pool []n.ApplicationGatewayBackendAddressPool) string {
 	return strings.Join(names, ", ")
 }
 
-func logTarget(verbosity glog.Level, target Target, message string) {
-	t, _ := json.Marshal(target)
-	glog.V(verbosity).Infof("Target is "+message+": %s", t)
-}
-
-// getPoolToTargetsMap creates a map from backend pool to targets this backend pool is responsible for.
-// We rely on the configuration that AGIC has already constructed: Frontend Listener, Routing Rules, etc.
-// We use the Listener to obtain the target hostname, the RoutingRule to get the
-func (c PoolContext) getPoolToTargetsMap() poolToTargets {
-
-	// Index listeners by their name
-	listenersByName := make(map[listenerName]n.ApplicationGatewayHTTPListener)
-	for _, listener := range c.Listeners {
-		listenersByName[listenerName(*listener.Name)] = listener
-	}
-
-	// Index URLPathMaps by the path map name
-	pathNameToPath := make(map[pathmapName]n.ApplicationGatewayURLPathMap)
-	for _, pm := range c.PathMaps {
-		pathNameToPath[pathmapName(*pm.Name)] = pm
-	}
-
-	// Add the default backend pool - with no target. This will be overwritten if the default backend pool exists with
-	// some targets already.
-	poolToTarget := poolToTargets{
-		backendPoolName(*c.DefaultBackendPool.Name): []Target{},
-	}
-
-	for _, rule := range c.RoutingRules {
-		listenerName := listenerName(utils.GetLastChunkOfSlashed(*rule.HTTPListener.ID))
-
-		var hostName string
-		if listener, found := listenersByName[listenerName]; !found {
-			continue
-		} else if listener.HostName != nil {
-			hostName = *listener.HostName
-		} else {
-			hostName = ""
-		}
-
-		target := Target{Hostname: hostName}
-		if rule.URLPathMap == nil {
-			// SSL Redirects do not have BackendAddressPool
-			if rule.BackendAddressPool == nil {
-				continue
-			}
+func (er ExistingResources) getBlacklistedPoolsSet() map[backendPoolName]interface{} {
+	blacklistedRoutingRules, _ := er.GetBlacklistedRoutingRules()
+	blacklistedPoolsSet := make(map[backendPoolName]interface{})
+	for _, rule := range blacklistedRoutingRules {
+		if rule.BackendAddressPool != nil && rule.BackendAddressPool.ID != nil {
 			poolName := backendPoolName(utils.GetLastChunkOfSlashed(*rule.BackendAddressPool.ID))
-			poolToTarget[poolName] = append(poolToTarget[poolName], target)
-		} else {
-			// Follow the path map
-			pathMapName := pathmapName(utils.GetLastChunkOfSlashed(*rule.URLPathMap.ID))
-			if pathNameToPath[pathMapName].DefaultBackendAddressPool == nil {
-				glog.Errorf("Path map with name %s does not have PathRules and does not have DefaultBackendAddressPool", pathMapName)
-				continue
-			}
-			poolName := backendPoolName(*c.DefaultBackendPool.Name)
-			poolToTarget[poolName] = append(poolToTarget[poolName], target)
-			for _, pathRule := range *pathNameToPath[pathMapName].PathRules {
-				if pathRule.BackendAddressPool == nil {
-					glog.Errorf("Path Rule %+v does not have BackendAddressPool", *pathRule.Name)
-					continue
-				}
-				poolName := backendPoolName(utils.GetLastChunkOfSlashed(*pathRule.BackendAddressPool.ID))
-				if pathRule.Paths == nil {
-					glog.V(5).Infof("Path Rule %+v does not have paths list", *pathRule.Name)
-					continue
-				}
-				for _, path := range *pathRule.Paths {
-					target.Path = strings.ToLower(path)
-					poolToTarget[poolName] = append(poolToTarget[poolName], target)
-				}
-			}
-
+			blacklistedPoolsSet[poolName] = nil
 		}
 	}
-	return poolToTarget
+	return blacklistedPoolsSet
 }

--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -23,11 +23,7 @@ type PoolContext struct {
 
 type listenerName string
 type pathmapName string
-type backendPoolName string
-
 type poolToTargets map[backendPoolName][]Target
-
-type poolsByName map[backendPoolName]n.ApplicationGatewayBackendAddressPool
 
 // TargetBlacklist is a list of Targets, which AGIC is not allowed to apply configuration for.
 type TargetBlacklist *[]Target


### PR DESCRIPTION
This PR depends on https://github.com/Azure/application-gateway-kubernetes-ingress/pull/374 and is a small piece of https://github.com/Azure/application-gateway-kubernetes-ingress/pull/369

We leverage the `GetBlacklistedRoutingRules()` introduced in https://github.com/Azure/application-gateway-kubernetes-ingress/pull/374 to determine what `HTTP Settings` are also blacklisted.