### PR TITLE
fixed string type conversion issue

### DIFF
--- a/pkg/appgw/istio_pools.go
+++ b/pkg/appgw/istio_pools.go
@@ -26,7 +26,7 @@ func (c *appGwConfigBuilder) getIstioBackendAddressPool(destinationID istioDesti
 		if _, portExists := getUniqueTCPPorts(subset)[serviceBackendPair.BackendPort]; portExists {
 			backendServicePort := ""
 			if destinationID.Destination.Port.Number != 0 {
-				backendServicePort = string(destinationID.Destination.Port.Number)
+				backendServicePort = fmt.Sprint(destinationID.Destination.Port.Number)
 			} else {
 				backendServicePort = destinationID.Destination.Port.Name
 			}


### PR DESCRIPTION
```go
package main

import (
	"fmt"

	"strconv"
)

func main() {
	port := 8000
	fmt.Println("Hello, playground", port, string(port), " vs ", strconv.Itoa(port))
}
```
`Hello, playground 8000 ὀ  vs  8000`
