### PR TITLE
Introducing EnableIstioIntegration feature flag within the ConfigBuilderContext struct

### DIFF
--- a/pkg/appgw/types.go
+++ b/pkg/appgw/types.go
@@ -26,4 +26,7 @@ type ConfigBuilderContext struct {
 
 	// Feature flag toggling Brownfield Deployment across the entire AGIC code base.
 	EnableBrownfieldDeployment bool
+
+	// Feature flag toggling Istio Integration across the entire AGIC code base.
+	EnableIstioIntegration bool
 }


### PR DESCRIPTION
This PR creates `EnableIstioIntegration` as a first-class feature flag within the `ConfigBuilderContext` struct.

We also reorganize the population of the `ProhibitedTargets`, `IstioGateways`, and `IstioVirtualServices` so that these happen only of the dedicated feature flag is on.