### PR TITLE
logging: Adding clarity to an ARM error 

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -42,8 +42,10 @@ import (
 )
 
 const (
-	verbosityFlag = "verbosity"
-	maxAuthRetry  = 10
+	verbosityFlag     = "verbosity"
+	maxAuthRetryCount = 10
+	tenSeconds        = 10 * time.Second
+	thirtySeconds     = 30 * time.Second
 )
 
 var (
@@ -58,7 +60,7 @@ var (
 	kubeConfigFile = flags.String("kubeconfig", "",
 		"Path to kubeconfig file with authorization and master location information.")
 
-	resyncPeriod = flags.Duration("sync-period", 30*time.Second,
+	resyncPeriod = flags.Duration("sync-period", thirtySeconds,
 		"Interval at which to re-list and confirm cloud resources.")
 
 	versionInfo = flags.Bool("version", false, "Print version")
@@ -175,8 +177,7 @@ func initAppGwClient(env environment.EnvVariables) (*n.ApplicationGatewaysClient
 func waitForAzureAuth(env environment.EnvVariables, client *n.ApplicationGatewaysClient) error {
 	var response n.ApplicationGateway
 	var err error
-	const retryTime = 10 * time.Second
-	for counter := 0; counter <= maxAuthRetry; counter++ {
+	for counter := 0; counter <= maxAuthRetryCount; counter++ {
 		// Fetch a new token
 		if client.Authorizer, err = getAzAuth(env); err != nil || client.Authorizer == nil {
 			glog.Fatal("Error creating Azure client", err)
@@ -189,10 +190,9 @@ func waitForAzureAuth(env environment.EnvVariables, client *n.ApplicationGateway
 		}
 
 		// Tries remaining
-		if counter < maxAuthRetry {
-			glog.Error("Error getting Application Gateway", env.AppGwName, err)
-			glog.Infof("Retrying in %v", retryTime)
-			time.Sleep(retryTime)
+		if counter < maxAuthRetryCount {
+			glog.Errorf("Failed fetching config for App Gateway instance %s. Will retry in %v. ARM Error: %s", env.AppGwName, tenSeconds, err)
+			time.Sleep(tenSeconds)
 		}
 	}
 
@@ -219,10 +219,10 @@ func getAzAuth(vars environment.EnvVariables) (autorest.Authorizer, error) {
 	if vars.AuthLocation == "" {
 		// requires aad-pod-identity to be deployed in the AKS cluster
 		// see https://github.com/Azure/aad-pod-identity for more information
-		glog.V(1).Infoln("Creating authorizer from Azure Managed Service Identity")
+		glog.V(1).Info("Creating authorizer from Azure Managed Service Identity")
 		return auth.NewAuthorizerFromEnvironment()
 	}
-	glog.V(1).Infoln("Creating authorizer from file referenced by AZURE_AUTH_LOCATION")
+	glog.V(1).Infof("Creating authorizer from file referenced by %s environment variable: %s", environment.AuthLocationVarName, vars.AuthLocation)
 	return auth.NewAuthorizerFromFile(n.DefaultBaseURI)
 }
 


### PR DESCRIPTION
Clarifying the error below to be more informative.
New error looks like this:
```bash
ERROR: logging before flag.Parse: I0724 11:58:49.047950    5802 main.go:275] Using verbosity level 3 from environment variable APPGW_VERBOSITY_LEVEL
I0724 11:58:49.048232    5802 main.go:225] Creating authorizer from file referenced by AZURE_AUTH_LOCATION environment variable: /home/xxx/.azure/azureAuth.json
E0724 11:58:49.701161    5802 main.go:194] Failed fetching config for App Gateway instance applicationgatewayxxx. Will retry in 10s. ARM Error: network.ApplicationGatewaysClient#Get: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceGroupNotFound" Message="Resource group 'xxx' could not be found."

```