### PR TITLE
Correct AzureIngressProhibitedTarget CRD URL pattern to allow for '/*'

### DIFF
--- a/crds/AzureIngressProhibitedTarget.yaml
+++ b/crds/AzureIngressProhibitedTarget.yaml
@@ -22,4 +22,4 @@ spec:
               type: array
               items:
                   type: string
-                  pattern: '^\/.*\/\*$'
+                  pattern: '^\/(?:.+\/)?\*$'


### PR DESCRIPTION
Tweaking the regex of the `AzureIngressProhibitedTarget` CRD to allow for `/*` wild card URL.

The change:
`'^\/.*\/\*$'` --> `'^\/(?:.+\/)?\*$'`

  1. adding `(?:    )` creates a non-capturing group
   2. adding `?` after the group - makes it optional