### PR TITLE
Panic on ARM PUT error

### DIFF
--- a/pkg/appgw/types.go
+++ b/pkg/appgw/types.go
@@ -29,4 +29,7 @@ type ConfigBuilderContext struct {
 
 	// Feature flag toggling Istio Integration across the entire AGIC code base.
 	EnableIstioIntegration bool
+
+	// Feature flag enabling panic() when put to ARM fails.
+	EnablePanicOnPutError bool
 }

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -42,6 +42,9 @@ const (
 
 	// EnableSaveConfigToFileVarName is a feature flag, which enables saving the App Gwy config to disk.
 	EnableSaveConfigToFileVarName = "APPGW_ENABLE_SAVE_CONFIG_TO_FILE"
+
+	// EnablePanicOnPutErrorVarName is a feature flag.
+	EnablePanicOnPutErrorVarName = "APPGW_ENABLE_PANIC_ON_PUT_ERROR"
 )
 
 // EnvVariables is a struct storing values for environment variables.
@@ -56,6 +59,7 @@ type EnvVariables struct {
 	EnableBrownfieldDeployment string
 	EnableIstioIntegration     string
 	EnableSaveConfigToFile     string
+	EnablePanicOnPutError      string
 }
 
 // GetEnv returns values for defined environment variables for Ingress Controller.
@@ -71,6 +75,7 @@ func GetEnv() EnvVariables {
 		EnableBrownfieldDeployment: os.Getenv(EnableBrownfieldDeploymentVarName),
 		EnableIstioIntegration:     os.Getenv(EnableIstioIntegrationVarName),
 		EnableSaveConfigToFile:     os.Getenv(EnableSaveConfigToFileVarName),
+		EnablePanicOnPutError:      os.Getenv(EnablePanicOnPutErrorVarName),
 	}
 
 	return env


### PR DESCRIPTION
I have been using the code in this PR to help me find PUT errors (and stop so I can troubleshoot these).

This introduces an env variable `APPGW_ENABLE_PANIC_ON_PUT_ERROR`, which when set to `"true"`, causes AGIC to panic on PUT error.

This is to be used in dev environment only. (Although it may be beneficial to kill the container if a PUT error occurs in prod as well)