### PR TITLE
Skip attachment of non-existent redirects

### DIFF
--- a/pkg/appgw/redirects.go
+++ b/pkg/appgw/redirects.go
@@ -61,7 +61,7 @@ func (c *appGwConfigBuilder) newSSLRedirectConfig(listenerConfig listenerAzConfi
 	}
 }
 
-func (c *appGwConfigBuilder) getRedirectsByID(redirects *[]n.ApplicationGatewayRedirectConfiguration) *map[string]interface{} {
+func (c *appGwConfigBuilder) groupRedirectsByID(redirects *[]n.ApplicationGatewayRedirectConfiguration) *map[string]interface{} {
 	redirectsSet := make(map[string]interface{})
 	for _, redirect := range *redirects {
 		redirectsSet[*redirect.ID] = nil

--- a/pkg/appgw/redirects.go
+++ b/pkg/appgw/redirects.go
@@ -60,3 +60,11 @@ func (c *appGwConfigBuilder) newSSLRedirectConfig(listenerConfig listenerAzConfi
 		ApplicationGatewayRedirectConfigurationPropertiesFormat: &props,
 	}
 }
+
+func (c *appGwConfigBuilder) getRedirectsByID(redirects *[]n.ApplicationGatewayRedirectConfiguration) *map[string]interface{} {
+	redirectsSet := make(map[string]interface{})
+	for _, redirect := range *redirects {
+		redirectsSet[*redirect.ID] = nil
+	}
+	return &redirectsSet
+}

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -277,7 +277,7 @@ func (c *appGwConfigBuilder) modifyPathRulesForRedirection(cbCtx *ConfigBuilderC
 
 	// We could end up in a situation where we are attempting to attach a redirect, which does not exist.
 	redirectRef := c.getSslRedirectConfigResourceReference(targetListener)
-	redirectsSet := *c.getRedirectsByID(c.getRedirectConfigurations(cbCtx))
+	redirectsSet := *c.groupRedirectsByID(c.getRedirectConfigurations(cbCtx))
 
 	if _, exists := redirectsSet[*redirectRef.ID]; !exists {
 		glog.Errorf("Will not attach redirect to rule; SSL Redirect does not exist: %s", *redirectRef.ID)

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -6,29 +6,37 @@
 package appgw
 
 import (
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
 var _ = Describe("Test SSL Redirect Annotations", func() {
 	targetListener := listenerIdentifier{
-		FrontendPort: int32(8080),
+		FrontendPort: int32(443),
 		HostName:     "foo.baz",
 	}
 
 	expectedRedirectID := "/subscriptions/--subscription--" +
 		"/resourceGroups/--resource-group--" +
 		"/providers/Microsoft.Network/applicationGateways/--app-gw-name--" +
-		"/redirectConfigurations/sslr-fl-foo.baz-8080"
+		"/redirectConfigurations/sslr-fl-foo.baz-443"
+
+	// TODO(draychev): Move to test fixtures
+	ingress := fixtures.GetIngress()
+
+	ingressList := []*v1beta1.Ingress{ingress}
+	serviceList := []*v1.Service{tests.NewServiceFixture()}
+	cbCtx := &ConfigBuilderContext{
+		IngressList: ingressList,
+		ServiceList: serviceList,
+	}
 
 	Context("test getSslRedirectConfigResourceReference", func() {
 		configBuilder := newConfigBuilderFixture(nil)
@@ -54,7 +62,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		})
 
 		// !! Action !! -- will mutate pathMap struct
-		configBuilder.modifyPathRulesForRedirection(&pathMap, targetListener)
+		configBuilder.modifyPathRulesForRedirection(cbCtx, &pathMap, targetListener)
 
 		actualID := *(pathMap.DefaultRedirectConfiguration.ID)
 		It("generated expected ID", func() {
@@ -81,7 +89,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		firstPathRule.RedirectConfiguration = nil
 
 		// !! Action !! -- will mutate pathMap struct
-		configBuilder.modifyPathRulesForRedirection(&pathMap, targetListener)
+		configBuilder.modifyPathRulesForRedirection(cbCtx, &pathMap, targetListener)
 
 		actual := *(*pathMap.PathRules)[0].ApplicationGatewayPathRulePropertiesFormat
 
@@ -101,54 +109,36 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 	Context("test RequestRoutingRules without HTTPS but with SSL Redirect", func() {
 		configBuilder := newConfigBuilderFixture(nil)
 		_ = configBuilder.k8sContext.Caches.Service.Add(tests.NewServiceFixture())
-
-		// TODO(draychev): Move to test fixtures
-		ingress := v1beta1.Ingress{
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServiceName: tests.ServiceName,
-											ServicePort: intstr.IntOrString{
-												Type:   intstr.Int,
-												IntVal: 80,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				TLS: nil,
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					annotations.IngressClassKey: annotations.ApplicationGatewayIngressClass,
-					annotations.SslRedirectKey:  "true",
-				},
-				Namespace: tests.Namespace,
-				Name:      tests.Name,
-			},
-		}
-
-		ingressList := []*v1beta1.Ingress{&ingress}
-		serviceList := []*v1.Service{tests.NewServiceFixture()}
-		cbCtx := &ConfigBuilderContext{
-			IngressList: ingressList,
-			ServiceList: serviceList,
-		}
 		_ = configBuilder.Listeners(cbCtx)
 		_ = configBuilder.RequestRoutingRules(cbCtx)
 
 		It("should have correct RequestRoutingRules", func() {
-			Expect(len(*configBuilder.appGw.RequestRoutingRules)).To(Equal(1))
-			expected := n.ApplicationGatewayRequestRoutingRule{
+			Expect(len(*configBuilder.appGw.RequestRoutingRules)).To(Equal(2))
+
+			Expect(*configBuilder.appGw.RequestRoutingRules).To(ContainElement(n.ApplicationGatewayRequestRoutingRule{
+				ApplicationGatewayRequestRoutingRulePropertiesFormat: &n.ApplicationGatewayRequestRoutingRulePropertiesFormat{
+					RuleType:            "Basic",
+					BackendAddressPool:  nil,
+					BackendHTTPSettings: nil,
+					HTTPListener: &n.SubResource{
+						ID: to.StringPtr("/subscriptions/--subscription--/resourceGroups/--resource-group--" +
+							"/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-80"),
+					},
+					URLPathMap:     nil,
+					RewriteRuleSet: nil,
+					RedirectConfiguration: &n.SubResource{
+						ID: to.StringPtr("/subscriptions/--subscription--/resourceGroups/--resource-group--" +
+							"/providers/Microsoft.Network/applicationGateways/--app-gw-name--" +
+							"/redirectConfigurations/sslr-fl-foo.baz-443")},
+					ProvisioningState: nil,
+				},
+				Name: to.StringPtr("rr-foo.baz-80"),
+				Etag: to.StringPtr("*"),
+				Type: nil,
+				ID:   to.StringPtr(configBuilder.appGwIdentifier.requestRoutingRuleID("rr-foo.baz-80")),
+			}))
+
+			Expect(*configBuilder.appGw.RequestRoutingRules).To(ContainElement(n.ApplicationGatewayRequestRoutingRule{
 				ApplicationGatewayRequestRoutingRulePropertiesFormat: &n.ApplicationGatewayRequestRoutingRulePropertiesFormat{
 					RuleType: "Basic",
 					BackendAddressPool: &n.SubResource{
@@ -163,19 +153,18 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 					},
 					HTTPListener: &n.SubResource{
 						ID: to.StringPtr("/subscriptions/--subscription--/resourceGroups/--resource-group--" +
-							"/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-80"),
+							"/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443"),
 					},
 					URLPathMap:            nil,
 					RewriteRuleSet:        nil,
 					RedirectConfiguration: nil,
 					ProvisioningState:     nil,
 				},
-				Name: to.StringPtr("rr-80"),
+				Name: to.StringPtr("rr-foo.baz-443"),
 				Etag: to.StringPtr("*"),
 				Type: nil,
-				ID:   to.StringPtr(configBuilder.appGwIdentifier.requestRoutingRuleID("rr-80")),
-			}
-			Expect(*configBuilder.appGw.RequestRoutingRules).To(ContainElement(expected))
+				ID:   to.StringPtr(configBuilder.appGwIdentifier.requestRoutingRuleID("rr-foo.baz-443")),
+			}))
 		})
 
 		It("should have correct URLPathMaps", func() {

--- a/pkg/tests/fixtures/ingress.go
+++ b/pkg/tests/fixtures/ingress.go
@@ -1,0 +1,61 @@
+package fixtures
+
+import (
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+)
+
+func GetIngress() *v1beta1.Ingress {
+	return &v1beta1.Ingress{
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: "foo.baz",
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: v1beta1.IngressBackend{
+										ServiceName: tests.ServiceName,
+										ServicePort: intstr.IntOrString{
+											Type:   intstr.Int,
+											IntVal: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			TLS: []v1beta1.IngressTLS{
+				{
+					Hosts: []string{
+						"www.contoso.com",
+						"ftp.contoso.com",
+						tests.Host,
+						"",
+					},
+					SecretName: tests.NameOfSecret,
+				},
+				{
+					Hosts:      []string{},
+					SecretName: tests.NameOfSecret,
+				},
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotations.IngressClassKey: annotations.ApplicationGatewayIngressClass,
+				annotations.SslRedirectKey:  "true",
+			},
+			Namespace: tests.Namespace,
+			Name:      tests.Name,
+		},
+	}
+}


### PR DESCRIPTION
In certain complex scenarios we run into an edge case where the list of `"redirectConfigurations": []` does not have the redirect we are still attaching it to a URLPathMap's rule (adding it to the lits `urlPathMaps..pathRules..redirectConfiguration=[...]`)

Regardless of the reason for which the SSL Redirect was *not* created - we should *not* construct an invalid JSON.

This PR removes the invalid reference end logs an error:
```
E0723 18:14:36.913659   18089 requestroutingrules.go:282] Will not attach redirect to rule; SSL Redirect does not exist: /subscriptions/xxx/resourceGroups/aa-rg-Z/providers/Microsoft.Network/applicationGateways/applicationgatewayaaaa/redirectConfigurations/sslr-fl-ws.mis.li-443
```

Example:
```
F0723 17:56:22.846431   17592 process.go:127] Failed applying App Gwy configuration: network.ApplicationGatewaysClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidResourceReference" Message="Resource /subscriptions/xxx/resourceGroups/aa-rg-Z/providers/Microsoft.Network/applicationGateways/applicationgatewayaaaa/redirectConfigurations/sslr-fl-ws.mis.li-443 referenced by resource /subscriptions/xxx/resourceGroups/aa-rg-Z/providers/Microsoft.Network/applicationGateways/applicationgatewayaaaa/urlPathMaps/url-ws.mis.li-80/pathRules/pr-aa-cairo-ns-websocket-ingress-0 was not found. Please make sure that the referenced resource exists, and that both resources are in the same region." Details=[] -- {
-- App Gwy config --    "etag": "W/\"8968da1b-c554-459d-850f-8bee37613527\"",
```