### PR TITLE
errors: Make errors.New() singletons - into errors.go

### DIFF
--- a/cmd/appgw-ingress/errors.go
+++ b/cmd/appgw-ingress/errors.go
@@ -1,0 +1,12 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package main
+
+import "errors"
+
+var (
+	ErrUnexpectedARMStatusCode = errors.New("unexpected ARM status code")
+)

--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -8,7 +8,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"sort"
 	"strconv"
@@ -20,7 +19,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -207,9 +205,8 @@ func waitForAzureAuth(env environment.EnvVariables, client *n.ApplicationGateway
 
 	if response.Response.StatusCode != 200 {
 		// for example, getting 401. This is not expected as we are getting a token before making the call.
-		errorLine := fmt.Sprintf("Recieved an unexpected status code from Azure while getting Application Gateway: %d", response.Response.StatusCode)
-		glog.Error(errorLine)
-		return errors.New(errorLine)
+		glog.Error("Recieved an unexpected status code from ARM while getting App Gateway: ", response.Response.StatusCode)
+		return ErrUnexpectedARMStatusCode
 	}
 
 	return err

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -6,7 +6,6 @@
 package appgw
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 
@@ -192,7 +191,7 @@ func (c *appGwConfigBuilder) getBackendsAndSettingsMap(cbCtx *ConfigBuilderConte
 	}
 
 	if len(unresolvedBackendID) > 0 {
-		return nil, nil, nil, errors.New("unable to resolve backend port for some services")
+		return nil, nil, nil, ErrResolvingBackendPortForService
 	}
 
 	httpSettingsCollection := make(map[string]n.ApplicationGatewayBackendHTTPSettings)
@@ -207,7 +206,7 @@ func (c *appGwConfigBuilder) getBackendsAndSettingsMap(cbCtx *ConfigBuilderConte
 				backendID.serviceKey(), backendID.Backend.ServicePort.String())
 			c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonPortResolutionError, logLine)
 			glog.Warning(logLine)
-			return nil, nil, nil, errors.New("more than one service-backend port binding is not allowed")
+			return nil, nil, nil, ErrMultipleServiceBackendPortBinding
 		}
 
 		// At this point there will be only one pair

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -6,7 +6,6 @@
 package appgw
 
 import (
-	"errors"
 	"fmt"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
@@ -51,14 +50,14 @@ func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationG
 	err := c.HealthProbesCollection(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate Health Probes, error [%v]", err.Error())
-		return nil, errors.New("unable to generate health probes")
+		return nil, ErrGeneratingProbes
 	}
 
 	glog.V(5).Infof("-----Generating Backend Http Settings-----")
 	err = c.BackendHTTPSettingsCollection(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate backend http settings, error [%v]", err.Error())
-		return nil, errors.New("unable to generate backend http settings")
+		return nil, ErrGeneratingBackendSettings
 	}
 
 	// BackendAddressPools depend on BackendHTTPSettings
@@ -66,7 +65,7 @@ func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationG
 	err = c.BackendAddressPools(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate backend address pools, error [%v]", err.Error())
-		return nil, errors.New("unable to generate backend address pools")
+		return nil, ErrGeneratingPools
 	}
 
 	// Listener configures the frontend listeners
@@ -77,7 +76,7 @@ func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationG
 	err = c.Listeners(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate frontend listeners, error [%v]", err.Error())
-		return nil, errors.New("unable to generate frontend listeners")
+		return nil, ErrGeneratingListeners
 	}
 
 	// SSL redirection configurations created elsewhere will be attached to the appropriate rule in this step.
@@ -85,7 +84,7 @@ func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationG
 	err = c.RequestRoutingRules(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate request routing rules, error [%v]", err.Error())
-		return nil, errors.New("unable to generate request routing rules")
+		return nil, ErrGeneratingRoutingRules
 	}
 
 	c.addTags()

--- a/pkg/appgw/errors.go
+++ b/pkg/appgw/errors.go
@@ -1,0 +1,24 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package appgw
+
+import "errors"
+
+var (
+	ErrResolvingBackendPortForService    = errors.New("unable to resolve backend port for some services")
+	ErrMultipleServiceBackendPortBinding = errors.New("more than one service-backend port binding is not allowed")
+	ErrGeneratingProbes                  = errors.New("unable to generate health probes")
+	ErrGeneratingBackendSettings         = errors.New("unable to generate backend http settings")
+	ErrGeneratingPools                   = errors.New("unable to generate backend address pools")
+	ErrGeneratingListeners               = errors.New("unable to generate frontend listeners")
+	ErrGeneratingRoutingRules            = errors.New("unable to generate request routing rules")
+	ErrKeyNoDefaults                     = errors.New("either a DefaultRedirectConfiguration or (DefaultBackendAddressPool + DefaultBackendHTTPSettings) must be configured")
+	ErrKeyEitherDefaults                 = errors.New("URL Path Map must have either DefaultRedirectConfiguration or (DefaultBackendAddressPool + DefaultBackendHTTPSettings) but not both")
+	ErrKeyNoBorR                         = errors.New("A valid path rule must have one of RedirectConfiguration or (BackendAddressPool + BackendHTTPSettings)")
+	ErrKeyEitherBorR                     = errors.New("A Path Rule must have either RedirectConfiguration or (BackendAddressPool + BackendHTTPSettings) but not both")
+	ErrKeyNoPrivateIP                    = errors.New("A Private IP must be present in the Application Gateway FrontendIPConfiguration if the controller is configured to UsePrivateIP for routing rules")
+	ErrKeyNoPublicIP                     = errors.New("A Public IP must be present in the Application Gateway FrontendIPConfiguration")
+)

--- a/pkg/appgw/validators.go
+++ b/pkg/appgw/validators.go
@@ -6,7 +6,6 @@
 package appgw
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -31,12 +30,12 @@ const (
 )
 
 var validationErrors = map[string]error{
-	errKeyNoDefaults:     errors.New("either a DefaultRedirectConfiguration or (DefaultBackendAddressPool + DefaultBackendHTTPSettings) must be configured"),
-	errKeyEitherDefaults: errors.New("URL Path Map must have either DefaultRedirectConfiguration or (DefaultBackendAddressPool + DefaultBackendHTTPSettings) but not both"),
-	errKeyNoBorR:         errors.New("A valid path rule must have one of RedirectConfiguration or (BackendAddressPool + BackendHTTPSettings)"),
-	errKeyEitherBorR:     errors.New("A Path Rule must have either RedirectConfiguration or (BackendAddressPool + BackendHTTPSettings) but not both"),
-	errKeyNoPrivateIP:    errors.New("A Private IP must be present in the Application Gateway FrontendIPConfiguration if the controller is configured to UsePrivateIP for routing rules"),
-	errKeyNoPublicIP:     errors.New("A Public IP must be present in the Application Gateway FrontendIPConfiguration"),
+	errKeyNoDefaults:     ErrKeyNoDefaults,
+	errKeyEitherDefaults: ErrKeyEitherDefaults,
+	errKeyNoBorR:         ErrKeyNoBorR,
+	errKeyEitherBorR:     ErrKeyEitherBorR,
+	errKeyNoPrivateIP:    ErrKeyNoPrivateIP,
+	errKeyNoPublicIP:     ErrKeyNoPublicIP,
 }
 
 func validateServiceDefinition(eventRecorder record.EventRecorder, config *n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error {

--- a/pkg/brownfield/errors.go
+++ b/pkg/brownfield/errors.go
@@ -1,0 +1,12 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import "errors"
+
+var (
+	ErrListenerLookup = errors.New("failed looking up listener")
+)

--- a/pkg/brownfield/routing_rules.go
+++ b/pkg/brownfield/routing_rules.go
@@ -6,7 +6,6 @@
 package brownfield
 
 import (
-	"errors"
 	"strings"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
@@ -155,7 +154,7 @@ func (er ExistingResources) getHostNameForRoutingRule(rule n.ApplicationGatewayR
 	if listener, found := er.getListenersByName()[listenerName]; !found {
 		glog.Errorf("[brownfield] Could not find listener %s in index", listenerName)
 		// TODO(draychev): move this error into a top-level file
-		return "", errors.New("failed looking up listener")
+		return "", ErrListenerLookup
 	} else if listener.HostName != nil {
 		return *listener.HostName, nil
 	}

--- a/pkg/controller/errors.go
+++ b/pkg/controller/errors.go
@@ -1,0 +1,13 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package controller
+
+import "errors"
+
+var (
+	ErrFetchingAppGatewayConfig  = errors.New("unable to get specified AppGateway")
+	ErrDeployingAppGatewayConfig = errors.New("unable to deploy App Gateway config")
+)

--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -7,7 +7,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -29,8 +28,8 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	// Get current application gateway config
 	appGw, err := c.appGwClient.Get(ctx, c.appGwIdentifier.ResourceGroup, c.appGwIdentifier.AppGwName)
 	if err != nil {
-		glog.Errorf("unable to get specified ApplicationGateway [%v], check ApplicationGateway identifier, error=[%v]", c.appGwIdentifier.AppGwName, err.Error())
-		return errors.New("unable to get specified ApplicationGateway")
+		glog.Errorf("unable to get specified AppGateway [%v], check AppGateway identifier, error=[%v]", c.appGwIdentifier.AppGwName, err.Error())
+		return ErrFetchingAppGatewayConfig
 	}
 
 	envVars := environment.GetEnv()
@@ -108,8 +107,8 @@ func (c AppGwIngressController) Process(event events.Event) error {
 		return nil
 	}
 
-	glog.V(3).Info("BEGIN ApplicationGateway deployment")
-	defer glog.V(3).Info("END ApplicationGateway deployment")
+	glog.V(3).Info("BEGIN AppGateway deployment")
+	defer glog.V(3).Info("END AppGateway deployment")
 
 	logToFile := cbCtx.EnvVariables.EnableSaveConfigToFile == "true"
 
@@ -139,7 +138,7 @@ func (c AppGwIngressController) Process(event events.Event) error {
 		// Reset cache
 		c.configCache = nil
 		glog.Warning("Unable to deploy App Gateway config.", err)
-		return errors.New("unable to deploy App Gateway config")
+		return ErrDeployingAppGatewayConfig
 	}
 
 	glog.V(3).Info("cache: Updated with latest applied config.")

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -6,7 +6,6 @@
 package k8scontext
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -188,9 +187,8 @@ func (c *Context) GetEndpointsByService(serviceKey string) (*v1.Endpoints, error
 	}
 
 	if !exist {
-		msg := fmt.Sprintf("Error fetching endpoints from store! Service does not exist: %s", serviceKey)
-		glog.Error(msg)
-		return nil, errors.New(msg)
+		glog.Error("Error fetching endpoints from store! Service does not exist: ", serviceKey)
+		return nil, ErrFetchingEnpdoints
 	}
 
 	return endpointsInterface.(*v1.Endpoints), nil

--- a/pkg/k8scontext/errors.go
+++ b/pkg/k8scontext/errors.go
@@ -1,0 +1,12 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package k8scontext
+
+import "errors"
+
+var (
+	ErrFetchingEnpdoints = errors.New("FetchingEndpoints")
+)


### PR DESCRIPTION
The goal of this PR is to establish a pattern where we instantiate types of errors once, and then reuse these globals.

This affords us easier error checking / error comparison.

Example (https://play.golang.org/p/S0Y2_0qBsbi):
```golang
package main

import (
	"errors"
	"fmt"
)

var ErrBlah = errors.New("blah")

func m() error { return ErrBlah }
func n() error { return ErrBlah }

func main() {
	fmt.Println("Hello, playground")

	a := errors.New("blah")
	b := errors.New("blah")

	fmt.Println(a == b)     // false
	fmt.Println(m() == n()) // true
}
```