### PR TITLE
Simplify feature flags; Move all to EnvVariables struct

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -133,10 +133,9 @@ func main() {
 	}
 
 	appGwIngressController := controller.NewAppGwIngressController(*appGwClient, appGwIdentifier, k8sContext, recorder)
-	if err := appGwIngressController.Start(env); err != nil{
+	if err := appGwIngressController.Start(env); err != nil {
 		glog.Fatal("Could not start AGIC: ", err)
 	}
-
 
 	// Start the Health Probe Server (responding to Kubernetes health probes)
 	healthServer := &http.Server{

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -41,7 +41,7 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 		}
 	}
 
-	if cbCtx.EnableIstioIntegration {
+	if cbCtx.EnvVariables.EnableIstioIntegration {
 		_, _, istioServiceBackendPairMap, _ := c.getIstioDestinationsAndSettingsMap(cbCtx)
 		for destinationID, serviceBackendPair := range istioServiceBackendPairMap {
 			glog.V(5).Info("Constructing backend pool for service:", destinationID.serviceKey())
@@ -56,7 +56,7 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 		agicCreatedPools = append(agicCreatedPools, *managedPool)
 	}
 
-	if cbCtx.EnableBrownfieldDeployment {
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment {
 		er := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, &defaultPool)
 
 		// Split the existing pools we obtained from App Gateway into ones AGIC is and is not allowed to change.

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -29,7 +29,7 @@ const (
 func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(cbCtx *ConfigBuilderContext) error {
 	agicHTTPSettings, _, _, err := c.getBackendsAndSettingsMap(cbCtx)
 
-	if cbCtx.EnableBrownfieldDeployment {
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment {
 		rCtx := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, nil)
 		allExistingSettings := rCtx.HTTPSettings
 
@@ -42,7 +42,7 @@ func (c *appGwConfigBuilder) BackendHTTPSettingsCollection(cbCtx *ConfigBuilderC
 		// as a managed rule would be overwritten.
 		agicHTTPSettings = brownfield.MergeHTTPSettings(allExistingSettings, agicHTTPSettings)
 	}
-	if cbCtx.EnableIstioIntegration {
+	if cbCtx.EnvVariables.EnableIstioIntegration {
 		istioHTTPSettings, _, _, _ := c.getIstioDestinationsAndSettingsMap(cbCtx)
 		if istioHTTPSettings != nil {
 			sort.Sort(sorter.BySettingsName(istioHTTPSettings))

--- a/pkg/appgw/certificates.go
+++ b/pkg/appgw/certificates.go
@@ -35,7 +35,7 @@ func (c *appGwConfigBuilder) getSslCertificates(cbCtx *ConfigBuilderContext) *[]
 		sslCertificates = append(sslCertificates, c.newCert(secretID, cert))
 	}
 
-	if cbCtx.EnableBrownfieldDeployment {
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment {
 		// MergePools would produce unique list of pools based on Name. Blacklisted pools, which have the same name
 		// as a managed pool would be overwritten.
 		sslCertificates = brownfield.MergeCerts(*c.appGw.SslCertificates, sslCertificates)

--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -23,7 +23,7 @@ func (c *appGwConfigBuilder) getListeners(cbCtx *ConfigBuilderContext) *[]n.Appl
 	}
 	var listeners []n.ApplicationGatewayHTTPListener
 
-	if cbCtx.EnableIstioIntegration {
+	if cbCtx.EnvVariables.EnableIstioIntegration {
 		for listenerID, config := range c.getListenerConfigsFromIstio(cbCtx.IstioGateways, cbCtx.IstioVirtualServices) {
 			listener := c.newListener(listenerID, config.Protocol)
 			listeners = append(listeners, listener)
@@ -39,7 +39,7 @@ func (c *appGwConfigBuilder) getListeners(cbCtx *ConfigBuilderContext) *[]n.Appl
 		listeners = append(listeners, listener)
 	}
 
-	if cbCtx.EnableBrownfieldDeployment {
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment {
 		er := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, nil)
 
 		// Listeners we obtained from App Gateway - we segment them into ones AGIC is and is not allowed to change.

--- a/pkg/appgw/frontend_ports.go
+++ b/pkg/appgw/frontend_ports.go
@@ -18,7 +18,7 @@ import (
 func (c *appGwConfigBuilder) getFrontendPorts(cbCtx *ConfigBuilderContext) *[]n.ApplicationGatewayFrontendPort {
 	allPorts := make(map[int32]interface{})
 
-	if cbCtx.EnableIstioIntegration {
+	if cbCtx.EnvVariables.EnableIstioIntegration {
 		for _, gwy := range cbCtx.IstioGateways {
 			for _, server := range gwy.Spec.Servers {
 				allPorts[int32(server.Port.Number)] = nil
@@ -52,7 +52,7 @@ func (c *appGwConfigBuilder) getFrontendPorts(cbCtx *ConfigBuilderContext) *[]n.
 		})
 	}
 
-	if cbCtx.EnableBrownfieldDeployment {
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment {
 		er := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, nil)
 
 		// Ports we obtained from App Gateway - we segment them into ones AGIC is and is not allowed to change.

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -29,7 +29,7 @@ func (c *appGwConfigBuilder) HealthProbesCollection(cbCtx *ConfigBuilderContext)
 		agicCreatedProbes = append(agicCreatedProbes, probe)
 	}
 
-	if cbCtx.EnableBrownfieldDeployment {
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment {
 		er := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, nil)
 		existingBlacklisted, existingNonBlacklisted := er.GetBlacklistedProbes()
 		brownfield.LogProbes(glog.V(3), existingBlacklisted, existingNonBlacklisted, agicCreatedProbes)
@@ -153,7 +153,7 @@ func (c *appGwConfigBuilder) getProbeForServiceContainer(service *v1.Service, ba
 			if _, ok := allPorts[port.ContainerPort]; !ok {
 				continue
 			}
-			
+
 			// found the container
 			var probe *v1.Probe
 			if container.ReadinessProbe != nil && container.ReadinessProbe.Handler.HTTPGet != nil {
@@ -174,7 +174,7 @@ func (c *appGwConfigBuilder) getProbeForServiceContainer(service *v1.Service, ba
 					}
 				}
 			}
-	
+
 			return probe
 		}
 	}

--- a/pkg/appgw/redirects.go
+++ b/pkg/appgw/redirects.go
@@ -34,7 +34,7 @@ func (c *appGwConfigBuilder) getRedirectConfigurations(cbCtx *ConfigBuilderConte
 		}
 	}
 
-	if cbCtx.EnableBrownfieldDeployment {
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment {
 		er := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, nil)
 
 		// Listeners we obtained from App Gateway - we segment them into ones AGIC is and is not allowed to change.

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -22,7 +22,7 @@ import (
 func (c *appGwConfigBuilder) RequestRoutingRules(cbCtx *ConfigBuilderContext) error {
 	requestRoutingRules, pathMaps := c.getRules(cbCtx)
 
-	if cbCtx.EnableBrownfieldDeployment {
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment {
 		rCtx := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, nil)
 		{
 			// PathMaps we obtained from App Gateway - we segment them into ones AGIC is and is not allowed to change.
@@ -39,7 +39,7 @@ func (c *appGwConfigBuilder) RequestRoutingRules(cbCtx *ConfigBuilderContext) er
 	sort.Sort(sorter.ByPathMap(pathMaps))
 	c.appGw.URLPathMaps = &pathMaps
 
-	if cbCtx.EnableBrownfieldDeployment {
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment {
 		rCtx := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, nil)
 		{
 			// RoutingRules we obtained from App Gateway - we segment them into ones AGIC is and is not allowed to change.
@@ -146,7 +146,7 @@ func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listen
 		}
 	}
 
-	if cbCtx.EnableIstioIntegration {
+	if cbCtx.EnvVariables.EnableIstioIntegration {
 		for listenerID, pathMap := range c.getIstioPathMaps(cbCtx) {
 			if _, exists := urlPathMaps[listenerID]; !exists {
 				urlPathMaps[listenerID] = pathMap

--- a/pkg/appgw/types.go
+++ b/pkg/appgw/types.go
@@ -23,15 +23,6 @@ type ConfigBuilderContext struct {
 	EnvVariables         environment.EnvVariables
 	IstioGateways        []*v1alpha3.Gateway
 	IstioVirtualServices []*v1alpha3.VirtualService
-
-	// Feature flag toggling Brownfield Deployment across the entire AGIC code base.
-	EnableBrownfieldDeployment bool
-
-	// Feature flag toggling Istio Integration across the entire AGIC code base.
-	EnableIstioIntegration bool
-
-	// Feature flag enabling panic() when put to ARM fails.
-	EnablePanicOnPutError bool
 }
 
 // InIngressList returns true if an ingress is in the ingress list

--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -43,47 +43,48 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	existingConfigJSON, _ := dumpSanitizedJSON(&appGw, false, to.StringPtr("-- Existing App Gwy Config --"))
 	glog.V(5).Info("Existing App Gateway config: ", string(existingConfigJSON))
 
-	envVars := environment.GetEnv()
-
 	cbCtx := &appgw.ConfigBuilderContext{
-		ServiceList:           c.k8sContext.ListServices(),
-		IngressList:           c.k8sContext.ListHTTPIngresses(),
-		EnvVariables:          envVars,
-		EnablePanicOnPutError: envVars.EnablePanicOnPutError == "true",
+		ServiceList:  c.k8sContext.ListServices(),
+		IngressList:  c.k8sContext.ListHTTPIngresses(),
+		EnvVariables: environment.GetEnv(),
 	}
 
-	if envVars.EnableBrownfieldDeployment == "true" {
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment {
 		prohibitedTargets := c.k8sContext.ListAzureProhibitedTargets()
 		if len(prohibitedTargets) > 0 {
 			cbCtx.ProhibitedTargets = prohibitedTargets
-			cbCtx.EnableBrownfieldDeployment = true
 			var prohibitedTargetsList []string
 			for _, target := range *brownfield.GetTargetBlacklist(prohibitedTargets) {
 				targetJSON, _ := json.Marshal(target)
 				prohibitedTargetsList = append(prohibitedTargetsList, string(targetJSON))
 			}
 			glog.V(3).Infof("[brownfield] Prohibited targets: %s", strings.Join(prohibitedTargetsList, ", "))
+		} else {
+			glog.Warning("Brownfield Deployment is enabled, but AGIC did not find any AzureProhibitedTarget CRDs; Disabling brownfield deployment feature.")
+			cbCtx.EnvVariables.EnableBrownfieldDeployment = false
 		}
 	}
 
-	if cbCtx.EnvVariables.EnableIstioIntegration == "true" {
+	if cbCtx.EnvVariables.EnableIstioIntegration {
 		istioServices := c.k8sContext.ListIstioVirtualServices()
 		istioGateways := c.k8sContext.ListIstioGateways()
 		if len(istioGateways) > 0 && len(istioServices) > 0 {
 			cbCtx.IstioGateways = istioGateways
 			cbCtx.IstioVirtualServices = istioServices
-			cbCtx.EnableIstioIntegration = true
+		} else {
+			glog.Warning("Istio Integration is enabled, but AGIC needs Istio Gateways and Virtual Services; Disabling Istio integration.")
+			cbCtx.EnvVariables.EnableIstioIntegration = false
 		}
 	}
 
 	cbCtx.IngressList = c.PruneIngress(&appGw, cbCtx)
-	if len(cbCtx.IngressList) == 0 && !cbCtx.EnableIstioIntegration {
+	if len(cbCtx.IngressList) == 0 && !cbCtx.EnvVariables.EnableIstioIntegration {
 		errorLine := "no Ingress in the pruned Ingress list. Please check Ingress events to get more information"
 		glog.Error(errorLine)
 		return nil
 	}
 
-	if cbCtx.EnableIstioIntegration {
+	if cbCtx.EnvVariables.EnableIstioIntegration {
 		var gatewaysInfo []string
 		for _, gateway := range cbCtx.IstioGateways {
 			gatewaysInfo = append(gatewaysInfo, fmt.Sprintf("%s/%s", gateway.Namespace, gateway.Name))
@@ -128,17 +129,15 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	glog.V(3).Info("BEGIN AppGateway deployment")
 	defer glog.V(3).Info("END AppGateway deployment")
 
-	logToFile := cbCtx.EnvVariables.EnableSaveConfigToFile == "true"
-
 	deploymentStart := time.Now()
 	// Initiate deployment
 	appGwFuture, err := c.appGwClient.CreateOrUpdate(ctx, c.appGwIdentifier.ResourceGroup, c.appGwIdentifier.AppGwName, *generatedAppGw)
 	if err != nil {
 		// Reset cache
 		c.configCache = nil
-		configJSON, _ := dumpSanitizedJSON(&appGw, logToFile, nil)
+		configJSON, _ := dumpSanitizedJSON(&appGw, cbCtx.EnvVariables.EnableSaveConfigToFile, nil)
 		glogIt := glog.Errorf
-		if cbCtx.EnablePanicOnPutError {
+		if cbCtx.EnvVariables.EnablePanicOnPutError {
 			glogIt = glog.Fatalf
 		}
 		glogIt("Failed applying App Gwy configuration: %s -- %s", err, string(configJSON))
@@ -146,7 +145,7 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	}
 	// Wait until deployment finshes and save the error message
 	err = appGwFuture.WaitForCompletionRef(ctx, c.appGwClient.BaseClient.Client)
-	configJSON, _ := dumpSanitizedJSON(&appGw, logToFile, nil)
+	configJSON, _ := dumpSanitizedJSON(&appGw, cbCtx.EnvVariables.EnableSaveConfigToFile, nil)
 	glog.V(5).Info(string(configJSON))
 
 	// We keep this at log level 1 to show some heartbeat in the logs. Without this it is way too quiet.

--- a/pkg/controller/prune.go
+++ b/pkg/controller/prune.go
@@ -24,7 +24,7 @@ var pruneFuncList []pruneFunc
 // PruneIngress filters ingress list based on filter functions and returns a filtered ingress list
 func (c *AppGwIngressController) PruneIngress(appGw *n.ApplicationGateway, cbCtx *appgw.ConfigBuilderContext) []*v1beta1.Ingress {
 	once.Do(func() {
-		if cbCtx.EnvVariables.EnableBrownfieldDeployment == "true" {
+		if cbCtx.EnvVariables.EnableBrownfieldDeployment {
 			pruneFuncList = append(pruneFuncList, pruneProhibitedIngress)
 		}
 		pruneFuncList = append(pruneFuncList, pruneNoPrivateIP)

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -60,14 +60,15 @@ type EnvVariables struct {
 	WatchNamespace             string
 	UsePrivateIP               string
 	VerbosityLevel             string
-	EnableBrownfieldDeployment string
-	EnableIstioIntegration     string
-	EnableSaveConfigToFile     string
-	EnablePanicOnPutError      string
+	EnableBrownfieldDeployment bool
+	EnableIstioIntegration     bool
+	EnableSaveConfigToFile     bool
+	EnablePanicOnPutError      bool
 	HealthProbeServicePort     string
 }
 
 var portNumberValidator = regexp.MustCompile(`^[0-9]{4,5}$`)
+var boolValidator = regexp.MustCompile(`^(?i)(true|false)$`)
 
 // GetEnv returns values for defined environment variables for Ingress Controller.
 func GetEnv() EnvVariables {
@@ -79,10 +80,10 @@ func GetEnv() EnvVariables {
 		WatchNamespace:             os.Getenv(WatchNamespaceVarName),
 		UsePrivateIP:               os.Getenv(UsePrivateIPVarName),
 		VerbosityLevel:             os.Getenv(VerbosityLevelVarName),
-		EnableBrownfieldDeployment: os.Getenv(EnableBrownfieldDeploymentVarName),
-		EnableIstioIntegration:     os.Getenv(EnableIstioIntegrationVarName),
-		EnableSaveConfigToFile:     os.Getenv(EnableSaveConfigToFileVarName),
-		EnablePanicOnPutError:      os.Getenv(EnablePanicOnPutErrorVarName),
+		EnableBrownfieldDeployment: GetEnvironmentVariable(EnableBrownfieldDeploymentVarName, "false", boolValidator) == "true",
+		EnableIstioIntegration:     GetEnvironmentVariable(EnableIstioIntegrationVarName, "false", boolValidator) == "true",
+		EnableSaveConfigToFile:     GetEnvironmentVariable(EnableSaveConfigToFileVarName, "false", boolValidator) == "true",
+		EnablePanicOnPutError:      GetEnvironmentVariable(EnablePanicOnPutErrorVarName, "false", boolValidator) == "true",
 		HealthProbeServicePort:     GetEnvironmentVariable(HealthProbeServicePortVarName, "8123", portNumberValidator),
 	}
 

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -60,10 +60,10 @@ var _ = Describe("Environment", func() {
 				_ = os.Setenv(WatchNamespaceVarName, "WatchNamespaceVarName")
 				_ = os.Setenv(UsePrivateIPVarName, "UsePrivateIPVarName")
 				_ = os.Setenv(VerbosityLevelVarName, "VerbosityLevelVarName")
-				_ = os.Setenv(EnableBrownfieldDeploymentVarName, "EnableBrownfieldDeploymentVarName")
-				_ = os.Setenv(EnableIstioIntegrationVarName, "EnableIstioIntegrationVarName")
-				_ = os.Setenv(EnableSaveConfigToFileVarName, "EnableSaveConfigToFileVarName")
-				_ = os.Setenv(EnablePanicOnPutErrorVarName, "EnablePanicOnPutErrorVarName")
+				_ = os.Setenv(EnableBrownfieldDeploymentVarName, "SomethingIrrelevant1234")
+				_ = os.Setenv(EnableIstioIntegrationVarName, "true")
+				_ = os.Setenv(EnableSaveConfigToFileVarName, "false")
+				_ = os.Setenv(EnablePanicOnPutErrorVarName, "true")
 
 				expected := EnvVariables{
 					SubscriptionID:             "SubscriptionIDVarName",
@@ -73,10 +73,10 @@ var _ = Describe("Environment", func() {
 					WatchNamespace:             "WatchNamespaceVarName",
 					UsePrivateIP:               "UsePrivateIPVarName",
 					VerbosityLevel:             "VerbosityLevelVarName",
-					EnableBrownfieldDeployment: "EnableBrownfieldDeploymentVarName",
-					EnableIstioIntegration:     "EnableIstioIntegrationVarName",
-					EnableSaveConfigToFile:     "EnableSaveConfigToFileVarName",
-					EnablePanicOnPutError:      "EnablePanicOnPutErrorVarName",
+					EnableBrownfieldDeployment: false,
+					EnableIstioIntegration:     true,
+					EnableSaveConfigToFile:     false,
+					EnablePanicOnPutError:      true,
 					HealthProbeServicePort:     "8123",
 				}
 

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -139,11 +139,11 @@ func (c *Context) Run(stopChannel chan struct{}, omitCRDs bool, envVariables env
 	}
 
 	// For AGIC to watch for these CRDs the EnableBrownfieldDeploymentVarName env variable must be set to true
-	if envVariables.EnableBrownfieldDeployment == "true" {
+	if envVariables.EnableBrownfieldDeployment {
 		sharedInformers = append(sharedInformers, c.informers.AzureIngressProhibitedTarget)
 	}
 
-	if envVariables.EnableIstioIntegration == "true" {
+	if envVariables.EnableIstioIntegration {
 		sharedInformers = append(sharedInformers, c.informers.IstioGateway, c.informers.IstioVirtualService)
 	}
 

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -24,32 +24,32 @@ import (
 
 // constant values to be used for testing
 const (
-	Namespace        = "--namespace--"
-	Name             = "--name--"
-	Host             = "bye.com"
-	OtherHost        = "--some-other-hostname--"
-	HostUnassociated = "---some-host-without-routing-rules---"
-	NameOfSecret     = "--the-name-of-the-secret--"
-	ServiceName      = "--service-name--"
-	NodeName         = "--node-name--"
-	URLPath1         = "/api1"
-	URLPath2         = "/api2"
-	URLPath3         = "/api3"
-	HealthPath       = "/healthz"
-	ContainerName    = "--container-name--"
-	ContainerPort    = int32(9876)
-	ContainerHealthPortName    = "--container-health-port-name--"
-	ContainerHealthPort    = int32(9090)
-	ServicePort      = "service-port"
-	SelectorKey      = "app"
-	SelectorValue    = "frontend"
-	Subscription     = "--subscription--"
-	ResourceGroup    = "--resource-group--"
-	AppGwName        = "--app-gw-name--"
-	PublicIPID       = "--front-end-ip-id-1--"
-	PrivateIPID      = "--front-end-ip-id-2--"
-	ServiceHTTPPort  = "--service-http-port--"
-	ServiceHTTPSPort = "--service-https-port--"
+	Namespace               = "--namespace--"
+	Name                    = "--name--"
+	Host                    = "bye.com"
+	OtherHost               = "--some-other-hostname--"
+	HostUnassociated        = "---some-host-without-routing-rules---"
+	NameOfSecret            = "--the-name-of-the-secret--"
+	ServiceName             = "--service-name--"
+	NodeName                = "--node-name--"
+	URLPath1                = "/api1"
+	URLPath2                = "/api2"
+	URLPath3                = "/api3"
+	HealthPath              = "/healthz"
+	ContainerName           = "--container-name--"
+	ContainerPort           = int32(9876)
+	ContainerHealthPortName = "--container-health-port-name--"
+	ContainerHealthPort     = int32(9090)
+	ServicePort             = "service-port"
+	SelectorKey             = "app"
+	SelectorValue           = "frontend"
+	Subscription            = "--subscription--"
+	ResourceGroup           = "--resource-group--"
+	AppGwName               = "--app-gw-name--"
+	PublicIPID              = "--front-end-ip-id-1--"
+	PrivateIPID             = "--front-end-ip-id-2--"
+	ServiceHTTPPort         = "--service-http-port--"
+	ServiceHTTPSPort        = "--service-https-port--"
 )
 
 // GetIngress creates an Ingress test fixture.


### PR DESCRIPTION
This PR simplifies the initialization of Feature Flags.

1) From the `ConfigBuilderContext ` struct - remove `EnableBrownfieldDeployment`, `EnableIstioIntegration`, and `EnablePanicOnPutError`
2) Convert environment variables `EnableBrownfieldDeployment `, `EnableIstioIntegration`, `EnableSaveConfigToFile`, `EnablePanicOnPutError` from `string` to `bool`
3) Use `GetEnvironmentVariable` to get env vars