### PR TITLE
istio: Do look for istio primitives even when no Ingresses are defined

### DIFF
--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -71,7 +71,7 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	}
 
 	cbCtx.IngressList = c.PruneIngress(&appGw, cbCtx)
-	if len(cbCtx.IngressList) == 0 {
+	if len(cbCtx.IngressList) == 0 && !cbCtx.EnableIstioIntegration {
 		errorLine := "no Ingress in the pruned Ingress list. Please check Ingress events to get more information"
 		glog.Error(errorLine)
 		return nil


### PR DESCRIPTION
In a Kubernetes setup where we have Istio, but no Ingress definition, this conditional would terminate the processing of the given event.  To get istio ingress working - we need this to continue.