### PR TITLE
Correct memoization of getListeners

### DIFF
--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -27,11 +27,16 @@ type ConfigBuilder interface {
 	PostBuildValidate(cbCtx *ConfigBuilderContext) error
 }
 
+type memoization struct {
+	listeners *[]n.ApplicationGatewayHTTPListener
+}
+
 type appGwConfigBuilder struct {
 	k8sContext      *k8scontext.Context
 	appGwIdentifier Identifier
 	appGw           n.ApplicationGateway
 	recorder        record.EventRecorder
+	mem             memoization
 }
 
 // NewConfigBuilder construct a builder

--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -18,8 +18,8 @@ import (
 
 // getListeners constructs the unique set of App Gateway HTTP listeners across all ingresses.
 func (c *appGwConfigBuilder) getListeners(cbCtx *ConfigBuilderContext) *[]n.ApplicationGatewayHTTPListener {
-	if c.appGw.HTTPListeners != nil {
-		return c.appGw.HTTPListeners
+	if c.mem.listeners != nil {
+		return c.mem.listeners
 	}
 	var listeners []n.ApplicationGatewayHTTPListener
 
@@ -56,7 +56,7 @@ func (c *appGwConfigBuilder) getListeners(cbCtx *ConfigBuilderContext) *[]n.Appl
 
 	// Since getListeners() would be called multiple times within the life cycle of a Process(Event)
 	// we cache the results of this function in what would be final place to store the Listeners.
-	c.appGw.HTTPListeners = &listeners
+	c.mem.listeners = &listeners
 	return &listeners
 }
 


### PR DESCRIPTION
The previous implementation was incorrect. The `c.appGw.HTTPListeners` contained App Gwy config we fetched from ARM on the arrival of a new K8s event.
This PR introduces a new struct, which will be `nil` on the arrival of a new event when we instantiate a new `appGwConfigBuilder ` with `NewConfigBuilder()`

To provide more context on this change:
1. The loop that receives Kubernetes events and launches Process(Event) [here](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/pkg/worker/worker.go#L33)

2. for each event we do a GET on App Gwy's config [here](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/pkg/controller/process.go#L31)
    
3. we pass the original config appGw into the NewConfigBuilder [here](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/pkg/controller/process.go#L95)

4. then we assign it to c.appGw [here](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/pkg/appgw/configbuilder.go#L42)

In other words we would not expect c.appGw.HTTPListeners to be nil.