### PR TITLE
brownfield: TargetPath.contains(TargetPath)

### DIFF
--- a/pkg/brownfield/ingress.go
+++ b/pkg/brownfield/ingress.go
@@ -50,7 +50,7 @@ func PruneIngressRules(ing *v1beta1.Ingress, prohibitedTargets []*ptv1.AzureIngr
 			},
 		}
 		for _, path := range rule.HTTP.Paths {
-			target.Path = path.Path
+			target.Path = TargetPath(path.Path)
 			if target.IsBlacklisted(blacklist) {
 				continue
 			}

--- a/pkg/brownfield/routing_rules.go
+++ b/pkg/brownfield/routing_rules.go
@@ -194,7 +194,7 @@ func (er ExistingResources) getRuleToTargets() (ruleToTargets, pathmapToTargets)
 					continue
 				}
 				for _, path := range *pathRule.Paths {
-					target := Target{hostName, strings.ToLower(path)}
+					target := Target{hostName, TargetPath(path)}
 					ruleToTargets[ruleName(*rule.Name)] = append(ruleToTargets[ruleName(*rule.Name)], target)
 					pathMapToTargets[pathMapName] = append(pathMapToTargets[pathMapName], target)
 				}

--- a/pkg/brownfield/targets.go
+++ b/pkg/brownfield/targets.go
@@ -74,8 +74,13 @@ func (p TargetPath) lower() string {
 }
 
 func (thisPath TargetPath) contains(otherPath TargetPath) bool {
-	if thisPath == "" || thisPath == "/" || thisPath == "*" || thisPath == "/*" {
+	if thisPath == "" || thisPath == "*" || thisPath == "/*" {
 		return true
+	}
+
+	// For strings that do not end with a * - do exact match
+	if !strings.HasSuffix(thisPath.lower(), "*") {
+		return thisPath.lower() == otherPath.lower()
 	}
 
 	// "/x/*" contains "/x"

--- a/pkg/brownfield/targets_test.go
+++ b/pkg/brownfield/targets_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Test blacklisting targets", func() {
 
 			// Targets /fox and /bar are in the blacklist
 			for _, path := range []string{fixtures.PathFox, fixtures.PathBar} {
-				expected.Path = path
+				expected.Path = TargetPath(path)
 				Expect(*blacklist).To(ContainElement(expected))
 			}
 			expected.Path = fixtures.PathFoo
@@ -84,6 +84,39 @@ var _ = Describe("Test blacklisting targets", func() {
 			Expect(targetNoPaths.IsBlacklisted(&blacklist)).To(BeTrue())
 			Expect(targetNonExistentPath.IsBlacklisted(&blacklist)).To(BeFalse())
 			Expect(targetNoHost.IsBlacklisted(&blacklist)).To(BeFalse())
+		})
+	})
+
+	Context("test TargetPath.contains(TargetPath)", func() {
+		It("TargetPath.contains(TargetPath) should work correctly", func() {
+			Expect(TargetPath("/*").contains("/blah")).To(BeTrue())
+			Expect(TargetPath("/*").contains("/")).To(BeTrue())
+			Expect(TargetPath("/*").contains("")).To(BeTrue())
+			Expect(TargetPath("/*").contains("/*")).To(BeTrue())
+
+			Expect(TargetPath("*").contains("/blah")).To(BeTrue())
+			Expect(TargetPath("*").contains("/")).To(BeTrue())
+			Expect(TargetPath("*").contains("")).To(BeTrue())
+			Expect(TargetPath("*").contains("/*")).To(BeTrue())
+
+			Expect(TargetPath("/").contains("/blah")).To(BeTrue())
+			Expect(TargetPath("/").contains("/")).To(BeTrue())
+			Expect(TargetPath("/").contains("")).To(BeTrue())
+			Expect(TargetPath("/").contains("/*")).To(BeTrue())
+
+			Expect(TargetPath("/x/*").contains("/blah")).To(BeFalse())
+			Expect(TargetPath("/x/*").contains("/")).To(BeFalse())
+			Expect(TargetPath("/x/*").contains("")).To(BeFalse())
+			Expect(TargetPath("/x/*").contains("/*")).To(BeFalse())
+
+			Expect(TargetPath("/x/*").contains("/x")).To(BeTrue())
+			Expect(TargetPath("/x/*").contains("/X")).To(BeTrue())
+			Expect(TargetPath("/X/*").contains("/x")).To(BeTrue())
+			Expect(TargetPath("/x/*").contains("/x/")).To(BeTrue())
+			Expect(TargetPath("/x/*").contains("/x/*")).To(BeTrue())
+
+			Expect(TargetPath("/abCD/xyZ/1/*").contains("/AbcD/Xyz/*")).To(BeFalse())
+			Expect(TargetPath("/AbcD/Xyz/*").contains("/abCD/xyZ/1/*")).To(BeTrue())
 		})
 	})
 })

--- a/pkg/brownfield/targets_test.go
+++ b/pkg/brownfield/targets_test.go
@@ -99,10 +99,11 @@ var _ = Describe("Test blacklisting targets", func() {
 			Expect(TargetPath("*").contains("")).To(BeTrue())
 			Expect(TargetPath("*").contains("/*")).To(BeTrue())
 
-			Expect(TargetPath("/").contains("/blah")).To(BeTrue())
+			Expect(TargetPath("/").contains("/blah")).To(BeFalse())
+			Expect(TargetPath("/blah").contains("/blah")).To(BeTrue())
 			Expect(TargetPath("/").contains("/")).To(BeTrue())
-			Expect(TargetPath("/").contains("")).To(BeTrue())
-			Expect(TargetPath("/").contains("/*")).To(BeTrue())
+			Expect(TargetPath("/").contains("")).To(BeFalse())
+			Expect(TargetPath("/").contains("/*")).To(BeFalse())
 
 			Expect(TargetPath("/x/*").contains("/blah")).To(BeFalse())
 			Expect(TargetPath("/x/*").contains("/")).To(BeFalse())


### PR DESCRIPTION
In this PR:

 - Introducing new type `TargetPath`, which is a string -- a URL Path - `/x/*` for example
 - adding a `contains` function to inform whether path N is contained within path M

Example:
```yaml
apiVersion: appgw.ingress.k8s.io/v1
kind: AzureIngressProhibitedTarget
metadata:
  name: blacklist-all-targets
spec:
  paths:
  - /*
```

should blacklist `/abc` and all other paths.

(This here is required for https://github.com/Azure/application-gateway-kubernetes-ingress/pull/412/files#diff-09ce61e60cf8eae7f9ff52a875eafea7R40)