### PR TITLE
worker: Simplify

### DIFF
--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -36,8 +36,10 @@ var _ = Describe("Worker Test", func() {
 				backChannel <- struct{}{}
 				return nil
 			})
-			worker := NewWorker(eventProcessor)
-			worker.Run(eventChannel, stopChannel)
+			worker := Worker{
+				EventProcessor: eventProcessor,
+			}
+			go worker.Run(eventChannel, stopChannel)
 
 			ingress := *tests.NewIngressFixture()
 			eventChannel.In() <- events.Event{


### PR DESCRIPTION
It seems that we can simplify `worker.go` a bit.

This PR:
  - removes `NewWorker()` - moves the struct initialization inline where `NewWorker()` was used - one place in production code (and one in tests)
  - pulls the launching of a goroutine out of `worker.Run()` and into `controller.go` --> `go worker.Run()`