### PR TITLE
chore: set resourceIds in subresources

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -48,6 +48,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	var ctxt *k8scontext.Context
 	var configBuilder ConfigBuilder
 	var stopChannel chan struct{}
+	var appGwIdentifier Identifier
 
 	version.Version = "a"
 	version.GitCommit = "b"
@@ -194,6 +195,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		probeName := generateProbeName(expectedBackend.ServiceName, expectedBackend.ServicePort.String(), ingress)
 		probe := &n.ApplicationGatewayProbe{
 			Name: &probeName,
+			ID:   to.StringPtr(appGwIdentifier.probeID(probeName)),
 			ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
 				Protocol:           n.HTTP,
 				Host:               to.StringPtr(tests.Host),
@@ -208,19 +210,19 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		Expect(len(probes)).To(Equal(2))
 
 		// Test the default health probe.
-		Expect(probes).To(ContainElement(defaultProbe()))
+		Expect(probes).To(ContainElement(defaultProbe(appGwIdentifier)))
 		// Test the ingress health probe that we installed.
 		Expect(probes).To(ContainElement(*probe))
 	}
 
 	defaultBackendHTTPSettingsChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
-		appGwIdentifier := Identifier{}
 		expectedBackend := &ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend
 		probeID := appGwIdentifier.probeID(generateProbeName(expectedBackend.ServiceName, expectedBackend.ServicePort.String(), ingress))
 		httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), backendPort, ingress.Name)
 		httpSettings := &n.ApplicationGatewayBackendHTTPSettings{
 			Etag: to.StringPtr("*"),
 			Name: &httpSettingsName,
+			ID:   to.StringPtr(appGwIdentifier.httpSettingsID(httpSettingsName)),
 			ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 				Protocol: n.HTTP,
 				Port:     &backendPort,
@@ -231,7 +233,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// Test the default backend HTTP settings.
-		Expect(*appGW.BackendHTTPSettingsCollection).To(ContainElement(defaultBackendHTTPSettings(appGwIdentifier.probeID(defaultProbeName))))
+		Expect(*appGW.BackendHTTPSettingsCollection).To(ContainElement(defaultBackendHTTPSettings(appGwIdentifier, defaultProbeName)))
 		// Test the ingress backend HTTP setting that we installed.
 		Expect(*appGW.BackendHTTPSettingsCollection).To(ContainElement(*httpSettings))
 	}
@@ -250,19 +252,19 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// Test the default backend address pool.
-		Expect(*appGW.BackendAddressPools).To(ContainElement(*defaultBackendAddressPool()))
+		Expect(*appGW.BackendAddressPools).To(ContainElement(defaultBackendAddressPool(appGwIdentifier)))
 		// Test the ingress backend address pool that we installed.
 		Expect(*appGW.BackendAddressPools).To(ContainElement(*addressPool))
 	}
 
 	defaultListenersChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
 		// Test the listener.
-		appGwIdentifier := Identifier{}
 		frontendPortID := appGwIdentifier.frontendPortID(generateFrontendPortName(80))
 		listenerName := generateListenerName(listenerIdentifier{80, domainName})
 		listener := &n.ApplicationGatewayHTTPListener{
 			Etag: to.StringPtr("*"),
 			Name: &listenerName,
+			ID:   to.StringPtr(appGwIdentifier.listenerID(listenerName)),
 			ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
 				FrontendIPConfiguration: resourceRef("*"),
 				FrontendPort:            resourceRef(frontendPortID),
@@ -379,6 +381,11 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 	BeforeEach(func() {
 		stopChannel = make(chan struct{})
+		appGwIdentifier = Identifier{
+			SubscriptionID: tests.Subscription,
+			ResourceGroup:  tests.ResourceGroup,
+			AppGwName:      tests.AppGwName,
+		}
 
 		// Create the mock K8s client.
 		k8sClient = testclient.NewSimpleClientset()
@@ -413,7 +420,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		Expect(ctxt).ShouldNot(BeNil(), "Unable to create `k8scontext`")
 
 		// Initialize the `ConfigBuilder`
-		configBuilder = NewConfigBuilder(ctxt, &Identifier{}, &n.ApplicationGateway{}, record.NewFakeRecorder(100))
+		configBuilder = NewConfigBuilder(ctxt, &appGwIdentifier, &n.ApplicationGateway{}, record.NewFakeRecorder(100))
 
 		builder, ok := configBuilder.(*appGwConfigBuilder)
 		Expect(ok).Should(BeTrue(), "Unable to get the more specific configBuilder implementation")
@@ -501,16 +508,16 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			ingressList := testIngress()
 
 			EmptyHealthProbeChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
-				Expect((*appGW.Probes)[0]).To(Equal(defaultProbe()))
+				Expect((*appGW.Probes)[0]).To(Equal(defaultProbe(appGwIdentifier)))
 			}
 
 			EmptyBackendHTTPSettingsChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
-				appGwIdentifier := Identifier{}
 				expectedBackend := &ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend
 				httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), servicePort, ingress.Name)
 				httpSettings := &n.ApplicationGatewayBackendHTTPSettings{
 					Etag: to.StringPtr("*"),
 					Name: &httpSettingsName,
+					ID:   to.StringPtr(appGwIdentifier.httpSettingsID(httpSettingsName)),
 					ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 						Protocol: n.HTTP,
 						Port:     &servicePort,
@@ -520,14 +527,14 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 				}
 
 				// Test the default backend HTTP settings.
-				Expect((*appGW.BackendHTTPSettingsCollection)).To(ContainElement(defaultBackendHTTPSettings(appGwIdentifier.probeID(defaultProbeName))))
+				Expect((*appGW.BackendHTTPSettingsCollection)).To(ContainElement(defaultBackendHTTPSettings(appGwIdentifier, defaultProbeName)))
 				// Test the ingress backend HTTP setting that we installed.
 				Expect((*appGW.BackendHTTPSettingsCollection)).To(ContainElement(*httpSettings))
 			}
 
 			EmptyBackendAddressPoolChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
 				// Test the default backend address pool.
-				Expect((*appGW.BackendAddressPools)).To(ContainElement(*defaultBackendAddressPool()))
+				Expect((*appGW.BackendAddressPools)).To(ContainElement(defaultBackendAddressPool(appGwIdentifier)))
 			}
 
 			testAGConfig(ingressList, serviceList, appGwConfigSettings{
@@ -619,7 +626,6 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 			httpsOnlyListenersChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
 				// Test the listener.
-				appGwIdentifier := Identifier{}
 				secretID := secretIdentifier{
 					Namespace: ingressNS,
 					Name:      "test-ag-secret",
@@ -631,6 +637,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 				httpsListener := &n.ApplicationGatewayHTTPListener{
 					Etag: to.StringPtr("*"),
 					Name: &httpsListenerName,
+					ID:   to.StringPtr(appGwIdentifier.listenerID(httpsListenerName)),
 					ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
 						FrontendIPConfiguration: resourceRef("*"),
 						FrontendPort:            resourceRef(frontendPortID),
@@ -729,13 +736,13 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			ingressList := annotationIngress()
 
 			annotationsHTTPSettingsChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
-				appGwIdentifier := Identifier{}
 				expectedBackend := &ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend
 				probeID := appGwIdentifier.probeID(generateProbeName(expectedBackend.ServiceName, expectedBackend.ServicePort.String(), ingress))
 				httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), backendPort, ingress.Name)
 				httpSettings := &n.ApplicationGatewayBackendHTTPSettings{
 					Etag: to.StringPtr("*"),
 					Name: &httpSettingsName,
+					ID:   to.StringPtr(appGwIdentifier.httpSettingsID(httpSettingsName)),
 					ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 						Protocol:            n.HTTP,
 						Port:                &backendPort,
@@ -753,11 +760,11 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 				backendSettings := *appGW.BackendHTTPSettingsCollection
 
-				defaultProbe := defaultBackendHTTPSettings(appGwIdentifier.probeID(defaultProbeName))
+				defaultHTTPSettings := defaultBackendHTTPSettings(appGwIdentifier, defaultProbeName)
 
 				Expect(len(backendSettings)).To(Equal(2))
 				// Test the default backend HTTP settings.
-				Expect(backendSettings).To(ContainElement(defaultProbe))
+				Expect(backendSettings).To(ContainElement(defaultHTTPSettings))
 				// Test the ingress backend HTTP setting that we installed.
 				Expect(backendSettings).To(ContainElement(*httpSettings))
 			}

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -29,9 +29,9 @@ func (c *appGwConfigBuilder) BackendAddressPools(cbCtx *ConfigBuilderContext) er
 }
 
 func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.ApplicationGatewayBackendAddressPool {
-	defaultPool := defaultBackendAddressPool()
+	defaultPool := defaultBackendAddressPool(c.appGwIdentifier)
 	managedPoolsByName := map[string]*n.ApplicationGatewayBackendAddressPool{
-		*defaultPool.Name: defaultPool,
+		*defaultPool.Name: &defaultPool,
 	}
 	_, _, serviceBackendPairMap, _ := c.getBackendsAndSettingsMap(cbCtx)
 	for backendID, serviceBackendPair := range serviceBackendPairMap {
@@ -57,7 +57,7 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 	}
 
 	if cbCtx.EnableBrownfieldDeployment {
-		er := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, defaultPool)
+		er := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, &defaultPool)
 
 		// Split the existing pools we obtained from App Gateway into ones AGIC is and is not allowed to change.
 		existingBlacklisted, existingNonBlacklisted := er.GetBlacklistedPools()
@@ -73,14 +73,14 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 }
 
 func (c *appGwConfigBuilder) newBackendPoolMap(cbCtx *ConfigBuilderContext) map[backendIdentifier]*n.ApplicationGatewayBackendAddressPool {
-	defaultPool := defaultBackendAddressPool()
+	defaultPool := defaultBackendAddressPool(c.appGwIdentifier)
 	addressPools := map[string]*n.ApplicationGatewayBackendAddressPool{
-		*defaultPool.Name: defaultPool,
+		*defaultPool.Name: &defaultPool,
 	}
 	backendPoolMap := make(map[backendIdentifier]*n.ApplicationGatewayBackendAddressPool)
 	_, _, serviceBackendPairMap, _ := c.getBackendsAndSettingsMap(cbCtx)
 	for backendID, serviceBackendPair := range serviceBackendPairMap {
-		backendPoolMap[backendID] = defaultPool
+		backendPoolMap[backendID] = &defaultPool
 		if pool := c.getBackendAddressPool(backendID, serviceBackendPair, addressPools); pool != nil {
 			backendPoolMap[backendID] = pool
 		}

--- a/pkg/appgw/backendaddresspools_test.go
+++ b/pkg/appgw/backendaddresspools_test.go
@@ -19,7 +19,6 @@ import (
 // appgw_suite_test.go launches these Ginkgo tests
 
 var _ = Describe("Test the creation of Backend Pools from Ingress definition", func() {
-
 	subset := v1.EndpointSubset{
 		Addresses: []v1.EndpointAddress{
 			{Hostname: "abc"},
@@ -61,19 +60,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		})
 
 		It("should contain correct backend address pools", func() {
-			props := &n.ApplicationGatewayBackendAddressPoolPropertiesFormat{
-				BackendIPConfigurations: nil,
-				BackendAddresses:        &[]n.ApplicationGatewayBackendAddress{},
-				ProvisioningState:       nil,
-			}
-			expected := n.ApplicationGatewayBackendAddressPool{
-				Name: to.StringPtr("defaultaddresspool"),
-				Etag: nil,
-				Type: nil,
-				ID:   nil,
-				ApplicationGatewayBackendAddressPoolPropertiesFormat: props,
-			}
-			Expect(*cb.appGw.BackendAddressPools).To(ContainElement(expected))
+			Expect(*cb.appGw.BackendAddressPools).To(ContainElement(defaultBackendAddressPool(cb.appGwIdentifier)))
 		})
 	})
 

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -228,9 +228,8 @@ func (c *appGwConfigBuilder) getIstioDestinationsAndSettingsMap(cbCtx *ConfigBui
 		return nil, nil, nil, errors.New("unable to resolve backend port for some services")
 	}
 
-	probeID := c.appGwIdentifier.probeID(defaultProbeName)
 	httpSettingsCollection := make(map[string]n.ApplicationGatewayBackendHTTPSettings)
-	defaultBackend := defaultBackendHTTPSettings(probeID)
+	defaultBackend := defaultBackendHTTPSettings(c.appGwIdentifier, defaultProbeName)
 	httpSettingsCollection[*defaultBackend.Name] = defaultBackend
 
 	for destinationID, serviceBackendPairs := range serviceBackendPairsMap {
@@ -359,9 +358,8 @@ func (c *appGwConfigBuilder) getBackendsAndSettingsMap(cbCtx *ConfigBuilderConte
 		return nil, nil, nil, errors.New("unable to resolve backend port for some services")
 	}
 
-	probeID := c.appGwIdentifier.probeID(defaultProbeName)
 	httpSettingsCollection := make(map[string]n.ApplicationGatewayBackendHTTPSettings)
-	defaultBackend := defaultBackendHTTPSettings(probeID)
+	defaultBackend := defaultBackendHTTPSettings(c.appGwIdentifier, defaultProbeName)
 	httpSettingsCollection[*defaultBackend.Name] = defaultBackend
 
 	// enforce single pair relationship between service port and backend port
@@ -401,6 +399,7 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 	httpSettings := n.ApplicationGatewayBackendHTTPSettings{
 		Etag: to.StringPtr("*"),
 		Name: &httpSettingsName,
+		ID:   to.StringPtr(c.appGwIdentifier.httpSettingsID(httpSettingsName)),
 		ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 			Protocol: n.HTTP,
 			Port:     &port,
@@ -454,6 +453,7 @@ func (c *appGwConfigBuilder) generateIstioHTTPSettings(destinationID istioDestin
 	httpSettings := n.ApplicationGatewayBackendHTTPSettings{
 		Etag: to.StringPtr("*"),
 		Name: &httpSettingsName,
+		ID:   to.StringPtr(c.appGwIdentifier.httpSettingsID(httpSettingsName)),
 		ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 			Protocol: n.HTTP,
 			Port:     &port,

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -48,12 +48,14 @@ func NewConfigBuilder(context *k8scontext.Context, appGwIdentifier *Identifier, 
 
 // Build gets a pointer to updated ApplicationGatewayPropertiesFormat.
 func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationGateway, error) {
+	glog.V(5).Infof("-----Generating Probes-----")
 	err := c.HealthProbesCollection(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate Health Probes, error [%v]", err.Error())
 		return nil, errors.New("unable to generate health probes")
 	}
 
+	glog.V(5).Infof("-----Generating Backend Http Settings-----")
 	err = c.BackendHTTPSettingsCollection(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate backend http settings, error [%v]", err.Error())
@@ -61,6 +63,7 @@ func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationG
 	}
 
 	// BackendAddressPools depend on BackendHTTPSettings
+	glog.V(5).Infof("-----Generating Backend Pools-----")
 	err = c.BackendAddressPools(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate backend address pools, error [%v]", err.Error())
@@ -71,6 +74,7 @@ func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationG
 	// This also creates redirection configuration (if TLS is configured and Ingress is annotated).
 	// This configuration must be attached to request routing rules, which are created in the steps below.
 	// The order of operations matters.
+	glog.V(5).Infof("-----Generating Listener, Ports and Certificates-----")
 	err = c.Listeners(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate frontend listeners, error [%v]", err.Error())
@@ -78,6 +82,7 @@ func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationG
 	}
 
 	// SSL redirection configurations created elsewhere will be attached to the appropriate rule in this step.
+	glog.V(5).Infof("-----Generating Routing rules and PathMaps-----")
 	err = c.RequestRoutingRules(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate request routing rules, error [%v]", err.Error())

--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -88,10 +88,11 @@ func (c *appGwConfigBuilder) getListenerConfigs(ingressList []*v1beta1.Ingress) 
 func (c *appGwConfigBuilder) newListener(listener listenerIdentifier, protocol n.ApplicationGatewayProtocol, envVariables environment.EnvVariables) n.ApplicationGatewayHTTPListener {
 	frontendPortName := generateFrontendPortName(listener.FrontendPort)
 	frontendPortID := c.appGwIdentifier.frontendPortID(frontendPortName)
-
+	listenerName := generateListenerName(listener)
 	return n.ApplicationGatewayHTTPListener{
 		Etag: to.StringPtr("*"),
-		Name: to.StringPtr(generateListenerName(listener)),
+		Name: to.StringPtr(listenerName),
+		ID:   to.StringPtr(c.appGwIdentifier.listenerID(listenerName)),
 		ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
 			// TODO: expose this to external configuration
 			FrontendIPConfiguration: resourceRef(*c.getIPConfigurationID(envVariables)),

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -98,6 +98,7 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			expected := n.ApplicationGatewayHTTPListener{
 				Etag: to.StringPtr("*"),
 				Name: to.StringPtr(expectedName),
+				ID:   to.StringPtr(cb.appGwIdentifier.listenerID(expectedName)),
 				ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
 					// TODO: expose this to external configuration
 					FrontendIPConfiguration: resourceRef(tests.IPID1),
@@ -128,6 +129,7 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			expected := n.ApplicationGatewayHTTPListener{
 				Etag: to.StringPtr("*"),
 				Name: to.StringPtr(expectedName),
+				ID:   to.StringPtr(cb.appGwIdentifier.listenerID(expectedName)),
 				ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
 					// TODO: expose this to external configuration
 					FrontendIPConfiguration: resourceRef(tests.IPID2),

--- a/pkg/appgw/frontend_ports.go
+++ b/pkg/appgw/frontend_ports.go
@@ -45,6 +45,7 @@ func (c *appGwConfigBuilder) getFrontendPorts(cbCtx *ConfigBuilderContext) *[]n.
 		frontendPorts = append(frontendPorts, n.ApplicationGatewayFrontendPort{
 			Etag: to.StringPtr("*"),
 			Name: &frontendPortName,
+			ID:   to.StringPtr(c.appGwIdentifier.frontendPortID(frontendPortName)),
 			ApplicationGatewayFrontendPortPropertiesFormat: &n.ApplicationGatewayFrontendPortPropertiesFormat{
 				Port: to.Int32Ptr(port),
 			},

--- a/pkg/appgw/frontend_ports_test.go
+++ b/pkg/appgw/frontend_ports_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Process ingress rules", func() {
 				Name: to.StringPtr("fp-80"),
 				Etag: to.StringPtr("*"),
 				Type: nil,
-				ID:   nil,
+				ID:   to.StringPtr(cb.appGwIdentifier.frontendPortID("fp-80")),
 			}
 			Expect(*ports).To(ContainElement(expected))
 		})
@@ -55,7 +55,7 @@ var _ = Describe("Process ingress rules", func() {
 				Name: to.StringPtr("fp-443"),
 				Etag: to.StringPtr("*"),
 				Type: nil,
-				ID:   nil,
+				ID:   to.StringPtr(cb.appGwIdentifier.frontendPortID("fp-443")),
 			}
 			Expect(*ports).To(ContainElement(expected))
 		})

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -46,25 +46,7 @@ var _ = Describe("configure App Gateway health probes", func() {
 		actual := cb.appGw.Probes
 
 		// We expect our health probe configurator to have arrived at this final setup
-		defaultProbe := n.ApplicationGatewayProbe{
-
-			ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
-				Protocol:                            n.HTTP,
-				Host:                                to.StringPtr("localhost"),
-				Path:                                to.StringPtr("/"),
-				Interval:                            to.Int32Ptr(30),
-				Timeout:                             to.Int32Ptr(30),
-				UnhealthyThreshold:                  to.Int32Ptr(3),
-				PickHostNameFromBackendHTTPSettings: nil,
-				MinServers:                          nil,
-				Match:                               nil,
-				ProvisioningState:                   nil,
-			},
-			Name: to.StringPtr(agPrefix + "defaultprobe"),
-			Etag: nil,
-			Type: nil,
-			ID:   nil,
-		}
+		probeName := agPrefix + "pb-" + tests.Namespace + "-" + tests.ServiceName + "-443---name--"
 		probeForHost := n.ApplicationGatewayProbe{
 			ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
 				Protocol:                            n.HTTP,
@@ -78,12 +60,13 @@ var _ = Describe("configure App Gateway health probes", func() {
 				Match:                               nil,
 				ProvisioningState:                   nil,
 			},
-			Name: to.StringPtr(agPrefix + "pb-" + tests.Namespace + "-" + tests.ServiceName + "-443---name--"),
+			Name: to.StringPtr(probeName),
 			Etag: nil,
 			Type: nil,
-			ID:   nil,
+			ID:   to.StringPtr(cb.appGwIdentifier.probeID(probeName)),
 		}
 
+		probeName = agPrefix + "pb-" + tests.Namespace + "-" + tests.ServiceName + "-80---name--"
 		probeForOtherHost := n.ApplicationGatewayProbe{
 			ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
 				Protocol:                            n.HTTP,
@@ -97,10 +80,10 @@ var _ = Describe("configure App Gateway health probes", func() {
 				Match:                               nil,
 				ProvisioningState:                   nil,
 			},
-			Name: to.StringPtr(agPrefix + "pb-" + tests.Namespace + "-" + tests.ServiceName + "-80---name--"),
+			Name: to.StringPtr(probeName),
 			Etag: nil,
 			Type: nil,
-			ID:   nil,
+			ID:   to.StringPtr(cb.appGwIdentifier.probeID(probeName)),
 		}
 
 		It("should have exactly 3 records", func() {
@@ -108,7 +91,7 @@ var _ = Describe("configure App Gateway health probes", func() {
 		})
 
 		It("should have created 1 default probe", func() {
-			Expect(*actual).To(ContainElement(defaultProbe))
+			Expect(*actual).To(ContainElement(defaultProbe(cb.appGwIdentifier)))
 		})
 
 		It("should have created 1 probe for Host", func() {
@@ -135,33 +118,12 @@ var _ = Describe("configure App Gateway health probes", func() {
 		_ = cb.HealthProbesCollection(cbCtx)
 		actual := cb.appGw.Probes
 
-		// We expect our health probe configurator to have arrived at this final setup
-		defaultProbe := n.ApplicationGatewayProbe{
-
-			ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
-				Protocol:                            n.HTTP,
-				Host:                                to.StringPtr("localhost"),
-				Path:                                to.StringPtr("/"),
-				Interval:                            to.Int32Ptr(30),
-				Timeout:                             to.Int32Ptr(30),
-				UnhealthyThreshold:                  to.Int32Ptr(3),
-				PickHostNameFromBackendHTTPSettings: nil,
-				MinServers:                          nil,
-				Match:                               nil,
-				ProvisioningState:                   nil,
-			},
-			Name: to.StringPtr(agPrefix + "defaultprobe"),
-			Etag: nil,
-			Type: nil,
-			ID:   nil,
-		}
-
 		It("should have exactly 1 record", func() {
 			Expect(len(*actual)).To(Equal(1), fmt.Sprintf("Actual probes: %+v", *actual))
 		})
 
 		It("should have created 1 default probe", func() {
-			Expect(*actual).To(ContainElement(defaultProbe))
+			Expect(*actual).To(ContainElement(defaultProbe(cb.appGwIdentifier)))
 		})
 	})
 })

--- a/pkg/appgw/identifier.go
+++ b/pkg/appgw/identifier.go
@@ -74,6 +74,10 @@ func (agw Identifier) publicIPID(publicIPName string) string {
 	return agw.resourceID("Microsoft.Network", "publicIPAddresses", publicIPName)
 }
 
+func (agw Identifier) requestRoutingRuleID(settingsName string) string {
+	return agw.gatewayResourceID("requestRoutingRules", settingsName)
+}
+
 func resourceRef(id string) *n.SubResource {
 	return &n.SubResource{ID: to.StringPtr(id)}
 }

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
 	"github.com/knative/pkg/apis/istio/v1alpha3"
 	"k8s.io/api/extensions/v1beta1"
@@ -163,20 +164,21 @@ var defaultBackendHTTPSettingsName = fmt.Sprintf("%sdefaulthttpsetting", agPrefi
 var defaultBackendAddressPoolName = fmt.Sprintf("%sdefaultaddresspool", agPrefix)
 var defaultProbeName = fmt.Sprintf("%sdefaultprobe", agPrefix)
 
-func defaultBackendHTTPSettings(probeID string) n.ApplicationGatewayBackendHTTPSettings {
+func defaultBackendHTTPSettings(appGWIdentifier Identifier, probeName string) n.ApplicationGatewayBackendHTTPSettings {
 	defHTTPSettingsName := defaultBackendHTTPSettingsName
 	defHTTPSettingsPort := int32(80)
 	return n.ApplicationGatewayBackendHTTPSettings{
 		Name: &defHTTPSettingsName,
+		ID:   to.StringPtr(appGWIdentifier.httpSettingsID(defHTTPSettingsName)),
 		ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 			Protocol: n.HTTP,
 			Port:     &defHTTPSettingsPort,
-			Probe:    resourceRef(probeID),
+			Probe:    resourceRef(appGWIdentifier.probeID(probeName)),
 		},
 	}
 }
 
-func defaultProbe() n.ApplicationGatewayProbe {
+func defaultProbe(appGWIdentifier Identifier) n.ApplicationGatewayProbe {
 	defProbeName := defaultProbeName
 	defProtocol := n.HTTP
 	defHost := "localhost"
@@ -186,6 +188,7 @@ func defaultProbe() n.ApplicationGatewayProbe {
 	defUnHealthyCount := int32(3)
 	return n.ApplicationGatewayProbe{
 		Name: &defProbeName,
+		ID:   to.StringPtr(appGWIdentifier.probeID(defProbeName)),
 		ApplicationGatewayProbePropertiesFormat: &n.ApplicationGatewayProbePropertiesFormat{
 			Protocol:           defProtocol,
 			Host:               &defHost,
@@ -197,9 +200,10 @@ func defaultProbe() n.ApplicationGatewayProbe {
 	}
 }
 
-func defaultBackendAddressPool() *n.ApplicationGatewayBackendAddressPool {
-	return &n.ApplicationGatewayBackendAddressPool{
+func defaultBackendAddressPool(appGWIdentifier Identifier) n.ApplicationGatewayBackendAddressPool {
+	return n.ApplicationGatewayBackendAddressPool{
 		Name: &defaultBackendAddressPoolName,
+		ID:   to.StringPtr(appGWIdentifier.addressPoolID(defaultBackendAddressPoolName)),
 		ApplicationGatewayBackendAddressPoolPropertiesFormat: &n.ApplicationGatewayBackendAddressPoolPropertiesFormat{
 			BackendAddresses: &[]n.ApplicationGatewayBackendAddress{},
 		},

--- a/pkg/appgw/redirects.go
+++ b/pkg/appgw/redirects.go
@@ -28,7 +28,7 @@ func (c *appGwConfigBuilder) getRedirectConfigurations(cbCtx *ConfigBuilderConte
 		// We will configure a Redirect only if the listener has TLS enabled (has a Certificate)
 		if isHTTPS && hasSslRedirect {
 			targetListener := resourceRef(c.appGwIdentifier.listenerID(generateListenerName(listenerID)))
-			redirectConfigs = append(redirectConfigs, newSSLRedirectConfig(listenerConfig, targetListener))
+			redirectConfigs = append(redirectConfigs, c.newSSLRedirectConfig(listenerConfig, targetListener))
 			glog.V(3).Infof("Created redirection configuration %s; not yet linked to a routing rule", listenerConfig.SslRedirectConfigurationName)
 		}
 	}
@@ -37,7 +37,7 @@ func (c *appGwConfigBuilder) getRedirectConfigurations(cbCtx *ConfigBuilderConte
 }
 
 // newSSLRedirectConfig creates a new Redirect in the form of a ApplicationGatewayRedirectConfiguration struct.
-func newSSLRedirectConfig(listenerConfig listenerAzConfig, targetListener *n.SubResource) n.ApplicationGatewayRedirectConfiguration {
+func (c *appGwConfigBuilder) newSSLRedirectConfig(listenerConfig listenerAzConfig, targetListener *n.SubResource) n.ApplicationGatewayRedirectConfiguration {
 	props := n.ApplicationGatewayRedirectConfigurationPropertiesFormat{
 		// RedirectType could be one of: 301/Permanent, 302/Found, 303/See Other, 307/Temporary
 		RedirectType: n.Permanent,
@@ -56,6 +56,7 @@ func newSSLRedirectConfig(listenerConfig listenerAzConfig, targetListener *n.Sub
 	return n.ApplicationGatewayRedirectConfiguration{
 		Etag: to.StringPtr("*"),
 		Name: &listenerConfig.SslRedirectConfigurationName,
+		ID:   to.StringPtr(c.appGwIdentifier.redirectConfigurationID(listenerConfig.SslRedirectConfigurationName)),
 		ApplicationGatewayRedirectConfigurationPropertiesFormat: &props,
 	}
 }

--- a/pkg/appgw/redirects_test.go
+++ b/pkg/appgw/redirects_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 			Name: to.StringPtr("sslr-fl-bye.com-443"),
 			Etag: to.StringPtr("*"),
 			Type: nil,
-			ID:   nil,
+			ID:   to.StringPtr(cb.appGwIdentifier.redirectConfigurationID("sslr-fl-bye.com-443")),
 		}
 
 		_, actualListeners := cb.processIngressRules(ingress)

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -175,10 +175,12 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 		rule := n.ApplicationGatewayRequestRoutingRule{
 			Etag: to.StringPtr("*"),
 			Name: to.StringPtr(generateRequestRoutingRuleName(listenerID)),
+			ID:   to.StringPtr(c.appGwIdentifier.requestRoutingRuleID(generateRequestRoutingRuleName(listenerID))),
 			ApplicationGatewayRequestRoutingRulePropertiesFormat: &n.ApplicationGatewayRequestRoutingRulePropertiesFormat{
 				HTTPListener: &n.SubResource{ID: to.StringPtr(c.appGwIdentifier.listenerID(*httpListener.Name))},
 			},
 		}
+		glog.V(3).Infof("Binding rule %s to listener %s", *rule.Name, *httpListener.Name)
 		if len(*urlPathMap.PathRules) == 0 {
 			// Basic Rule, because we have no path-based rule
 			rule.RuleType = n.Basic
@@ -208,6 +210,7 @@ func (c *appGwConfigBuilder) pathMaps(ingress *v1beta1.Ingress, cbCtx *ConfigBui
 		urlPathMap = &n.ApplicationGatewayURLPathMap{
 			Etag: to.StringPtr("*"),
 			Name: to.StringPtr(generateURLPathMapName(listenerID)),
+			ID:   to.StringPtr(c.appGwIdentifier.urlPathMapID(generateURLPathMapName(listenerID))),
 			ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 				DefaultBackendAddressPool:  &n.SubResource{ID: &defaultAddressPoolID},
 				DefaultBackendHTTPSettings: &n.SubResource{ID: &defaultHTTPSettingsID},

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 				Name: to.StringPtr("rr-80"),
 				Etag: to.StringPtr("*"),
 				Type: nil,
-				ID:   nil,
+				ID:   to.StringPtr(configBuilder.appGwIdentifier.requestRoutingRuleID("rr-80")),
 			}
 			Expect(*configBuilder.appGw.RequestRoutingRules).To(ContainElement(expected))
 		})


### PR DESCRIPTION
This PR sets the sub-resource's resourceId so that it can be used to perform lookups.

This is sub-part to brownfield work.
#396 