### PR TITLE
brownfield: Redirect Configurations

### DIFF
--- a/pkg/brownfield/redirects.go
+++ b/pkg/brownfield/redirects.go
@@ -1,0 +1,90 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package brownfield
+
+import (
+	"strings"
+
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
+	"github.com/golang/glog"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
+)
+
+type redirectName string
+type redirectsByName map[redirectName]n.ApplicationGatewayRedirectConfiguration
+
+// GetBlacklistedRedirects filters the given list of health probes to the list Probes that AGIC is allowed to manage.
+func (er ExistingResources) GetBlacklistedRedirects() ([]n.ApplicationGatewayRedirectConfiguration, []n.ApplicationGatewayRedirectConfiguration) {
+	blacklistedListeners := er.getBlacklistedListenersSet()
+	var blacklisted, nonBlacklisted []n.ApplicationGatewayRedirectConfiguration
+	for _, redirect := range er.Redirects {
+		// We consider a redirect blacklisted if it is pointing (targeting) a listener that is blacklisted
+		listenerNm := listenerName(utils.GetLastChunkOfSlashed(*redirect.TargetListener.ID))
+		if _, exists := blacklistedListeners[listenerNm]; exists {
+			glog.V(5).Infof("[brownfield] Redirect %s is blacklisted", *redirect.Name)
+			blacklisted = append(blacklisted, redirect)
+			continue
+		}
+		glog.V(5).Infof("[brownfield] Redirect %s is not blacklisted", *redirect.Name)
+		nonBlacklisted = append(nonBlacklisted, redirect)
+	}
+	return blacklisted, nonBlacklisted
+}
+
+// LogRedirects emits a few log lines detailing what Redirects are created, blacklisted, and removed from ARM.
+func LogRedirects(existingBlacklisted []n.ApplicationGatewayRedirectConfiguration, existingNonBlacklisted []n.ApplicationGatewayRedirectConfiguration, managedRedirects []n.ApplicationGatewayRedirectConfiguration) {
+	var garbage []n.ApplicationGatewayRedirectConfiguration
+
+	blacklistedSet := indexRedirectsByName(existingBlacklisted)
+	managedSet := indexRedirectsByName(managedRedirects)
+
+	for redirectName, redirect := range indexRedirectsByName(existingNonBlacklisted) {
+		_, existsInBlacklist := blacklistedSet[redirectName]
+		_, existsInNewRedirects := managedSet[redirectName]
+		if !existsInBlacklist && !existsInNewRedirects {
+			garbage = append(garbage, redirect)
+		}
+	}
+
+	glog.V(3).Info("[brownfield] Redirects AGIC created: ", getRedirectNames(managedRedirects))
+	glog.V(3).Info("[brownfield] Existing Blacklisted Redirects AGIC will retain: ", getRedirectNames(existingBlacklisted))
+	glog.V(3).Info("[brownfield] Existing Redirects AGIC will remove: ", getRedirectNames(garbage))
+}
+
+// MergeRedirects merges list of lists of redirects into a single list, maintaining uniqueness.
+func MergeRedirects(redirectBuckets ...[]n.ApplicationGatewayRedirectConfiguration) []n.ApplicationGatewayRedirectConfiguration {
+	uniqRedirects := make(redirectsByName)
+	for _, bucket := range redirectBuckets {
+		for _, redirect := range bucket {
+			uniqRedirects[redirectName(*redirect.Name)] = redirect
+		}
+	}
+	var merged []n.ApplicationGatewayRedirectConfiguration
+	for _, redirect := range uniqRedirects {
+		merged = append(merged, redirect)
+	}
+	return merged
+}
+
+func getRedirectNames(redirects []n.ApplicationGatewayRedirectConfiguration) string {
+	var names []string
+	for _, redirect := range redirects {
+		names = append(names, *redirect.Name)
+	}
+	if len(names) == 0 {
+		return "n/a"
+	}
+	return strings.Join(names, ", ")
+}
+
+func indexRedirectsByName(redirects []n.ApplicationGatewayRedirectConfiguration) redirectsByName {
+	indexed := make(redirectsByName)
+	for _, redirect := range redirects {
+		indexed[redirectName(*redirect.Name)] = redirect
+	}
+	return indexed
+}

--- a/pkg/brownfield/targets.go
+++ b/pkg/brownfield/targets.go
@@ -41,11 +41,11 @@ func (t Target) IsBlacklisted(blacklist TargetBlacklist) bool {
 		// whether given target is in the blacklist. Ideally this would be URL Path set overlap operation,
 		// which we deliberately leave for a later time.
 		if hostIsBlacklisted && pathIsBlacklisted {
-			glog.V(5).Infof("[brownfield] Target is in blacklist: %s", jsonTarget)
+			glog.V(5).Infof("[brownfield] Target %s is blacklisted", jsonTarget)
 			return true // Found it
 		}
 	}
-	glog.V(5).Infof("[brownfield] Target is not in blacklist: %s", jsonTarget)
+	glog.V(5).Infof("[brownfield] Target %s is not blacklisted", jsonTarget)
 	return false // Did not find it
 }
 

--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -25,6 +25,7 @@ type ExistingResources struct {
 	HTTPSettings       []n.ApplicationGatewayBackendHTTPSettings
 	Ports              []n.ApplicationGatewayFrontendPort
 	Probes             []n.ApplicationGatewayProbe
+	Redirects          []n.ApplicationGatewayRedirectConfiguration
 	ProhibitedTargets  []*ptv1.AzureIngressProhibitedTarget
 	DefaultBackendPool *n.ApplicationGatewayBackendAddressPool
 
@@ -75,6 +76,11 @@ func NewExistingResources(appGw n.ApplicationGateway, prohibitedTargets []*ptv1.
 		allExistingBackendPools = *appGw.BackendAddressPools
 	}
 
+	var allExistingRedirects []n.ApplicationGatewayRedirectConfiguration
+	if appGw.RedirectConfigurations != nil {
+		allExistingRedirects = *appGw.RedirectConfigurations
+	}
+
 	return ExistingResources{
 		BackendPools:       allExistingBackendPools,
 		Certificates:       allExistingCertificates,
@@ -84,6 +90,7 @@ func NewExistingResources(appGw n.ApplicationGateway, prohibitedTargets []*ptv1.
 		HTTPSettings:       allExistingSettings,
 		Ports:              allExistingPorts,
 		Probes:             allExistingHealthProbes,
+		Redirects:          allExistingRedirects,
 		ProhibitedTargets:  prohibitedTargets,
 		DefaultBackendPool: defaultPool,
 	}

--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -62,7 +62,7 @@ func (c *AppGwIngressController) configIsSame(appGw *n.ApplicationGateway) bool 
 	return c.configCache != nil && bytes.Compare(*c.configCache, sanitized) == 0
 }
 
-func (c *AppGwIngressController) dumpSanitizedJSON(appGw *n.ApplicationGateway, logToFile bool) ([]byte, error) {
+func dumpSanitizedJSON(appGw *n.ApplicationGateway, logToFile bool) ([]byte, error) {
 	jsonConfig, err := appGw.MarshalJSON()
 	if err != nil {
 		return nil, err

--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -32,6 +32,9 @@ func (c AppGwIngressController) Process(event events.Event) error {
 		return ErrFetchingAppGatewayConfig
 	}
 
+	existingConfigJSON, _ := dumpSanitizedJSON(&appGw, false)
+	glog.V(5).Info("Existing App Gateway config: ", string(existingConfigJSON))
+
 	envVars := environment.GetEnv()
 
 	cbCtx := &appgw.ConfigBuilderContext{
@@ -118,7 +121,7 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	if err != nil {
 		// Reset cache
 		c.configCache = nil
-		configJSON, _ := c.dumpSanitizedJSON(&appGw, logToFile)
+		configJSON, _ := dumpSanitizedJSON(&appGw, logToFile)
 		glogIt := glog.Errorf
 		if cbCtx.EnablePanicOnPutError {
 			glogIt = glog.Fatalf
@@ -128,7 +131,7 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	}
 	// Wait until deployment finshes and save the error message
 	err = appGwFuture.WaitForCompletionRef(ctx, c.appGwClient.BaseClient.Client)
-	configJSON, _ := c.dumpSanitizedJSON(&appGw, logToFile)
+	configJSON, _ := dumpSanitizedJSON(&appGw, logToFile)
 	glog.V(5).Info(string(configJSON))
 
 	// We keep this at log level 1 to show some heartbeat in the logs. Without this it is way too quiet.


### PR DESCRIPTION
Applying all the same patterns as we have done with the other App Gateway configuration resources - we now apply `AzureIngressProhibitedTarget` (blacklist) CRD to the `RedirectConfigurations`.

Additionally - adding helper to dump the config we obtained from App Gateway (at `glog.V(5)`)