### PR TITLE
health: Adding a health-probe service

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,0 +1,37 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package health
+
+import "net/http"
+
+type Probe func() bool
+
+type HealthProbes interface {
+	Liveness() bool
+	Readiness() bool
+}
+
+func makeHandler(router *http.ServeMux, url string, probe Probe) {
+	router.Handle(url, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(map[bool]int{
+			true:  http.StatusOK,
+			false: http.StatusServiceUnavailable,
+		}[probe()])
+	}))
+}
+
+// NewHealthMux makes a new *http.ServeMux
+func NewHealthMux(healthProbes HealthProbes) *http.ServeMux {
+	router := http.NewServeMux()
+	var handlers = map[string]Probe{
+		"/health/ready": healthProbes.Readiness,
+		"/health/alive": healthProbes.Liveness,
+	}
+	for url, probe := range handlers {
+		makeHandler(router, url, probe)
+	}
+	return router
+}


### PR DESCRIPTION
The goal of this is to create a service that responds to Kubernetes health-checking the AGIC pod.

Proposed endpoins:
  - `/health/ready`
  - `/health/alive`

Second part of this is coming in a PR shortly