### PR TITLE
Move istio specific functions in seprate files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,9 +32,9 @@ require (
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 // indirect
 	golang.org/x/sys v0.0.0-20190614160838-b47fdc937951 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
-	google.golang.org/api v0.6.0 // indirect
+	google.golang.org/api v0.7.0 // indirect
 	google.golang.org/appengine v1.6.1 // indirect
-	google.golang.org/genproto v0.0.0-20190626174449-989357319d63 // indirect
+	google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610 // indirect
 	google.golang.org/grpc v1.21.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e h1:JHB7F/4TJCrYBW8+GZO8VkWDj1jxcWuCl6uxKODiyi4=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -274,6 +276,8 @@ google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMt
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.6.0 h1:2tJEkRfnZL5g1GeBUlITh/rqT5HG3sFcoVCUUxmgJ2g=
 google.golang.org/api v0.6.0/go.mod h1:btoxGiFvQNVUZQ8W08zLtrVS08CNpINPEfxXxgJL1Q4=
+google.golang.org/api v0.7.0 h1:9sdfJOzWlkqPltHAuzT2Cp+yrBeY1KRVYgms8soxMwM=
+google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
@@ -291,6 +295,8 @@ google.golang.org/genproto v0.0.0-20190620144150-6af8c5fc6601 h1:9VBRTdmgQxbs6HE
 google.golang.org/genproto v0.0.0-20190620144150-6af8c5fc6601/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/genproto v0.0.0-20190626174449-989357319d63 h1:UsSJe9fhWNSz6emfIGPpH5DF23t7ALo2Pf3sC+/hsdg=
 google.golang.org/genproto v0.0.0-20190626174449-989357319d63/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
+google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610 h1:Ygq9/SRJX9+dU0WCIICM8RkWvDw03lvB77hrhJnpxfU=
+google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0 h1:cfg4PD8YEdSFnm7qLV4++93WcmhH2nIUhMjhdCvl3j8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -88,35 +88,6 @@ func (c *appGwConfigBuilder) newBackendPoolMap(cbCtx *ConfigBuilderContext) map[
 	return backendPoolMap
 }
 
-func (c *appGwConfigBuilder) getIstioBackendAddressPool(destinationID istioDestinationIdentifier, serviceBackendPair serviceBackendPortPair, addressPools map[string]*n.ApplicationGatewayBackendAddressPool) *n.ApplicationGatewayBackendAddressPool {
-	endpoints, err := c.k8sContext.GetEndpointsByService(destinationID.serviceKey())
-	if err != nil {
-		logLine := fmt.Sprintf("Failed fetching endpoints for service: %s", destinationID.serviceKey())
-		glog.Errorf(logLine)
-		//TODO(rhea): add recorder event for error
-		return nil
-	}
-
-	for _, subset := range endpoints.Subsets {
-		if _, portExists := getUniqueTCPPorts(subset)[serviceBackendPair.BackendPort]; portExists {
-			backendServicePort := ""
-			if destinationID.Destination.Port.Number != 0 {
-				backendServicePort = string(destinationID.Destination.Port.Number)
-			} else {
-				backendServicePort = destinationID.Destination.Port.Name
-			}
-			poolName := generateAddressPoolName(destinationID.serviceFullName(), backendServicePort, serviceBackendPair.BackendPort)
-			if pool, ok := addressPools[poolName]; ok {
-				return pool
-			}
-			return newPool(poolName, subset)
-		}
-		logLine := fmt.Sprintf("Backend target port %d does not have matching endpoint port", serviceBackendPair.BackendPort)
-		glog.Error(logLine)
-		//TODO(rhea): add recorder event for error
-	}
-	return nil
-}
 
 func (c *appGwConfigBuilder) getBackendAddressPool(backendID backendIdentifier, serviceBackendPair serviceBackendPortPair, addressPools map[string]*n.ApplicationGatewayBackendAddressPool) *n.ApplicationGatewayBackendAddressPool {
 	endpoints, err := c.k8sContext.GetEndpointsByService(backendID.serviceKey())

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -13,7 +13,6 @@ import (
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
-	"github.com/knative/pkg/apis/istio/v1alpha3"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -98,36 +97,6 @@ func newBackendIdsFiltered(cbCtx *ConfigBuilderContext) map[backendIdentifier]in
 	return finalBackendIDs
 }
 
-func istioMatchDestinationIds(cbCtx *ConfigBuilderContext) ([]istioMatchIdentifier, map[istioDestinationIdentifier]interface{}) {
-	matchIDs := make([]istioMatchIdentifier, 0)
-	destinationIDs := make(map[istioDestinationIdentifier]interface{})
-	for _, virtualService := range cbCtx.IstioVirtualServices {
-		for _, rule := range virtualService.Spec.HTTP {
-			destinations := make([]*v1alpha3.Destination, 0)
-			for _, routeDestination := range rule.Route {
-				if routeDestination.Weight != 0 {
-					destinations = append(destinations, &routeDestination.Destination)
-					/* TODO(rhea): Weights are being ignored for now, since this is not
-					yet supported on App Gateway. Include gates from routeDestination when
-					this is supported */
-				}
-				destinationID := generateIstioDestinationID(virtualService, &routeDestination.Destination)
-				destinationIDs[destinationID] = nil
-			}
-			for _, match := range rule.Match {
-				if match.URI == nil {
-					glog.V(5).Infof("Skipped match request, no URI field. Other forms of match requests are not supported.")
-					continue
-				}
-				matchID := generateIstioMatchID(virtualService, &rule, &match, destinations)
-				matchIDs = append(matchIDs, matchID)
-			}
-		}
-	}
-	/* TODO(rhea): Filter out destinations for virtual services referencing non-existent Services */
-	return matchIDs, destinationIDs
-}
-
 func newServiceSet(services *[]*v1.Service) map[string]*v1.Service {
 	servicesSet := make(map[string]*v1.Service)
 	for _, service := range *services {
@@ -135,137 +104,6 @@ func newServiceSet(services *[]*v1.Service) map[string]*v1.Service {
 		servicesSet[serviceKey] = service
 	}
 	return servicesSet
-}
-
-func (c *appGwConfigBuilder) getIstioDestinationsAndSettingsMap(cbCtx *ConfigBuilderContext) ([]n.ApplicationGatewayBackendHTTPSettings, map[istioDestinationIdentifier]*n.ApplicationGatewayBackendHTTPSettings, map[istioDestinationIdentifier]serviceBackendPortPair, error) {
-	serviceBackendPairsMap := make(map[istioDestinationIdentifier]map[serviceBackendPortPair]interface{})
-	backendHTTPSettingsMap := make(map[istioDestinationIdentifier]*n.ApplicationGatewayBackendHTTPSettings)
-	finalServiceBackendPairMap := make(map[istioDestinationIdentifier]serviceBackendPortPair)
-
-	var unresolvedDestinationID []istioDestinationIdentifier
-	_, destinationIDs := istioMatchDestinationIds(cbCtx)
-	for destinationID := range destinationIDs {
-		resolvedBackendPorts := make(map[serviceBackendPortPair]interface{})
-
-		service := c.k8sContext.GetService(destinationID.serviceKey())
-		destinationPortNum := int32(destinationID.Destination.Port.Number)
-		if service == nil {
-			// Once services are filtered in the istioMatchDestinationIDs function, this should never happen
-			logLine := fmt.Sprintf("Unable to get the service [%s]", destinationID.serviceKey())
-			glog.Errorf(logLine)
-			// TODO(rhea): add error event
-			pair := serviceBackendPortPair{
-				ServicePort: destinationPortNum,
-				BackendPort: destinationPortNum,
-			}
-			resolvedBackendPorts[pair] = nil
-		} else {
-			for _, sp := range service.Spec.Ports {
-				// find the backend port number
-				// check if any service ports matches the specified ports
-				if sp.Protocol != v1.ProtocolTCP {
-					// ignore UDP ports
-					continue
-				}
-				if sp.Port == destinationPortNum ||
-					sp.Name == destinationID.Destination.Port.Name ||
-					sp.TargetPort.String() == destinationID.Destination.Port.Name ||
-					sp.TargetPort.String() == string(destinationPortNum) {
-					// matched a service port with a port from the service
-
-					if sp.TargetPort.String() == "" {
-						// targetPort is not defined, by default targetPort == port
-						pair := serviceBackendPortPair{
-							ServicePort: sp.Port,
-							BackendPort: sp.Port,
-						}
-						resolvedBackendPorts[pair] = nil
-					} else {
-						// target port is defined as name or port number
-						if sp.TargetPort.Type == intstr.Int {
-							// port is defined as port number
-							pair := serviceBackendPortPair{
-								ServicePort: sp.Port,
-								BackendPort: sp.TargetPort.IntVal,
-							}
-							resolvedBackendPorts[pair] = nil
-						} else {
-							// if service port is defined by name, need to resolve
-							targetPortName := sp.TargetPort.StrVal
-							glog.V(1).Infof("resolving port name %s", targetPortName)
-							targetPortsResolved := c.resolveIstioPortName(targetPortName, &destinationID)
-							for targetPort := range targetPortsResolved {
-								pair := serviceBackendPortPair{
-									ServicePort: sp.Port,
-									BackendPort: targetPort,
-								}
-								resolvedBackendPorts[pair] = nil
-							}
-						}
-					}
-					break
-				}
-			}
-		}
-		if len(resolvedBackendPorts) == 0 {
-			logLine := fmt.Sprintf("Unable to resolve any backend port for service [%s]", destinationID.serviceKey())
-			glog.Error(logLine)
-			//TODO(rhea): Add error event
-
-			unresolvedDestinationID = append(unresolvedDestinationID, destinationID)
-			break
-		}
-
-		// Merge serviceBackendPairsMap[backendID] into resolvedBackendPorts
-		if _, ok := serviceBackendPairsMap[destinationID]; !ok {
-			serviceBackendPairsMap[destinationID] = make(map[serviceBackendPortPair]interface{})
-		}
-		for portPair := range resolvedBackendPorts {
-			serviceBackendPairsMap[destinationID][portPair] = nil
-		}
-	}
-	if len(unresolvedDestinationID) > 0 {
-		return nil, nil, nil, errors.New("unable to resolve backend port for some services")
-	}
-
-	httpSettingsCollection := make(map[string]n.ApplicationGatewayBackendHTTPSettings)
-	defaultBackend := defaultBackendHTTPSettings(c.appGwIdentifier, defaultProbeName)
-	httpSettingsCollection[*defaultBackend.Name] = defaultBackend
-
-	for destinationID, serviceBackendPairs := range serviceBackendPairsMap {
-		if len(serviceBackendPairs) > 1 {
-			// more than one possible backend port exposed through ingress
-			backendServicePort := ""
-			if destinationID.Destination.Port.Number != 0 {
-				backendServicePort = string(destinationID.Destination.Port.Number)
-			} else {
-				backendServicePort = destinationID.Destination.Port.Name
-			}
-			logLine := fmt.Sprintf("service:port [%s:%s] has more than one service-backend port binding",
-				destinationID.serviceKey(), backendServicePort)
-			glog.Warning(logLine)
-			//TODO(rhea): add error event recorder
-			return nil, nil, nil, errors.New("more than one service-backend port binding is not allowed")
-		}
-
-		// At this point there will be only one pair
-		var uniquePair serviceBackendPortPair
-		for k := range serviceBackendPairs {
-			uniquePair = k
-		}
-
-		finalServiceBackendPairMap[destinationID] = uniquePair
-		httpSettings := c.generateIstioHTTPSettings(destinationID, uniquePair.BackendPort, cbCtx)
-		httpSettingsCollection[*httpSettings.Name] = httpSettings
-		backendHTTPSettingsMap[destinationID] = &httpSettings
-	}
-
-	httpSettings := make([]n.ApplicationGatewayBackendHTTPSettings, 0, len(httpSettingsCollection))
-	for _, backend := range httpSettingsCollection {
-		httpSettings = append(httpSettings, backend)
-	}
-
-	return httpSettings, backendHTTPSettingsMap, finalServiceBackendPairMap, nil
 }
 
 func (c *appGwConfigBuilder) getBackendsAndSettingsMap(cbCtx *ConfigBuilderContext) ([]n.ApplicationGatewayBackendHTTPSettings, map[backendIdentifier]*n.ApplicationGatewayBackendHTTPSettings, map[backendIdentifier]serviceBackendPortPair, error) {
@@ -436,30 +274,6 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 	if reqTimeout, err := annotations.RequestTimeout(backendID.Ingress); err == nil {
 		httpSettings.RequestTimeout = to.Int32Ptr(reqTimeout)
 	}
-
-	return httpSettings
-}
-
-func (c *appGwConfigBuilder) generateIstioHTTPSettings(destinationID istioDestinationIdentifier, port int32, cbCtx *ConfigBuilderContext) n.ApplicationGatewayBackendHTTPSettings {
-	backendServicePort := ""
-	if destinationID.Destination.Port.Number != 0 {
-		backendServicePort = string(destinationID.Destination.Port.Number)
-	} else {
-		backendServicePort = destinationID.Destination.Port.Name
-	}
-	httpSettingsName := generateHTTPSettingsName(destinationID.serviceFullName(), backendServicePort, port, destinationID.VirtualService.Name)
-	glog.V(5).Infof("Created a new HTTP setting w/ name: %s\n", httpSettingsName)
-	httpSettings := n.ApplicationGatewayBackendHTTPSettings{
-		Etag: to.StringPtr("*"),
-		Name: &httpSettingsName,
-		ID:   to.StringPtr(c.appGwIdentifier.httpSettingsID(httpSettingsName)),
-		ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
-			Protocol: n.HTTP,
-			Port:     &port,
-		},
-	}
-
-	//TODO(rhea): check relevant annotations and modify http settings accordingly
 
 	return httpSettings
 }

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -17,7 +17,6 @@ import (
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
-	"github.com/knative/pkg/apis/istio/v1alpha3"
 	"k8s.io/api/extensions/v1beta1"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
@@ -41,21 +40,6 @@ type backendIdentifier struct {
 	Rule    *v1beta1.IngressRule
 	Path    *v1beta1.HTTPIngressPath
 	Backend *v1beta1.IngressBackend
-}
-
-type istioMatchIdentifier struct {
-	Namespace      string
-	VirtualService *v1alpha3.VirtualService
-	Rule           *v1alpha3.HTTPRoute
-	Match          *v1alpha3.HTTPMatchRequest
-	Destinations   []*v1alpha3.Destination
-	Gateways       []string
-}
-
-type istioDestinationIdentifier struct {
-	serviceIdentifier
-	VirtualService *v1alpha3.VirtualService
-	Destination    *v1alpha3.Destination
 }
 
 type serviceBackendPortPair struct {

--- a/pkg/appgw/istio_config.go
+++ b/pkg/appgw/istio_config.go
@@ -1,0 +1,54 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package appgw
+
+import (
+	"github.com/golang/glog"
+	"github.com/knative/pkg/apis/istio/v1alpha3"
+)
+
+func (c *appGwConfigBuilder) resolveIstioPortName(portName string, destinationID *istioDestinationIdentifier) map[int32]interface{} {
+	resolvedPorts := make(map[int32]interface{})
+	endpoints, err := c.k8sContext.GetEndpointsByService(destinationID.serviceKey())
+	if err != nil {
+		glog.Error("Could not fetch endpoint by service key from cache", err)
+		return resolvedPorts
+	}
+
+	if endpoints == nil {
+		return resolvedPorts
+	}
+	for _, subset := range endpoints.Subsets {
+		for _, epPort := range subset.Ports {
+			if epPort.Name == portName {
+				resolvedPorts[epPort.Port] = nil
+			}
+		}
+	}
+	return resolvedPorts
+}
+
+func generateIstioMatchID(virtualService *v1alpha3.VirtualService, rule *v1alpha3.HTTPRoute, match *v1alpha3.HTTPMatchRequest, destinations []*v1alpha3.Destination) istioMatchIdentifier {
+	return istioMatchIdentifier{
+		Namespace:      virtualService.Namespace,
+		VirtualService: virtualService,
+		Rule:           rule,
+		Match:          match,
+		Destinations:   destinations,
+		Gateways:       match.Gateways,
+	}
+}
+
+func generateIstioDestinationID(virtualService *v1alpha3.VirtualService, destination *v1alpha3.Destination) istioDestinationIdentifier {
+	return istioDestinationIdentifier{
+		serviceIdentifier: serviceIdentifier{
+			Namespace: virtualService.Namespace,
+			Name:      destination.Host,
+		},
+		VirtualService: virtualService,
+		Destination:    destination,
+	}
+}

--- a/pkg/appgw/istio_listeners.go
+++ b/pkg/appgw/istio_listeners.go
@@ -1,0 +1,50 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package appgw
+
+import (
+	"github.com/golang/glog"
+	"github.com/knative/pkg/apis/istio/v1alpha3"
+)
+
+func (c *appGwConfigBuilder) getListenerConfigsFromIstio(istioGateways []*v1alpha3.Gateway, istioVirtualServices []*v1alpha3.VirtualService) map[listenerIdentifier]listenerAzConfig {
+	knownHosts := make(map[string]interface{})
+	for _, virtualService := range istioVirtualServices {
+		for _, host := range virtualService.Spec.Hosts {
+			knownHosts[host] = nil
+		}
+	}
+
+	allListeners := make(map[listenerIdentifier]listenerAzConfig)
+	for _, igwy := range istioGateways {
+		for _, server := range igwy.Spec.Servers {
+			if server.Port.Protocol != v1alpha3.ProtocolHTTP {
+				glog.Infof("[istio] AGIC does not support Gateway with Server.Port.Protocol=%+v", server.Port.Protocol)
+				continue
+			}
+			for _, host := range server.Hosts {
+				if _, exist := knownHosts[host]; !exist {
+					continue
+				}
+				listenerID := listenerIdentifier{
+					FrontendPort: int32(server.Port.Number),
+					HostName:     host,
+				}
+				allListeners[listenerID] = listenerAzConfig{Protocol: n.HTTP}
+			}
+		}
+	}
+
+	// App Gateway must have at least one listener - the default one!
+	if len(allListeners) == 0 {
+		allListeners[defaultFrontendListenerIdentifier()] = listenerAzConfig{
+			// Default protocol
+			Protocol: n.HTTP,
+		}
+	}
+
+	return allListeners
+}

--- a/pkg/appgw/istio_listeners.go
+++ b/pkg/appgw/istio_listeners.go
@@ -6,6 +6,7 @@
 package appgw
 
 import (
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/golang/glog"
 	"github.com/knative/pkg/apis/istio/v1alpha3"
 )

--- a/pkg/appgw/istio_pools.go
+++ b/pkg/appgw/istio_pools.go
@@ -7,7 +7,10 @@ package appgw
 
 import (
 	"fmt"
+
 	"github.com/golang/glog"
+
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 )
 
 func (c *appGwConfigBuilder) getIstioBackendAddressPool(destinationID istioDestinationIdentifier, serviceBackendPair serviceBackendPortPair, addressPools map[string]*n.ApplicationGatewayBackendAddressPool) *n.ApplicationGatewayBackendAddressPool {

--- a/pkg/appgw/istio_pools.go
+++ b/pkg/appgw/istio_pools.go
@@ -1,0 +1,41 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package appgw
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+)
+
+func (c *appGwConfigBuilder) getIstioBackendAddressPool(destinationID istioDestinationIdentifier, serviceBackendPair serviceBackendPortPair, addressPools map[string]*n.ApplicationGatewayBackendAddressPool) *n.ApplicationGatewayBackendAddressPool {
+	endpoints, err := c.k8sContext.GetEndpointsByService(destinationID.serviceKey())
+	if err != nil {
+		logLine := fmt.Sprintf("Failed fetching endpoints for service: %s", destinationID.serviceKey())
+		glog.Errorf(logLine)
+		//TODO(rhea): add recorder event for error
+		return nil
+	}
+
+	for _, subset := range endpoints.Subsets {
+		if _, portExists := getUniqueTCPPorts(subset)[serviceBackendPair.BackendPort]; portExists {
+			backendServicePort := ""
+			if destinationID.Destination.Port.Number != 0 {
+				backendServicePort = string(destinationID.Destination.Port.Number)
+			} else {
+				backendServicePort = destinationID.Destination.Port.Name
+			}
+			poolName := generateAddressPoolName(destinationID.serviceFullName(), backendServicePort, serviceBackendPair.BackendPort)
+			if pool, ok := addressPools[poolName]; ok {
+				return pool
+			}
+			return newPool(poolName, subset)
+		}
+		logLine := fmt.Sprintf("Backend target port %d does not have matching endpoint port", serviceBackendPair.BackendPort)
+		glog.Error(logLine)
+		//TODO(rhea): add recorder event for error
+	}
+	return nil
+}

--- a/pkg/appgw/istio_settings.go
+++ b/pkg/appgw/istio_settings.go
@@ -1,0 +1,197 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package appgw
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/knative/pkg/apis/istio/v1alpha3"
+)
+
+func istioMatchDestinationIds(cbCtx *ConfigBuilderContext) ([]istioMatchIdentifier, map[istioDestinationIdentifier]interface{}) {
+	matchIDs := make([]istioMatchIdentifier, 0)
+	destinationIDs := make(map[istioDestinationIdentifier]interface{})
+	for _, virtualService := range cbCtx.IstioVirtualServices {
+		for _, rule := range virtualService.Spec.HTTP {
+			destinations := make([]*v1alpha3.Destination, 0)
+			for _, routeDestination := range rule.Route {
+				if routeDestination.Weight != 0 {
+					destinations = append(destinations, &routeDestination.Destination)
+					/* TODO(rhea): Weights are being ignored for now, since this is not
+					yet supported on App Gateway. Include gates from routeDestination when
+					this is supported */
+				}
+				destinationID := generateIstioDestinationID(virtualService, &routeDestination.Destination)
+				destinationIDs[destinationID] = nil
+			}
+			for _, match := range rule.Match {
+				if match.URI == nil {
+					glog.V(5).Infof("Skipped match request, no URI field. Other forms of match requests are not supported.")
+					continue
+				}
+				matchID := generateIstioMatchID(virtualService, &rule, &match, destinations)
+				matchIDs = append(matchIDs, matchID)
+			}
+		}
+	}
+	/* TODO(rhea): Filter out destinations for virtual services referencing non-existent Services */
+	return matchIDs, destinationIDs
+}
+
+func (c *appGwConfigBuilder) getIstioDestinationsAndSettingsMap(cbCtx *ConfigBuilderContext) ([]n.ApplicationGatewayBackendHTTPSettings, map[istioDestinationIdentifier]*n.ApplicationGatewayBackendHTTPSettings, map[istioDestinationIdentifier]serviceBackendPortPair, error) {
+	serviceBackendPairsMap := make(map[istioDestinationIdentifier]map[serviceBackendPortPair]interface{})
+	backendHTTPSettingsMap := make(map[istioDestinationIdentifier]*n.ApplicationGatewayBackendHTTPSettings)
+	finalServiceBackendPairMap := make(map[istioDestinationIdentifier]serviceBackendPortPair)
+
+	var unresolvedDestinationID []istioDestinationIdentifier
+	_, destinationIDs := istioMatchDestinationIds(cbCtx)
+	for destinationID := range destinationIDs {
+		resolvedBackendPorts := make(map[serviceBackendPortPair]interface{})
+
+		service := c.k8sContext.GetService(destinationID.serviceKey())
+		destinationPortNum := int32(destinationID.Destination.Port.Number)
+		if service == nil {
+			// Once services are filtered in the istioMatchDestinationIDs function, this should never happen
+			logLine := fmt.Sprintf("Unable to get the service [%s]", destinationID.serviceKey())
+			glog.Errorf(logLine)
+			// TODO(rhea): add error event
+			pair := serviceBackendPortPair{
+				ServicePort: destinationPortNum,
+				BackendPort: destinationPortNum,
+			}
+			resolvedBackendPorts[pair] = nil
+		} else {
+			for _, sp := range service.Spec.Ports {
+				// find the backend port number
+				// check if any service ports matches the specified ports
+				if sp.Protocol != v1.ProtocolTCP {
+					// ignore UDP ports
+					continue
+				}
+				if sp.Port == destinationPortNum ||
+					sp.Name == destinationID.Destination.Port.Name ||
+					sp.TargetPort.String() == destinationID.Destination.Port.Name ||
+					sp.TargetPort.String() == string(destinationPortNum) {
+					// matched a service port with a port from the service
+
+					if sp.TargetPort.String() == "" {
+						// targetPort is not defined, by default targetPort == port
+						pair := serviceBackendPortPair{
+							ServicePort: sp.Port,
+							BackendPort: sp.Port,
+						}
+						resolvedBackendPorts[pair] = nil
+					} else {
+						// target port is defined as name or port number
+						if sp.TargetPort.Type == intstr.Int {
+							// port is defined as port number
+							pair := serviceBackendPortPair{
+								ServicePort: sp.Port,
+								BackendPort: sp.TargetPort.IntVal,
+							}
+							resolvedBackendPorts[pair] = nil
+						} else {
+							// if service port is defined by name, need to resolve
+							targetPortName := sp.TargetPort.StrVal
+							glog.V(1).Infof("resolving port name %s", targetPortName)
+							targetPortsResolved := c.resolveIstioPortName(targetPortName, &destinationID)
+							for targetPort := range targetPortsResolved {
+								pair := serviceBackendPortPair{
+									ServicePort: sp.Port,
+									BackendPort: targetPort,
+								}
+								resolvedBackendPorts[pair] = nil
+							}
+						}
+					}
+					break
+				}
+			}
+		}
+		if len(resolvedBackendPorts) == 0 {
+			logLine := fmt.Sprintf("Unable to resolve any backend port for service [%s]", destinationID.serviceKey())
+			glog.Error(logLine)
+			//TODO(rhea): Add error event
+
+			unresolvedDestinationID = append(unresolvedDestinationID, destinationID)
+			break
+		}
+
+		// Merge serviceBackendPairsMap[backendID] into resolvedBackendPorts
+		if _, ok := serviceBackendPairsMap[destinationID]; !ok {
+			serviceBackendPairsMap[destinationID] = make(map[serviceBackendPortPair]interface{})
+		}
+		for portPair := range resolvedBackendPorts {
+			serviceBackendPairsMap[destinationID][portPair] = nil
+		}
+	}
+	if len(unresolvedDestinationID) > 0 {
+		return nil, nil, nil, errors.New("unable to resolve backend port for some services")
+	}
+
+	httpSettingsCollection := make(map[string]n.ApplicationGatewayBackendHTTPSettings)
+	defaultBackend := defaultBackendHTTPSettings(c.appGwIdentifier, defaultProbeName)
+	httpSettingsCollection[*defaultBackend.Name] = defaultBackend
+
+	for destinationID, serviceBackendPairs := range serviceBackendPairsMap {
+		if len(serviceBackendPairs) > 1 {
+			// more than one possible backend port exposed through ingress
+			backendServicePort := ""
+			if destinationID.Destination.Port.Number != 0 {
+				backendServicePort = string(destinationID.Destination.Port.Number)
+			} else {
+				backendServicePort = destinationID.Destination.Port.Name
+			}
+			logLine := fmt.Sprintf("service:port [%s:%s] has more than one service-backend port binding",
+				destinationID.serviceKey(), backendServicePort)
+			glog.Warning(logLine)
+			//TODO(rhea): add error event recorder
+			return nil, nil, nil, errors.New("more than one service-backend port binding is not allowed")
+		}
+
+		// At this point there will be only one pair
+		var uniquePair serviceBackendPortPair
+		for k := range serviceBackendPairs {
+			uniquePair = k
+		}
+
+		finalServiceBackendPairMap[destinationID] = uniquePair
+		httpSettings := c.generateIstioHTTPSettings(destinationID, uniquePair.BackendPort, cbCtx)
+		httpSettingsCollection[*httpSettings.Name] = httpSettings
+		backendHTTPSettingsMap[destinationID] = &httpSettings
+	}
+
+	httpSettings := make([]n.ApplicationGatewayBackendHTTPSettings, 0, len(httpSettingsCollection))
+	for _, backend := range httpSettingsCollection {
+		httpSettings = append(httpSettings, backend)
+	}
+
+	return httpSettings, backendHTTPSettingsMap, finalServiceBackendPairMap, nil
+}
+
+func (c *appGwConfigBuilder) generateIstioHTTPSettings(destinationID istioDestinationIdentifier, port int32, cbCtx *ConfigBuilderContext) n.ApplicationGatewayBackendHTTPSettings {
+	backendServicePort := ""
+	if destinationID.Destination.Port.Number != 0 {
+		backendServicePort = string(destinationID.Destination.Port.Number)
+	} else {
+		backendServicePort = destinationID.Destination.Port.Name
+	}
+	httpSettingsName := generateHTTPSettingsName(destinationID.serviceFullName(), backendServicePort, port, destinationID.VirtualService.Name)
+	glog.V(5).Infof("Created a new HTTP setting w/ name: %s\n", httpSettingsName)
+	httpSettings := n.ApplicationGatewayBackendHTTPSettings{
+		Etag: to.StringPtr("*"),
+		Name: &httpSettingsName,
+		ID:   to.StringPtr(c.appGwIdentifier.httpSettingsID(httpSettingsName)),
+		ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
+			Protocol: n.HTTP,
+			Port:     &port,
+		},
+	}
+
+	//TODO(rhea): check relevant annotations and modify http settings accordingly
+
+	return httpSettings
+}

--- a/pkg/appgw/istio_settings.go
+++ b/pkg/appgw/istio_settings.go
@@ -6,9 +6,15 @@
 package appgw
 
 import (
+	"errors"
 	"fmt"
+
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
 	"github.com/knative/pkg/apis/istio/v1alpha3"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func istioMatchDestinationIds(cbCtx *ConfigBuilderContext) ([]istioMatchIdentifier, map[istioDestinationIdentifier]interface{}) {

--- a/pkg/appgw/istio_types.go
+++ b/pkg/appgw/istio_types.go
@@ -1,0 +1,23 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package appgw
+
+import "github.com/knative/pkg/apis/istio/v1alpha3"
+
+type istioMatchIdentifier struct {
+	Namespace      string
+	VirtualService *v1alpha3.VirtualService
+	Rule           *v1alpha3.HTTPRoute
+	Match          *v1alpha3.HTTPMatchRequest
+	Destinations   []*v1alpha3.Destination
+	Gateways       []string
+}
+
+type istioDestinationIdentifier struct {
+	serviceIdentifier
+	VirtualService *v1alpha3.VirtualService
+	Destination    *v1alpha3.Destination
+}

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -272,24 +272,6 @@ func (c *Context) ListAzureProhibitedTargets() []*prohibitedv1.AzureIngressProhi
 	return targets
 }
 
-// ListIstioGateways returns a list of discovered Istio Gateways
-func (c *Context) ListIstioGateways() []*v1alpha3.Gateway {
-	var gateways []*v1alpha3.Gateway
-	for _, gateway := range c.Caches.IstioGateway.List() {
-		gateways = append(gateways, gateway.(*v1alpha3.Gateway))
-	}
-	return gateways
-}
-
-// ListIstioVirtualServices returns a list of discovered Istio Virtual Services
-func (c *Context) ListIstioVirtualServices() []*v1alpha3.VirtualService {
-	var virtualServices []*v1alpha3.VirtualService
-	for _, virtualService := range c.Caches.IstioVirtualService.List() {
-		virtualServices = append(virtualServices, virtualService.(*v1alpha3.VirtualService))
-	}
-	return virtualServices
-}
-
 // GetService returns the service identified by the key.
 func (c *Context) GetService(serviceKey string) *v1.Service {
 	serviceInterface, exist, err := c.Caches.Service.GetByKey(serviceKey)

--- a/pkg/k8scontext/istio_context.go
+++ b/pkg/k8scontext/istio_context.go
@@ -1,0 +1,26 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package k8scontext
+
+import "github.com/knative/pkg/apis/istio/v1alpha3"
+
+// ListIstioGateways returns a list of discovered Istio Gateways
+func (c *Context) ListIstioGateways() []*v1alpha3.Gateway {
+	var gateways []*v1alpha3.Gateway
+	for _, gateway := range c.Caches.IstioGateway.List() {
+		gateways = append(gateways, gateway.(*v1alpha3.Gateway))
+	}
+	return gateways
+}
+
+// ListIstioVirtualServices returns a list of discovered Istio Virtual Services
+func (c *Context) ListIstioVirtualServices() []*v1alpha3.VirtualService {
+	var virtualServices []*v1alpha3.VirtualService
+	for _, virtualService := range c.Caches.IstioVirtualService.List() {
+		virtualServices = append(virtualServices, virtualService.(*v1alpha3.VirtualService))
+	}
+	return virtualServices
+}


### PR DESCRIPTION
This PR is a no-op. Simply moving Istio related functions into separate files, but still within the same packages.
This separates concerns and lowers cognitive load when working within these files -- also lowers the chance of stepping on each others toes / merge conflicts etc.