### PR TITLE
istio: Avoid duplicate defaulthttpsettings within getIstioDestinationsAndSettingsMap

### DIFF
--- a/pkg/appgw/istio_settings.go
+++ b/pkg/appgw/istio_settings.go
@@ -139,9 +139,6 @@ func (c *appGwConfigBuilder) getIstioDestinationsAndSettingsMap(cbCtx *ConfigBui
 	}
 
 	httpSettingsCollection := make(map[string]n.ApplicationGatewayBackendHTTPSettings)
-	defaultBackend := defaultBackendHTTPSettings(c.appGwIdentifier, defaultProbeName)
-	httpSettingsCollection[*defaultBackend.Name] = defaultBackend
-
 	for destinationID, serviceBackendPairs := range serviceBackendPairsMap {
 		if len(serviceBackendPairs) > 1 {
 			// more than one possible backend port exposed through ingress


### PR DESCRIPTION
The `defaultBackend` will be added by `getBackendsAndSettingsMap` [here](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/f1464dbd2a1f2d6ba0917f54d9ac73395b5fccca/pkg/appgw/backendhttpsettings.go#L198)
`getIstioDestinationsAndSettingsMap` then does not need to add a default backend.

We can safely omit these lines.