### PR TITLE
Ensure pure functions / idempotency

### DIFF
--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -21,7 +21,6 @@ import (
 
 // getListeners constructs the unique set of App Gateway HTTP listeners across all ingresses.
 func (c *appGwConfigBuilder) getListeners(cbCtx *ConfigBuilderContext) *[]n.ApplicationGatewayHTTPListener {
-	// TODO(draychev): this is for compatibility w/ RequestRoutingRules and should be removed ASAP
 	var listeners []n.ApplicationGatewayHTTPListener
 
 	if cbCtx.EnableIstioIntegration {

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -60,7 +60,7 @@ func (c *appGwConfigBuilder) RequestRoutingRules(cbCtx *ConfigBuilderContext) er
 }
 
 func (c *appGwConfigBuilder) getURLPathMaps(cbCtx *ConfigBuilderContext) map[listenerIdentifier]*n.ApplicationGatewayURLPathMap {
-	httpListenersMap := c.groupListenersByListenerIdentifier(c.appGw.HTTPListeners)
+	httpListenersMap := c.groupListenersByListenerIdentifier(c.getListeners(cbCtx))
 	urlPathMaps := make(map[listenerIdentifier]*n.ApplicationGatewayURLPathMap)
 	backendPools := c.newBackendPoolMap(cbCtx)
 	_, backendHTTPSettingsMap, _, _ := c.getBackendsAndSettingsMap(cbCtx)
@@ -170,7 +170,7 @@ func (c *appGwConfigBuilder) getURLPathMaps(cbCtx *ConfigBuilderContext) map[lis
 }
 
 func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.ApplicationGatewayRequestRoutingRule, []n.ApplicationGatewayURLPathMap) {
-	httpListenersMap := c.groupListenersByListenerIdentifier(c.appGw.HTTPListeners)
+	httpListenersMap := c.groupListenersByListenerIdentifier(c.getListeners(cbCtx))
 	var pathMap []n.ApplicationGatewayURLPathMap
 	var requestRoutingRules []n.ApplicationGatewayRequestRoutingRule
 	for listenerID, urlPathMap := range c.getURLPathMaps(cbCtx) {


### PR DESCRIPTION
I accidentally stumbled on these 2 lines of code.  I thought we removed most of the side-effects - it seems that we missed these.

Removing the dependency on the order of operations would remove the risk of running into incorrect config generation and would allow us to enable concurrency.
On the other hand - there is obviously redundant work that is going to be done here.
At a later stage we should introduce memoization (should performance become an issue)