### PR TITLE
Ignore events from the kube-system namespace

### DIFF
--- a/pkg/controller/should_process.go
+++ b/pkg/controller/should_process.go
@@ -15,11 +15,19 @@ import (
 // ShouldProcess determines whether to process an event.
 func (c AppGwIngressController) ShouldProcess(event events.Event) (bool, string) {
 	if pod, ok := event.Value.(*v1.Pod); ok {
+		if pod.Namespace == "kube-system" {
+			// Ignore kube-system namespace events
+			return false, ""
+		}
 		// this pod is not used by any ingress, skip any event for this
 		return c.k8sContext.IsPodReferencedByAnyIngress(pod), fmt.Sprintf("Skipping pod %s/%s as it is not used by any ingress", pod.Namespace, pod.Name)
 	}
 
 	if endpoints, ok := event.Value.(*v1.Endpoints); ok {
+		if endpoints.Namespace == "kube-system" {
+			// Ignore kube-system namespace events
+			return false, ""
+		}
 		// this pod is not used by any ingress, skip any event for this
 		return c.k8sContext.IsEndpointReferencedByAnyIngress(endpoints), fmt.Sprintf("Skipping endpoints %s/%s as it is not used by any ingress", endpoints.Namespace, endpoints.Name)
 	}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -35,7 +35,9 @@ func (w *Worker) Run(eventChannel *channels.RingChannel, stopChannel chan struct
 			case in := <-eventChannel.Out():
 				event := in.(events.Event)
 				if shouldProcess, reason := w.ShouldProcess(event); !shouldProcess {
-					glog.V(5).Infof("Skipping event: %s", reason)
+					if reason != "" {
+						glog.V(5).Infof("Skipping event: %s", reason)
+					}
 					continue
 				}
 


### PR DESCRIPTION
Events from the `kube-system` namespace generate lots of log noise. This PR takes a rudimentary approach to limiting this.

Example:
```
I0729 18:09:11.537224   28650 worker.go:38] Skipping event: Skipping endpoints kube-system/kube-controller-manager as it is not used by any ingress
I0729 18:09:13.329869   28650 context.go:283] unable to get service from store, no such service kube-system/kube-scheduler
I0729 18:09:13.329894   28650 worker.go:38] Skipping event: Skipping endpoints kube-system/kube-scheduler as it is not used by any ingress
I0729 18:09:13.587406   28650 context.go:283] unable to get service from store, no such service kube-system/kube-controller-manager
I0729 18:09:13.587446   28650 worker.go:38] Skipping event: Skipping endpoints kube-system/kube-controller-manager as it is not used by any ingress
I0729 18:09:15.350457   28650 context.go:283] unable to get service from store, no such service kube-system/kube-scheduler
I0729 18:09:15.350501   28650 worker.go:38] Skipping event: Skipping endpoints kube-system/kube-scheduler as it is not used by any ingress
I0729 18:09:15.615252   28650 context.go:283] unable to get service from store, no such service kube-system/kube-controller-manager
I0729 18:09:15.615304   28650 worker.go:38] Skipping event: Skipping endpoints kube-system/kube-controller-manager as it is not used by any ingress
I0729 18:09:17.385471   28650 context.go:283] unable to get service from store, no such service kube-system/kube-scheduler
I0729 18:09:17.385513   28650 worker.go:38] Skipping event: Skipping endpoints kube-system/kube-scheduler as it is not used by any ingress
I0729 18:09:17.625656   28650 context.go:283] unable to get service from store, no such service kube-system/kube-controller-manager
I0729 18:09:17.625681   28650 worker.go:38] Skipping event: Skipping endpoints kube-system/kube-controller-manager as it is not used by any ingress
```