### PR TITLE
start worker after context, eventhandler for prohibited crd

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -48,13 +48,13 @@ func NewAppGwIngressController(appGwClient n.ApplicationGatewaysClient, appGwIde
 // Start function runs the k8scontext and continues to listen to the
 // event channel and enqueue events before stopChannel is closed
 func (c *AppGwIngressController) Start(envVariables environment.EnvVariables) {
-	// Starts Worker
-	// This will start worker to process events from k8sContext
-	c.worker.Run(c.k8sContext.UpdateChannel, c.stopChannel)
-
 	// Starts k8scontext which contains all the informers
 	// This will start individual go routines for informers
 	c.k8sContext.Run(c.stopChannel, false, envVariables)
+
+	// Starts Worker
+	// This will start worker to process events from k8sContext
+	c.worker.Run(c.k8sContext.UpdateChannel, c.stopChannel)
 
 	select {}
 }

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -106,6 +106,7 @@ func NewContext(kubeClient kubernetes.Interface, crdClient versioned.Interface, 
 	informerCollection.Pods.AddEventHandler(resourceHandler)
 	informerCollection.Secret.AddEventHandler(secretResourceHandler)
 	informerCollection.Service.AddEventHandler(resourceHandler)
+	informerCollection.AzureIngressProhibitedLocation.AddEventHandler(resourceHandler)
 
 	return context
 }


### PR DESCRIPTION
This PR:
1. starts worker after context so that context can finish sync up.
1. Add event handler for prohibited CRD.