### PR TITLE
validators: Check for nil App Gateway config

### DIFF
--- a/pkg/appgw/errors.go
+++ b/pkg/appgw/errors.go
@@ -1,0 +1,12 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package appgw
+
+import "errors"
+
+var (
+	ErrEmptyConfig = errors.New("empty App Gateway config")
+)

--- a/pkg/appgw/validators.go
+++ b/pkg/appgw/validators.go
@@ -112,10 +112,7 @@ func validateURLPathMaps(eventRecorder record.EventRecorder, config *n.Applicati
 	return nil
 }
 
-func validateFrontendIPConfiguration(eventRecorder record.EventRecorder, config *n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables) error {
-	if config == nil {
-		return ErrEmptyConfig
-	}
+func validateFrontendIPConfiguration(eventRecorder record.EventRecorder, config n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables) error {
 	privateIPPresent := false
 	publicIPPresent := false
 	var jsonConfigs []string
@@ -147,13 +144,16 @@ func validateFrontendIPConfiguration(eventRecorder record.EventRecorder, config 
 
 // FatalValidateOnExistingConfig validates the existing configuration is valid for the specified setting of the controller.
 func FatalValidateOnExistingConfig(eventRecorder record.EventRecorder, config *n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables) error {
+	if config == nil {
+		return ErrEmptyConfig
+	}
 
-	validators := []func(eventRecorder record.EventRecorder, config *n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables) error{
+	validators := []func(eventRecorder record.EventRecorder, config n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables) error{
 		validateFrontendIPConfiguration,
 	}
 
 	for _, fn := range validators {
-		if err := fn(eventRecorder, config, envVariables); err != nil {
+		if err := fn(eventRecorder, *config, envVariables); err != nil {
 			return err
 		}
 	}

--- a/pkg/appgw/validators.go
+++ b/pkg/appgw/validators.go
@@ -113,6 +113,9 @@ func validateURLPathMaps(eventRecorder record.EventRecorder, config *n.Applicati
 }
 
 func validateFrontendIPConfiguration(eventRecorder record.EventRecorder, config *n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables) error {
+	if config == nil {
+		return ErrEmptyConfig
+	}
 	privateIPPresent := false
 	publicIPPresent := false
 	var jsonConfigs []string

--- a/pkg/appgw/validators_test.go
+++ b/pkg/appgw/validators_test.go
@@ -27,12 +27,12 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 		serviceList := []*v1.Service{}
 		envVariables := environment.GetFakeEnv()
 
-		config := n.ApplicationGatewayPropertiesFormat{
+		config := &n.ApplicationGatewayPropertiesFormat{
 			URLPathMaps: &[]n.ApplicationGatewayURLPathMap{},
 		}
 
 		It("", func() {
-			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
+			err := validateURLPathMaps(eventRecorder, config, envVariables, ingressList, serviceList)
 			Expect(err).To(BeNil())
 		})
 
@@ -46,7 +46,7 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 				},
 			}
 			config.URLPathMaps = &[]n.ApplicationGatewayURLPathMap{pathMap}
-			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
+			err := validateURLPathMaps(eventRecorder, config, envVariables, ingressList, serviceList)
 			Expect(err).ToNot(BeNil())
 			Expect(err).To(Equal(validationErrors[errKeyNoDefaults]))
 		})
@@ -61,7 +61,7 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 				},
 			}
 			config.URLPathMaps = &[]n.ApplicationGatewayURLPathMap{pathMap}
-			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
+			err := validateURLPathMaps(eventRecorder, config, envVariables, ingressList, serviceList)
 			Expect(err).ToNot(BeNil())
 			Expect(err).To(Equal(validationErrors[errKeyEitherDefaults]))
 		})
@@ -76,7 +76,7 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 				},
 			}
 			config.URLPathMaps = &[]n.ApplicationGatewayURLPathMap{pathMap}
-			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
+			err := validateURLPathMaps(eventRecorder, config, envVariables, ingressList, serviceList)
 			Expect(err).ToNot(BeNil())
 			Expect(err).To(Equal(validationErrors[errKeyNoDefaults]))
 		})
@@ -91,7 +91,7 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 				},
 			}
 			config.URLPathMaps = &[]n.ApplicationGatewayURLPathMap{pathMap}
-			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
+			err := validateURLPathMaps(eventRecorder, config, envVariables, ingressList, serviceList)
 			Expect(err).To(BeNil())
 		})
 
@@ -105,7 +105,7 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 				},
 			}
 			config.URLPathMaps = &[]n.ApplicationGatewayURLPathMap{pathMap}
-			err := validateURLPathMaps(eventRecorder, &config, envVariables, ingressList, serviceList)
+			err := validateURLPathMaps(eventRecorder, config, envVariables, ingressList, serviceList)
 			Expect(err).To(BeNil())
 		})
 	})
@@ -146,19 +146,19 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 
 		It("should error out when Ip Configuration is empty.", func() {
 			config.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{}
-			err := validateFrontendIPConfiguration(eventRecorder, &config, envVariables)
+			err := validateFrontendIPConfiguration(eventRecorder, config, envVariables)
 			Expect(err).To(Equal(validationErrors[errKeyNoPublicIP]))
 		})
 
 		It("should not error out when Ip Configuration is contains 1 PublicIP and UsePrivateIP is false.", func() {
 			config.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{publicIPConf}
-			err := validateFrontendIPConfiguration(eventRecorder, &config, envVariables)
+			err := validateFrontendIPConfiguration(eventRecorder, config, envVariables)
 			Expect(err).To(BeNil())
 		})
 
 		It("should not error out when Ip Configuration is contains both PublicIP & PrivateIP and UsePrivateIP is false.", func() {
 			config.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{publicIPConf, privateIPConf}
-			err := validateFrontendIPConfiguration(eventRecorder, &config, envVariables)
+			err := validateFrontendIPConfiguration(eventRecorder, config, envVariables)
 			Expect(err).To(BeNil())
 		})
 
@@ -167,7 +167,7 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 			envVariablesNew.UsePrivateIP = "true"
 			Expect(envVariablesNew.UsePrivateIP).To(Equal("true"))
 			config.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{publicIPConf, privateIPConf}
-			err := validateFrontendIPConfiguration(eventRecorder, &config, envVariablesNew)
+			err := validateFrontendIPConfiguration(eventRecorder, config, envVariablesNew)
 			Expect(err).To(BeNil())
 		})
 
@@ -176,13 +176,13 @@ var _ = Describe("Test ConfigBuilder validator functions", func() {
 			envVariablesNew.UsePrivateIP = "true"
 			Expect(envVariablesNew.UsePrivateIP).To(Equal("true"))
 			config.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{publicIPConf}
-			err := validateFrontendIPConfiguration(eventRecorder, &config, envVariablesNew)
+			err := validateFrontendIPConfiguration(eventRecorder, config, envVariablesNew)
 			Expect(err).To(Equal(validationErrors[errKeyNoPrivateIP]))
 		})
 
 		It("should error out when Ip Configuration is doesn't contain public IP.", func() {
 			config.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{privateIPConf}
-			err := validateFrontendIPConfiguration(eventRecorder, &config, envVariables)
+			err := validateFrontendIPConfiguration(eventRecorder, config, envVariables)
 			Expect(err).To(Equal(validationErrors[errKeyNoPublicIP]))
 		})
 	})


### PR DESCRIPTION
This PR fixes the issue shown in the log below.
We should return a meaningful error. The root cause for missing config are permission issues; the nil pointer dereference issue is actually ok, but adds noise and distracts from quickly arriving at the actual issue at hand.
```bash
E0724 22:06:00.508471       1 main.go:179] Error getting Application Gatewayapplicationgatewayd0f0azure.BearerAuthorizer#WithAuthorization: Failed to refresh the Token for request to https://management.azure.com/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Network/applicationGateways/xxx?api-version=2018-12-01: StatusCode=403 -- Original Error: adal: Refresh request failed. Status Code = '403'. Response body: no AzureAssignedIdentity found for pod:default/ingress-azure-xx-xx
I0724 22:06:00.508514       1 main.go:180] Retrying in 10s
I0724 22:06:10.695843       1 main.go:111] Ingress Controller will observe the following namespaces:default
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x12b89ca]

goroutine 1 [running]:
github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw.validateFrontendIPConfiguration(0x185e4e0, 0xc000438680, 0x0, 0xc000044016, 0x24, 0xc0000420a5, 0xd, 0xc00004206b, 0x16, 0x0, ...)
        /gopath/src/github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw/validators.go:119 +0x3a
github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw.FatalValidateOnExistingConfig(0x185e4e0, 0xc000438680, 0x0, 0xc000044016, 0x24, 0xc0000420a5, 0xd, 0xc00004206b, 0x16, 0x0, ...)
        /gopath/src/github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw/validators.go:153 +0xc0
main.main()
        /gopath/src/github.com/Azure/application-gateway-kubernetes-ingress/cmd/appgw-ingress/main.go:121 +0x83c
```