### PR TITLE
helm: Hard-code secretName to networking-appgw-k8s-azure-service-principal

### DIFF
--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -33,20 +33,20 @@ spec:
         {{- if eq .Values.armAuth.type "servicePrincipal"}}
         env:
           - name: AZURE_AUTH_LOCATION
-            value: /etc/Azure/Networking-AppGW/auth/{{ required "armAuth.secretKey is required if using servicePrincipal" .Values.armAuth.secretKey }}
+            value: /etc/Azure/Networking-AppGW/auth/armAuth.json
         {{- end}}
         envFrom:
         - configMapRef:
             name: {{ template "application-gateway-kubernetes-ingress.configmapname" . }}
         {{- if eq .Values.armAuth.type "servicePrincipal"}}
         volumeMounts:
-          - name: {{ required "armAuth.secretName is required if using servicePrincipal" .Values.armAuth.secretName }}-mount
+          - name: networking-appgw-k8s-azure-service-principal-mount
             mountPath: /etc/Azure/Networking-AppGW/auth
             readOnly: true
         {{- end}}
       {{- if eq .Values.armAuth.type "servicePrincipal"}}
       volumes:
-        - name: {{ .Values.armAuth.secretName }}-mount
+        - name: networking-appgw-k8s-azure-service-principal-mount
           secret:
-            secretName: {{ .Values.armAuth.secretName }}
+            secretName: networking-appgw-k8s-azure-service-principal
       {{- end}}

--- a/helm/ingress-azure/templates/secrets.yaml
+++ b/helm/ingress-azure/templates/secrets.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.armAuth -}}
+{{- if eq .Values.armAuth.type "servicePrincipal" -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: networking-appgw-k8s-azure-service-principal
+type: Opaque
+data:
+  armAuth.json: "{{- required "armAuth.secretJSON is required when using servicePrincipal" .Values.armAuth.secretJSON -}}"
+{{- end -}}
+{{- end -}}

--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -35,8 +35,10 @@ image:
 # - Option 2: ServicePrincipal as a kubernetes secret
 # armAuth:
 #   type: servicePrincipal
-#   secretName: networking-appgw-k8s-azure-service-principal
-#   secretKey: ServicePrincipal.json
+#
+#   # secretJSON could be derived via base64 -w auth.json
+#   # Generate auth.json with: 'az ad sp create-for-rbac --subscription <subs> --sdk-auth > auth.json'
+#   secretJSON: <base64 encoded, single line value of your auth.json file>
 
 ################################################################################
 # Specify if the cluster is RBAC enabled or not

--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -36,9 +36,9 @@ image:
 # armAuth:
 #   type: servicePrincipal
 #
-#   # secretJSON could be derived via base64 -w auth.json
-#   # Generate auth.json with: 'az ad sp create-for-rbac --subscription <subs> --sdk-auth > auth.json'
-#   secretJSON: <base64 encoded, single line value of your auth.json file>
+#   # Generate this value with:
+#   #   az ad sp create-for-rbac --subscription <subscription-uuid> --sdk-auth | base64 -w0
+#   secretJSON: <base64-encoded-JSON-blob>
 
 ################################################################################
 # Specify if the cluster is RBAC enabled or not

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -35,8 +35,10 @@ image:
 # - Option 2: ServicePrincipal as a kubernetes secret
 # armAuth:
 #   type: servicePrincipal
-#   secretName: networking-appgw-k8s-azure-service-principal
-#   secretKey: ServicePrincipal.json
+#
+#   # secretJSON could be derived via base64 -w auth.json
+#   # Generate auth.json with: 'az ad sp create-for-rbac --subscription <subs> --sdk-auth > auth.json'
+#   secretJSON: <base64 encoded, single line value of your auth.json file>
 
 ################################################################################
 # Specify if the cluster is RBAC enabled or not

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -36,9 +36,9 @@ image:
 # armAuth:
 #   type: servicePrincipal
 #
-#   # secretJSON could be derived via base64 -w auth.json
-#   # Generate auth.json with: 'az ad sp create-for-rbac --subscription <subs> --sdk-auth > auth.json'
-#   secretJSON: <base64 encoded, single line value of your auth.json file>
+#   # Generate this value with:
+#   #   az ad sp create-for-rbac --subscription <subscription-uuid> --sdk-auth | base64 -w0
+#   secretJSON: <base64-encoded-JSON-blob>
 
 ################################################################################
 # Specify if the cluster is RBAC enabled or not


### PR DESCRIPTION
This PR corrects and simplifies the option to provide Service Principal auth to AGIC.

Changes:
  - hard coded the Kubernetes secret name to: `networking-appgw-k8s-azure-service-principal` (I don't see a reason to allow for this to be tweaked, except of course in cases where the name would collide with some other existing secret; given the specificity of the string - I can't imagine a situation where this would occur)
  - hard coded the filename where the the secret would me mounted to: `armAuth.json`
  - the service principal JSON blob will be provided via new key -- `secretJSON`
  - added instructions on how to generate the `secretJSON`

Documentation still needs to be updated on how to use this method of authenticating against ARM. This will come in another PR.