### PR TITLE
s/Application Gateway/App Gateway/g

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -119,7 +119,7 @@ func main() {
 	// fatal config validations
 	appGw, _ := appGwClient.Get(context.Background(), env.ResourceGroupName, env.AppGwName)
 	if err := appgw.FatalValidateOnExistingConfig(recorder, appGw.ApplicationGatewayPropertiesFormat, env); err != nil {
-		glog.Fatal("Got a fatal validation error on existing Application Gateway config. Please update Application Gateway or the controller's helm config. Error:", err)
+		glog.Fatal("Got a fatal validation error on existing App Gateway config. Please update App Gateway or the controller's helm config. Error:", err)
 	}
 
 	// initiliaze controller
@@ -182,7 +182,7 @@ func waitForAzureAuth(env environment.EnvVariables, client *n.ApplicationGateway
 			glog.Fatal("Error creating Azure client", err)
 		}
 
-		// Get Application Gateway
+		// Get App Gateway
 		response, err = client.Get(context.Background(), env.ResourceGroupName, env.AppGwName)
 		if err == nil {
 			return nil
@@ -190,7 +190,7 @@ func waitForAzureAuth(env environment.EnvVariables, client *n.ApplicationGateway
 
 		// Tries remaining
 		if counter < maxAuthRetry {
-			glog.Error("Error getting Application Gateway", env.AppGwName, err)
+			glog.Error("Error getting App Gateway", env.AppGwName, err)
 			glog.Infof("Retrying in %v", retryTime)
 			time.Sleep(retryTime)
 		}
@@ -201,13 +201,13 @@ func waitForAzureAuth(env environment.EnvVariables, client *n.ApplicationGateway
 		infoLine := "Possible reasons:"
 		infoLine += " AKS Service Principal requires 'Managed Identity Operator' access on Controller Identity;"
 		infoLine += " 'identityResourceID' and/or 'identityClientID' are incorrect in the Helm config;"
-		infoLine += " AGIC Identity requires 'Contributor' access on Application Gateway and 'Reader' access on Application Gateway's Resource Group;"
+		infoLine += " AGIC Identity requires 'Contributor' access on App Gateway and 'Reader' access on App Gateway's Resource Group;"
 		glog.Error(infoLine)
 	}
 
 	if response.Response.StatusCode != 200 {
 		// for example, getting 401. This is not expected as we are getting a token before making the call.
-		errorLine := fmt.Sprintf("Recieved an unexpected status code from Azure while getting Application Gateway: %d", response.Response.StatusCode)
+		errorLine := fmt.Sprintf("Recieved an unexpected status code from Azure while getting App Gateway: %d", response.Response.StatusCode)
 		glog.Error(errorLine)
 		return errors.New(errorLine)
 	}

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	// ApplicationGatewayPrefix defines the prefix for all keys associated with Application Gateway Ingress controller.
+	// ApplicationGatewayPrefix defines the prefix for all keys associated with App Gateway Ingress controller.
 	ApplicationGatewayPrefix = "appgw.ingress.kubernetes.io"
 
 	// BackendPathPrefixKey defines the key for Path which should be used as a prefix for all HTTP requests.
@@ -55,7 +55,7 @@ func IngressClass(ing *v1beta1.Ingress) (string, error) {
 	return parseString(ing, IngressClassKey)
 }
 
-// IsApplicationGatewayIngress checks if the Ingress resource can be handled by the Application Gateway ingress controller.
+// IsApplicationGatewayIngress checks if the Ingress resource can be handled by the App Gateway ingress controller.
 func IsApplicationGatewayIngress(ing *v1beta1.Ingress) (bool, error) {
 	controllerName, err := parseString(ing, IngressClassKey)
 	return controllerName == ApplicationGatewayIngressClass, err

--- a/pkg/apis/azureingressprohibitedtarget/v1/types.go
+++ b/pkg/apis/azureingressprohibitedtarget/v1/types.go
@@ -29,7 +29,7 @@ type AzureIngressProhibitedTargetSpec struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// IP address of the prohibited target; Could be the public or private address attached to the Application Gateway
+	// IP address of the prohibited target; Could be the public or private address attached to the App Gateway
 	IP string `json:"ip"`
 
 	// +optional
@@ -41,7 +41,7 @@ type AzureIngressProhibitedTargetSpec struct {
 	Port int32 `json:"port,omitempty"`
 
 	// +optional
-	// Paths is a list of URL paths, for which the Ingress Controller is prohibited from mutating Application Gateway configuration; Must begin with a / and end with /*
+	// Paths is a list of URL paths, for which the Ingress Controller is prohibited from mutating App Gateway configuration; Must begin with a / and end with /*
 	Paths []string `json:"paths,omitempty"`
 }
 

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -425,8 +425,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		builder, ok := configBuilder.(*appGwConfigBuilder)
 		Expect(ok).Should(BeTrue(), "Unable to get the more specific configBuilder implementation")
 
-		// Since this is a mock the `Application Gateway v2` does not have a public IP. During configuration process
-		// the controller would expect the `Application Gateway v2` to have some public IP before it starts generating
+		// Since this is a mock the `App Gateway v2` does not have a public IP. During configuration process
+		// the controller would expect the `App Gateway v2` to have some public IP before it starts generating
 		// configuration for the application gateway, hence creating this dummy configuration in the application gateway configuration.
 		builder.appGw.ApplicationGatewayPropertiesFormat = &n.ApplicationGatewayPropertiesFormat{
 			FrontendIPConfigurations: &[]n.ApplicationGatewayFrontendIPConfiguration{
@@ -448,8 +448,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		close(stopChannel)
 	})
 
-	Context("Tests Application Gateway Configuration", func() {
-		It("Should be able to create Application Gateway Configuration from Ingress", func() {
+	Context("Tests App Gateway Configuration", func() {
+		It("Should be able to create App Gateway Configuration from Ingress", func() {
 			// Start the informers. This will sync the cache with the latest ingress.
 			ctxt.Run(stopChannel, true, environment.GetFakeEnv())
 
@@ -488,7 +488,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	})
 
 	Context("Tests Ingress Controller when Service doesn't exists", func() {
-		It("Should be able to create Application Gateway Configuration from Ingress with empty backend pool.", func() {
+		It("Should be able to create App Gateway Configuration from Ingress with empty backend pool.", func() {
 			// Delete the service
 			options := &metav1.DeleteOptions{}
 			err := k8sClient.CoreV1().Services(ingressNS).Delete(serviceName, options)
@@ -568,7 +568,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	})
 
 	Context("Tests Ingress Controller TLS", func() {
-		It("Should be able to create Application Gateway Configuration from Ingress with TLS.", func() {
+		It("Should be able to create App Gateway Configuration from Ingress with TLS.", func() {
 			// Test setup ........................
 			// 1. Create secrets object in the Kubernetes secret store.
 			ingressSecret := &v1.Secret{
@@ -645,7 +645,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 						Protocol:                n.HTTPS,
 						HostName:                &domainName,
 
-						// RequireServerNameIndication is not used in Application Gateway v2
+						// RequireServerNameIndication is not used in App Gateway v2
 						RequireServerNameIndication: nil,
 					},
 				}
@@ -699,7 +699,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	})
 
 	Context("Tests Ingress Controller Annotations", func() {
-		It("Should be able to create Application Gateway Configuration from Ingress with all annotations.", func() {
+		It("Should be able to create App Gateway Configuration from Ingress with all annotations.", func() {
 			ingress, err := k8sClient.ExtensionsV1beta1().Ingresses(ingressNS).Get(ingressName, metav1.GetOptions{})
 			Expect(err).Should(BeNil(), "Unable to create ingress resource due to: %v", err)
 
@@ -798,8 +798,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		})
 	})
 
-	Context("Tests Application Gateway Generate HTTP Settings Name", func() {
-		It("Should be create an Application Gateway Backend Pool Name With Less than 80 Characters", func() {
+	Context("Tests App Gateway Generate HTTP Settings Name", func() {
+		It("Should be create an App Gateway Backend Pool Name With Less than 80 Characters", func() {
 			// Start the informers. This will sync the cache with the latest ingress.
 			ctxt.Run(stopChannel, true, environment.GetFakeEnv())
 

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -220,7 +220,7 @@ func generateListenerID(rule *v1beta1.IngressRule,
 	return listenerID
 }
 
-// addTags will add certain tags to Application Gateway
+// addTags will add certain tags to App Gateway
 func (c *appGwConfigBuilder) addTags() {
 	if c.appGw.Tags == nil {
 		c.appGw.Tags = make(map[string]*string)

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			Expect(listener).To(Equal(expected))
 		})
 	})
-	Context("Fatal if UsePrivateIp is specified and Application Gateway doesn't have a private IP configured.", func() {
+	Context("Fatal if UsePrivateIp is specified and App Gateway doesn't have a private IP configured.", func() {
 		const (
 			expectedEnvVarValue = "true"
 		)

--- a/pkg/appgw/identifier.go
+++ b/pkg/appgw/identifier.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 )
 
-// Identifier is identifier for a specific Application Gateway
+// Identifier is identifier for a specific App Gateway
 type Identifier struct {
 	SubscriptionID string
 	ResourceGroup  string

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
-// A note on naming Application Gateway properties:
+// A note on naming App Gateway properties:
 // A constraint on the App Gateway property names - these must begin and end with a word character or an underscore
 // A word character is well defined here: https://docs.microsoft.com/en-us/dotnet/standard/base-types/character-classes-in-regular-expressions#WordCharacter
 

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -274,7 +274,7 @@ func (c *appGwConfigBuilder) getSslRedirectConfigResourceReference(targetListene
 }
 
 func (c *appGwConfigBuilder) modifyPathRulesForRedirection(httpURLPathMap *n.ApplicationGatewayURLPathMap, targetListener listenerIdentifier) {
-	// Application Gateway supports Basic and Path-based rules
+	// App Gateway supports Basic and Path-based rules
 
 	if len(*httpURLPathMap.PathRules) == 0 {
 		// There are no paths. This is a rule of type "Basic"

--- a/pkg/appgw/validators.go
+++ b/pkg/appgw/validators.go
@@ -35,8 +35,8 @@ var validationErrors = map[string]error{
 	errKeyEitherDefaults: errors.New("URL Path Map must have either DefaultRedirectConfiguration or (DefaultBackendAddressPool + DefaultBackendHTTPSettings) but not both"),
 	errKeyNoBorR:         errors.New("A valid path rule must have one of RedirectConfiguration or (BackendAddressPool + BackendHTTPSettings)"),
 	errKeyEitherBorR:     errors.New("A Path Rule must have either RedirectConfiguration or (BackendAddressPool + BackendHTTPSettings) but not both"),
-	errKeyNoPrivateIP:    errors.New("A Private IP must be present in the Application Gateway FrontendIPConfiguration if the controller is configured to UsePrivateIP for routing rules"),
-	errKeyNoPublicIP:     errors.New("A Public IP must be present in the Application Gateway FrontendIPConfiguration"),
+	errKeyNoPrivateIP:    errors.New("A Private IP must be present in the App Gateway FrontendIPConfiguration if the controller is configured to UsePrivateIP for routing rules"),
+	errKeyNoPublicIP:     errors.New("A Public IP must be present in the App Gateway FrontendIPConfiguration"),
 }
 
 func validateServiceDefinition(eventRecorder record.EventRecorder, config *n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error {

--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -77,9 +77,9 @@ func (c AppGwIngressController) Process(event events.Event) error {
 		glog.V(5).Infof("Istio Gateways: %+v", strings.Join(gatewaysInfo, ","))
 	}
 
-	// Run fatal validations on the existing config of the Application Gateway.
+	// Run fatal validations on the existing config of the App Gateway.
 	if err := appgw.FatalValidateOnExistingConfig(c.recorder, appGw.ApplicationGatewayPropertiesFormat, cbCtx.EnvVariables); err != nil {
-		glog.Error("Got a fatal validation error on existing Application Gateway config. Will retry getting Application Gateway until error is resolved:", err)
+		glog.Error("Got a fatal validation error on existing App Gateway config. Will retry getting App Gateway until error is resolved:", err)
 		return err
 	}
 

--- a/pkg/k8scontext/k8scontext_test.go
+++ b/pkg/k8scontext/k8scontext_test.go
@@ -174,7 +174,7 @@ var _ = Describe("K8scontext", func() {
 			Expect(len(ingressListInterface)).To(Equal(0), "Expected to have no ingress in the k8scontext but found: %d ingresses", len(testIngresses))
 		})
 
-		It("Should be following Ingress Resource with Application Gateway specific annotations only.", func() {
+		It("Should be following Ingress Resource with App Gateway specific annotations only.", func() {
 			nonAppGWIngress := &v1beta1.Ingress{}
 			deepcopy.Copy(nonAppGWIngress, ingress)
 			nonAppGWIngress.Name = ingressName + "123"
@@ -182,7 +182,7 @@ var _ = Describe("K8scontext", func() {
 			nonAppGWIngress.Annotations[annotations.IngressClassKey] = annotations.ApplicationGatewayIngressClass + "123"
 
 			_, err := k8sClient.ExtensionsV1beta1().Ingresses(ingressNS).Create(nonAppGWIngress)
-			Expect(err).Should(BeNil(), "Unable to create non-Application Gateway ingress resource due to: %v", err)
+			Expect(err).Should(BeNil(), "Unable to create non-App Gateway ingress resource due to: %v", err)
 
 			// Retrieve the Ingress to make sure it was updated.
 			ingresses, err := k8sClient.ExtensionsV1beta1().Ingresses(ingressNS).List(metav1.ListOptions{})


### PR DESCRIPTION
This is a no-op PR renaming all string literal and comment occurrences of `Application Gateway` to `App Gateway`

This is mainly for consistency - we tend to use these two interchangeably. In logs (which we have many of) would be great to consistently use the shorter form.