### PR TITLE
brownfield: Determine whether a listener is prohibited based on hosts first

### DIFF
--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -46,14 +46,12 @@ func NewConfigBuilder(context *k8scontext.Context, appGwIdentifier *Identifier, 
 
 // Build gets a pointer to updated ApplicationGatewayPropertiesFormat.
 func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationGateway, error) {
-	glog.V(5).Infof("-----Generating Probes-----")
 	err := c.HealthProbesCollection(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate Health Probes, error [%v]", err.Error())
 		return nil, ErrGeneratingProbes
 	}
 
-	glog.V(5).Infof("-----Generating Backend Http Settings-----")
 	err = c.BackendHTTPSettingsCollection(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate backend http settings, error [%v]", err.Error())
@@ -61,7 +59,6 @@ func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationG
 	}
 
 	// BackendAddressPools depend on BackendHTTPSettings
-	glog.V(5).Infof("-----Generating Backend Pools-----")
 	err = c.BackendAddressPools(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate backend address pools, error [%v]", err.Error())
@@ -72,7 +69,6 @@ func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationG
 	// This also creates redirection configuration (if TLS is configured and Ingress is annotated).
 	// This configuration must be attached to request routing rules, which are created in the steps below.
 	// The order of operations matters.
-	glog.V(5).Infof("-----Generating Listener, Ports and Certificates-----")
 	err = c.Listeners(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate frontend listeners, error [%v]", err.Error())
@@ -80,7 +76,6 @@ func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationG
 	}
 
 	// SSL redirection configurations created elsewhere will be attached to the appropriate rule in this step.
-	glog.V(5).Infof("-----Generating Routing rules and PathMaps-----")
 	err = c.RequestRoutingRules(cbCtx)
 	if err != nil {
 		glog.Errorf("unable to generate request routing rules, error [%v]", err.Error())

--- a/pkg/brownfield/targets_test.go
+++ b/pkg/brownfield/targets_test.go
@@ -6,6 +6,7 @@
 package brownfield
 
 import (
+	v1 "github.com/Azure/application-gateway-kubernetes-ingress/pkg/apis/azureingressprohibitedtarget/v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -118,6 +119,34 @@ var _ = Describe("Test blacklisting targets", func() {
 
 			Expect(TargetPath("/abCD/xyZ/1/*").contains("/AbcD/Xyz/*")).To(BeFalse())
 			Expect(TargetPath("/AbcD/Xyz/*").contains("/abCD/xyZ/1/*")).To(BeTrue())
+		})
+	})
+
+	Context("Test getProhibitedHostnames()", func() {
+		er := ExistingResources{
+			ProhibitedTargets: []*v1.AzureIngressProhibitedTarget{
+				{
+					Spec: v1.AzureIngressProhibitedTargetSpec{
+						Hostname: tests.Host,
+					},
+				},
+				{
+					Spec: v1.AzureIngressProhibitedTargetSpec{
+						Paths: []string{
+							"/a",
+							"/b",
+						},
+					},
+				},
+			},
+		}
+		It("should create a list of prohibited hostnames", func() {
+			prohibitedHostnames := er.getProhibitedHostnames()
+			Expect(len(prohibitedHostnames)).To(Equal(1))
+			expected := map[string]interface{}{
+				tests.Host: nil,
+			}
+			Expect(er.getProhibitedHostnames()).To(Equal(expected))
 		})
 	})
 })

--- a/pkg/brownfield/types.go
+++ b/pkg/brownfield/types.go
@@ -95,3 +95,14 @@ func NewExistingResources(appGw n.ApplicationGateway, prohibitedTargets []*ptv1.
 		DefaultBackendPool: defaultPool,
 	}
 }
+
+func (er ExistingResources) getProhibitedHostnames() map[string]interface{} {
+	prohibitedHostnames := make(map[string]interface{})
+	for _, pt := range er.ProhibitedTargets {
+		if len(pt.Spec.Hostname) == 0 {
+			continue
+		}
+		prohibitedHostnames[pt.Spec.Hostname] = nil
+	}
+	return prohibitedHostnames
+}

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -24,24 +24,25 @@ import (
 
 // constant values to be used for testing
 const (
-	Namespace     = "--namespace--"
-	Name          = "--name--"
-	Host          = "bye.com"
-	OtherHost     = "--some-other-hostname--"
-	NameOfSecret  = "--the-name-of-the-secret--"
-	ServiceName   = "--service-name--"
-	NodeName      = "--node-name--"
-	URLPath       = "/healthz"
-	ContainerName = "--container-name--"
-	ContainerPort = int32(9876)
-	ServicePort   = "service-port"
-	SelectorKey   = "app"
-	SelectorValue = "frontend"
-	Subscription  = "--subscription--"
-	ResourceGroup = "--resource-group--"
-	AppGwName     = "--app-gw-name--"
-	IPID1         = "--front-end-ip-id-1--"
-	IPID2         = "--front-end-ip-id-2--"
+	Namespace        = "--namespace--"
+	Name             = "--name--"
+	Host             = "bye.com"
+	OtherHost        = "--some-other-hostname--"
+	HostUnassociated = "---some-host-without-routing-rules---"
+	NameOfSecret     = "--the-name-of-the-secret--"
+	ServiceName      = "--service-name--"
+	NodeName         = "--node-name--"
+	URLPath          = "/healthz"
+	ContainerName    = "--container-name--"
+	ContainerPort    = int32(9876)
+	ServicePort      = "service-port"
+	SelectorKey      = "app"
+	SelectorValue    = "frontend"
+	Subscription     = "--subscription--"
+	ResourceGroup    = "--resource-group--"
+	AppGwName        = "--app-gw-name--"
+	IPID1            = "--front-end-ip-id-1--"
+	IPID2            = "--front-end-ip-id-2--"
 )
 
 // GetIngress creates an Ingress test fixture.

--- a/pkg/tests/fixtures/app_gateway.go
+++ b/pkg/tests/fixtures/app_gateway.go
@@ -28,6 +28,7 @@ func GetAppGateway() n.ApplicationGateway {
 				*GetListenerBasic(),
 				*GetListenerPathBased1(),
 				*GetListenerPathBased2(),
+				*GetListenerUnassociated(),
 			},
 
 			SslCertificates: &[]n.ApplicationGatewaySslCertificate{

--- a/pkg/tests/fixtures/listeners.go
+++ b/pkg/tests/fixtures/listeners.go
@@ -24,6 +24,9 @@ const (
 
 	// HTTPListenerPathBased2 is a string constant.
 	HTTPListenerPathBased2 = "HTTPListener-PathBased2"
+
+	// HTTPListenerUnassociated is a string constant.
+	HTTPListenerUnassociated = "HTTPListener-Unassociated"
 )
 
 // GetListenerBasic creates a new struct for use in unit tests.
@@ -78,6 +81,20 @@ func GetListenerPathBased2() *n.ApplicationGatewayHTTPListener {
 			Protocol:                    n.HTTP,
 			HostName:                    to.StringPtr(tests.OtherHost),
 			SslCertificate:              &n.SubResource{ID: to.StringPtr(CertificateName3)},
+			RequireServerNameIndication: to.BoolPtr(true),
+		},
+	}
+}
+
+// GetListenerUnassociated creates a new listener, which is not associated with routing rules etc.
+func GetListenerUnassociated() *n.ApplicationGatewayHTTPListener {
+	return &n.ApplicationGatewayHTTPListener{
+		Name: to.StringPtr(HTTPListenerUnassociated),
+		ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
+			FrontendIPConfiguration:     &n.SubResource{ID: to.StringPtr("")},
+			FrontendPort:                &n.SubResource{ID: to.StringPtr("")},
+			Protocol:                    n.HTTP,
+			HostName:                    to.StringPtr(tests.HostUnassociated),
 			RequireServerNameIndication: to.BoolPtr(true),
 		},
 	}


### PR DESCRIPTION
Looking at Routing Rules to determine whether a listener is prohibited is not sufficient.
When a customer is creating a now Listener, which is not yet connected to routing rules, AGIC will  delete it.

This PR proposes we look at hostnames to determine whether a listener is prohibited.

We retain the current functionality of also looking at routing rules -- this is useful in the cases where a listener does not have a hostname, but is linked to a prohibited URL.