### PR TITLE
fix: build binary with version arguments and chmod bin

### DIFF
--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -46,10 +46,10 @@ steps:
     BUILD_DATE=$(date +%Y-%m-%d-%H:%MT%z)
     COMMIT_VAR="${REPO_PATH}/pkg/version.GitCommit"
     GIT_HASH=$(git rev-parse --short HEAD)
-    
+
     echo "VERSION $VERSION, BUILD_DATE $BUILD_DATE, GIT_HASH $GIT_HASH"
     if  go install -ldflags "-s -X ${VERSION_VAR}=${VERSION} -X ${DATE_VAR}=${BUILD_DATE} -X ${COMMIT_VAR}=${GIT_HASH}" -v ./cmd/appgw-ingress; then
-        chmod -R 777 bin
+        chmod -R 777 $(GOBIN)
         echo -e "\e[42;97m Build SUCCEEDED \e[0m"
     else
         echo -e "\e[101;97m Build FAILED \e[0m"

--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -38,7 +38,17 @@ steps:
 - script: |
     go version
     echo -e "\e[44;97m Compiling ... \e[0m"
-    if  go install -v ./cmd/appgw-ingress; then
+
+    # set version
+    VERSION_VAR="${REPO_PATH}/pkg/version.Version"
+    VERSION=$(git describe --abbrev=0 --tags)
+    DATE_VAR="${REPO_PATH}/pkg/version.BuildDate"
+    BUILD_DATE=$(date +%Y-%m-%d-%H:%MT%z)
+    COMMIT_VAR="${REPO_PATH}/pkg/version.GitCommit"
+    GIT_HASH=$(git rev-parse --short HEAD)
+    
+    echo "VERSION $VERSION, BUILD_DATE $BUILD_DATE, GIT_HASH $GIT_HASH"
+    if  go install -ldflags "-s -X ${VERSION_VAR}=${VERSION} -X ${DATE_VAR}=${BUILD_DATE} -X ${COMMIT_VAR}=${GIT_HASH}" -v ./cmd/appgw-ingress; then
         chmod -R 777 bin
         echo -e "\e[42;97m Build SUCCEEDED \e[0m"
     else


### PR DESCRIPTION
This PR fixes 
1) build pipeline to build the binary with linker flag for version.
2) issue related to binary not being executable.

Before:
![image](https://user-images.githubusercontent.com/5294363/63394141-1d324580-c373-11e9-82a5-65b3edbfc6c3.png)

After:
![image](https://user-images.githubusercontent.com/5294363/63394153-2de2bb80-c373-11e9-9bd0-145b368736b5.png)