### PR TITLE
delete removeIngressStatus and type for parse function

### DIFF
--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -143,8 +143,22 @@ func deleteKeyFromJSON(jsonWithEtag []byte, keysToDelete ...string) ([]byte, err
 	return json.Marshal(m)
 }
 
+// SubscriptionID in the resourceID
+type SubscriptionID string
+
+// ResourceGroup in the resourceID
+type ResourceGroup string
+
+// ResourceName in the resourceID
+type ResourceName string
+
 // ParseResourceID gets subscriptionId, resource group, resource name from resourceID
-func ParseResourceID(ID string) (string, string, string) {
+func ParseResourceID(ID string) (SubscriptionID, ResourceGroup, ResourceName) {
 	split := strings.Split(ID, "/")
-	return split[2], split[4], split[8]
+	if len(split) < 9 {
+		glog.Errorf("resourceID %s is invalid. There should be atleast 9 segments in resourceID", ID)
+		return "", "", ""
+	}
+
+	return SubscriptionID(split[2]), ResourceGroup(split[4]), ResourceName(split[8])
 }

--- a/pkg/controller/helpers_test.go
+++ b/pkg/controller/helpers_test.go
@@ -106,9 +106,9 @@ var _ = Describe("test helpers", func() {
 
 	Context("ensure ParseResourceID works as expected", func() {
 		It("should parse appgw resourceId correctly", func() {
-			subID := "xxxx"
-			resGp := "yyyy"
-			resName := "zzzz"
+			subID := SubscriptionID("xxxx")
+			resGp := ResourceGroup("yyyy")
+			resName := ResourceName("zzzz")
 			resourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/publicIPAddresses/%s", subID, resGp, resName)
 			outSubID, outResGp, outResName := ParseResourceID(resourceID)
 			Expect(outSubID).To(Equal(subID))

--- a/pkg/k8scontext/k8scontext_test.go
+++ b/pkg/k8scontext/k8scontext_test.go
@@ -377,39 +377,26 @@ var _ = Describe("K8scontext", func() {
 		ip := k8scontext.IPAddress("address")
 		It("adds IP when not present and then removes", func() {
 			// add test
-			ctxt.AddIngressStatus(*ingress, ip)
+			ctxt.UpdateIngressStatus(*ingress, ip)
 			updatedIngress, _ := k8sClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Get(ingress.Name, metav1.GetOptions{})
 			Expect(updatedIngress.Status.LoadBalancer.Ingress).Should(ContainElement(v1.LoadBalancerIngress{
 				Hostname: "",
 				IP:       string(ip),
 			}))
 			Expect(len(updatedIngress.Status.LoadBalancer.Ingress)).To(Equal(1))
-
-			// remove test
-			ctxt.RemoveIngressStatus(*updatedIngress, ip)
-			updatedIngress, _ = k8sClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Get(ingress.Name, metav1.GetOptions{})
-			Expect(len(updatedIngress.Status.LoadBalancer.Ingress)).To(Equal(0))
 		})
 
 		It("doesn't add IP again when already present", func() {
 			// add
-			ctxt.AddIngressStatus(*ingress, ip)
+			ctxt.UpdateIngressStatus(*ingress, ip)
 			// add again
-			ctxt.AddIngressStatus(*ingress, ip)
+			ctxt.UpdateIngressStatus(*ingress, ip)
 			updatedIngress, _ := k8sClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Get(ingress.Name, metav1.GetOptions{})
 			Expect(updatedIngress.Status.LoadBalancer.Ingress).Should(ContainElement(v1.LoadBalancerIngress{
 				Hostname: "",
 				IP:       string(ip),
 			}))
 			Expect(len(updatedIngress.Status.LoadBalancer.Ingress)).To(Equal(1))
-		})
-
-		It("remove ip doesn't fail when ip is not present", func() {
-			// remove test
-			updatedIngress, _ := k8sClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Get(ingress.Name, metav1.GetOptions{})
-			ctxt.RemoveIngressStatus(*updatedIngress, ip)
-			updatedIngress, _ = k8sClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Get(ingress.Name, metav1.GetOptions{})
-			Expect(len(updatedIngress.Status.LoadBalancer.Ingress)).To(Equal(0))
 		})
 	})
 })


### PR DESCRIPTION
This PR is a part of https://github.com/Azure/application-gateway-kubernetes-ingress/pull/335

Removing this function as we will take simple approach just overriding the status.