### PR TITLE
redirects: Bump log level from 3 to 5 to reduce noise

### DIFF
--- a/pkg/appgw/redirects.go
+++ b/pkg/appgw/redirects.go
@@ -29,7 +29,7 @@ func (c *appGwConfigBuilder) getRedirectConfigurations(cbCtx *ConfigBuilderConte
 		if isHTTPS && hasSslRedirect {
 			targetListener := resourceRef(c.appGwIdentifier.listenerID(generateListenerName(listenerID)))
 			redirectConfigs = append(redirectConfigs, c.newSSLRedirectConfig(listenerConfig, targetListener))
-			glog.V(3).Infof("Created redirection configuration %s; not yet linked to a routing rule", listenerConfig.SslRedirectConfigurationName)
+			glog.V(5).Infof("Created redirection configuration %s; not yet linked to a routing rule", listenerConfig.SslRedirectConfigurationName)
 		}
 	}
 	sort.Sort(sorter.ByRedirectName(redirectConfigs))

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -183,7 +183,7 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 				HTTPListener: &n.SubResource{ID: to.StringPtr(c.appGwIdentifier.listenerID(*httpListener.Name))},
 			},
 		}
-		glog.V(3).Infof("Binding rule %s to listener %s", *rule.Name, *httpListener.Name)
+		glog.V(5).Infof("Binding rule %s to listener %s", *rule.Name, *httpListener.Name)
 		if len(*urlPathMap.PathRules) == 0 {
 			// Basic Rule, because we have no path-based rule
 			rule.RuleType = n.Basic


### PR DESCRIPTION
This PR increases the log level from 3 to 5 for routing rules and redirect configurations.
These are informational messages and we emit lots of them.
Level 3 should be reserved for warnings and errors.