### PR TITLE
Adding AzureIngressProhibitedTarget to Helm

### DIFF
--- a/docs/examples/sample-helm-config.yaml
+++ b/docs/examples/sample-helm-config.yaml
@@ -8,6 +8,17 @@ armAuth:
     identityResourceID: <identityResourceId>
     identityClientID:  <identityClientId>
 
+## Alternatively you can use Service Principal credentials
+# armAuth:
+#    type: servicePrincipal
+#    secretJSON: <<Generate this value with: "az ad sp create-for-rbac --subscription <subscription-uuid> --sdk-auth | base64 -w0" >>
+
 # Specify aks cluster related information. THIS IS BEING DEPRECATED.
 aksClusterConfiguration:
-        apiServerAddress: <aks-api-server-address>
+    apiServerAddress: <aks-api-server-address>
+
+# Setting brownfield.enabled to "true" will create an AzureIngressProhibitedTarget CRD.
+# This blacklist all hostnames and paths, prohibiting AGIC from aplying config for any of them.
+# Use "kubectl get AzureIngressProhibitedTargets" to view and change prohibited targets
+brownfield:
+  enabled: false

--- a/docs/examples/sample-helm-config.yaml
+++ b/docs/examples/sample-helm-config.yaml
@@ -21,4 +21,4 @@ aksClusterConfiguration:
 # This blacklist all hostnames and paths, prohibiting AGIC from applying config for any of them.
 # Use "kubectl get AzureIngressProhibitedTargets" to view and change prohibited targets
 brownfield:
-  enabled: false
+    enabled: false

--- a/docs/examples/sample-helm-config.yaml
+++ b/docs/examples/sample-helm-config.yaml
@@ -18,7 +18,7 @@ aksClusterConfiguration:
     apiServerAddress: <aks-api-server-address>
 
 # Setting brownfield.enabled to "true" will create an AzureIngressProhibitedTarget CRD.
-# This blacklist all hostnames and paths, prohibiting AGIC from aplying config for any of them.
+# This blacklist all hostnames and paths, prohibiting AGIC from applying config for any of them.
 # Use "kubectl get AzureIngressProhibitedTargets" to view and change prohibited targets
 brownfield:
   enabled: false

--- a/helm/ingress-azure/templates/NOTES.txt
+++ b/helm/ingress-azure/templates/NOTES.txt
@@ -17,7 +17,7 @@ Configuration Details:
     - Subscription ID : {{ .Values.appgw.subscriptionId }}
     - Resource Group  : {{ .Values.appgw.resourceGroup }}
     - Application Gateway Name : {{ .Values.appgw.name }}
- * Kubernetes:
+ * Kubernetes Ingress Controller:
 {{- if .Values.kubernetes }}
     {{- if .Values.kubernetes.watchNamespace }}
     - Watching Namespaces: {{ .Values.kubernetes.watchNamespace }}
@@ -27,7 +27,12 @@ Configuration Details:
 {{- else }}
     - Watching All Namespaces
 {{- end }}
- * Verbosity level: {{ .Values.verbosityLevel }}
+    - Verbosity level: {{ .Values.verbosityLevel }}
+{{- if .Values.brownfield }}
+{{- if .Values.brownfield.enabled }}
+    - Brownfield deployment is enabled; Use "kubectl get AzureIngressProhibitedTargets" to view and modify config
+{{- end }}
+{{- end }}
 {{ if eq .Values.armAuth.type "aadPodIdentity"}}
 Please make sure the associated aadpodidentity and aadpodidbinding is configured.
 For more information on AAD-Pod-Identity, please visit https://github.com/Azure/aad-pod-identity

--- a/helm/ingress-azure/templates/azureingressprohibitedtarget.yaml
+++ b/helm/ingress-azure/templates/azureingressprohibitedtarget.yaml
@@ -6,7 +6,6 @@ metadata:
   name: azureingressprohibitedtargets.appgw.ingress.k8s.io
   annotations:
     "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: appgw.ingress.k8s.io
   version: v1

--- a/helm/ingress-azure/templates/azureingressprohibitedtarget.yaml
+++ b/helm/ingress-azure/templates/azureingressprohibitedtarget.yaml
@@ -34,7 +34,7 @@ spec:
 apiVersion: appgw.ingress.k8s.io/v1
 kind: AzureIngressProhibitedTarget
 metadata:
-  name: blacklist-all-targets
+  name: prohibit-all-targets
 spec:
   paths:
     - /*

--- a/helm/ingress-azure/templates/azureingressprohibitedtarget.yaml
+++ b/helm/ingress-azure/templates/azureingressprohibitedtarget.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.brownfield -}}
+{{- if .Values.brownfield.enabled -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: azureingressprohibitedtargets.appgw.ingress.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: appgw.ingress.k8s.io
+  version: v1
+  names:
+    kind: AzureIngressProhibitedTarget
+    plural: azureingressprohibitedtargets
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            hostname:
+              description: "(optional) Hostname of the prohibited target"
+              type: string
+            paths:
+              description: "(optional) A list of URL paths, for which the Ingress Controller is prohibited from mutating Application Gateway configuration; Must begin with a / and end with /*"
+              type: array
+              items:
+                  type: string
+                  pattern: '^\/(?:.+\/)?\*$'
+
+---
+
+apiVersion: appgw.ingress.k8s.io/v1
+kind: AzureIngressProhibitedTarget
+metadata:
+  name: blacklist-all-targets
+spec:
+  paths:
+    - /*
+{{- end -}}
+{{- end -}}

--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -21,3 +21,8 @@ data:
 {{- end }}
 {{- end }}
   USE_PRIVATE_IP: "{{ .Values.appgw.usePrivateIP }}"
+{{- if .Values.brownfield }}
+{{- if .Values.brownfield.enabled }}
+  APPGW_ENABLE_BROWNFIELD_DEPLOYMENT: "{{ .Values.brownfield.enabled }}"
+{{- end }}
+{{- end }}


### PR DESCRIPTION
This PR:
  - makes it possible to enable brownfield deployment via `helm --set brownfield.enabled=false`
  - adds `AzureIngressProhibitedTarget` CRD to helm chart
  - adds `blacklist-all-targets` AzureIngressProhibitedTarget by default, which as the name implies - by default blacklists all traffic targets