### PR TITLE
Dockerfile: mark /appgw-ingress as executable

### DIFF
--- a/dockerfiles/deploy.Dockerfile
+++ b/dockerfiles/deploy.Dockerfile
@@ -2,4 +2,5 @@ FROM ubuntu:16.04
 RUN apt-get update
 RUN apt-get install -y ca-certificates openssl
 ADD bin/appgw-ingress /
+RUN chmod +x /appgw-ingress
 CMD ["/appgw-ingress"]


### PR DESCRIPTION
Let's mark the binary as executable.