### PR TITLE
prune redirect and no TLS ingresses

### DIFF
--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -156,7 +156,7 @@ func (c *appGwConfigBuilder) getBackendsAndSettingsMap(cbCtx *ConfigBuilderConte
 							resolvedBackendPorts[pair] = nil
 						} else {
 							// if service port is defined by name, need to resolve
-							glog.V(3).Infof("resolving port name %s", sp.Name)
+							glog.V(5).Infof("resolving port name [%s] for service [%s] and service port [%s] for Ingress [%s]", sp.Name, backendID.serviceKey(), backendID.Backend.ServicePort.String(), backendID.Ingress.Name)
 							targetPortsResolved := c.resolvePortName(sp.Name, &backendID)
 							for targetPort := range targetPortsResolved {
 								pair := serviceBackendPortPair{
@@ -173,7 +173,7 @@ func (c *appGwConfigBuilder) getBackendsAndSettingsMap(cbCtx *ConfigBuilderConte
 		}
 
 		if len(resolvedBackendPorts) == 0 {
-			logLine := fmt.Sprintf("Unable to resolve any backend port for service [%s]", backendID.serviceKey())
+			logLine := fmt.Sprintf("unable to resolve any backend port for service [%s] and service port [%s] for Ingress [%s]", backendID.serviceKey(), backendID.Backend.ServicePort.String(), backendID.Ingress.Name)
 			c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonPortResolutionError, logLine)
 			glog.Error(logLine)
 

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -24,5 +24,9 @@ const (
 	// ReasonPortResolutionError is a reason for an event to be emitted.
 	ReasonPortResolutionError = "PortResolutionError"
 
+	// ReasonNoPrivateIPError is a reason for an event to be emitted.
 	ReasonNoPrivateIPError = "NoPrivateIP"
+
+	// ReasonRedirectwithNoTLS is a reason for an event to be emitted.
+	ReasonRedirectWithNoTLS = "RedirectWithNoTLS"
 )


### PR DESCRIPTION
This PR allows to ignore ingresses that have ssl-redirect true but no TLS which is an valid configuration.
We cannot configure HTTPS for it and since, it was meant to have redirect for HTTP, we should nto configure HTTP for it.