### PR TITLE
fix: port resolution when targetPort is string

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
 				{
-					Name: "frontendPort",
+					Name: "servicePort",
 					TargetPort: intstr.IntOrString{
 						Type:   intstr.String,
 						StrVal: backendName,
@@ -163,7 +163,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 				},
 				Ports: []v1.EndpointPort{
 					{
-						Name:     backendName,
+						Name:     "servicePort",
 						Port:     backendPort,
 						Protocol: v1.ProtocolTCP,
 					},

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -177,9 +177,8 @@ func (c *appGwConfigBuilder) getBackendsAndSettingsMap(cbCtx *ConfigBuilderConte
 							resolvedBackendPorts[pair] = nil
 						} else {
 							// if service port is defined by name, need to resolve
-							targetPortName := sp.TargetPort.StrVal
-							glog.V(1).Infof("resolving port name %s", targetPortName)
-							targetPortsResolved := c.resolvePortName(targetPortName, &backendID)
+							glog.V(3).Infof("resolving port name %s", sp.Name)
+							targetPortsResolved := c.resolvePortName(sp.Name, &backendID)
 							for targetPort := range targetPortsResolved {
 								pair := serviceBackendPortPair{
 									ServicePort: sp.Port,

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -7,12 +7,13 @@ package appgw
 
 import (
 	"fmt"
+	"sort"
+
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sort"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/brownfield"
@@ -124,7 +125,7 @@ func (c *appGwConfigBuilder) getProbeForServiceContainer(service *v1.Service, ba
 				// port is defined as port number
 				allPorts[sp.TargetPort.IntVal] = nil
 			} else {
-				for targetPort := range c.resolvePortName(sp.TargetPort.StrVal, &backendID) {
+				for targetPort := range c.resolvePortName(sp.Name, &backendID) {
 					allPorts[targetPort] = nil
 				}
 			}


### PR DESCRIPTION
This PR fixes port resolution.
In case when we get a targetport as string, we do a lookup on endpoints object to get the port using the target port name.
But endpoints object contains port with `Name` taken from service Port. So the lookup should happen using service's port name.

Fixes #372 