### PR TITLE
Memoize oft used functions; Use Port in lieu of int32

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -224,7 +224,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	defaultBackendHTTPSettingsChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
 		expectedBackend := &ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend
 		probeID := appGwIdentifier.probeID(generateProbeName(expectedBackend.ServiceName, expectedBackend.ServicePort.String(), ingress))
-		httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), backendPort, ingress.Name)
+		httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), Port(backendPort), ingress.Name)
 		httpSettings := &n.ApplicationGatewayBackendHTTPSettings{
 			Etag: to.StringPtr("*"),
 			Name: &httpSettingsName,
@@ -246,7 +246,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 	defaultBackendAddressPoolChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
 		expectedBackend := &ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend
-		addressPoolName := generateAddressPoolName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), backendPort)
+		addressPoolName := generateAddressPoolName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), Port(backendPort))
 		addressPoolAddresses := []n.ApplicationGatewayBackendAddress{{IPAddress: &endpoint1}, {IPAddress: &endpoint2}, {IPAddress: &endpoint3}}
 
 		addressPool := &n.ApplicationGatewayBackendAddressPool{
@@ -522,7 +522,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 			EmptyBackendHTTPSettingsChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
 				expectedBackend := &ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend
-				httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), servicePort, ingress.Name)
+				httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), Port(servicePort), ingress.Name)
 				httpSettings := &n.ApplicationGatewayBackendHTTPSettings{
 					Etag: to.StringPtr("*"),
 					Name: &httpSettingsName,
@@ -749,7 +749,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			annotationsHTTPSettingsChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
 				expectedBackend := &ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend
 				probeID := appGwIdentifier.probeID(generateProbeName(expectedBackend.ServiceName, expectedBackend.ServicePort.String(), ingress))
-				httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), backendPort, ingress.Name)
+				httpSettingsName := generateHTTPSettingsName(generateBackendID(ingress, nil, nil, expectedBackend).serviceFullName(), fmt.Sprintf("%d", servicePort), Port(backendPort), ingress.Name)
 				httpSettings := &n.ApplicationGatewayBackendHTTPSettings{
 					Etag: to.StringPtr("*"),
 					Name: &httpSettingsName,
@@ -823,7 +823,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			backendPortNo := Port(8089)
 			ingress := "cm-acme-http-solver-t8rnf"
 
-			httpSettingsName := generateHTTPSettingsName(serviceName, servicePort, backendPortNo, ingress)
+			httpSettingsName := generateHTTPSettingsName(serviceName, servicePort, Port(backendPortNo), ingress)
 			Ω(len(httpSettingsName)).Should(BeNumerically("<=", 80), "Expected App Gateway Backend Pool with 80 Character but got one with: %d", len(httpSettingsName))
 		})
 	})

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -29,6 +29,10 @@ func (c *appGwConfigBuilder) BackendAddressPools(cbCtx *ConfigBuilderContext) er
 }
 
 func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.ApplicationGatewayBackendAddressPool {
+	if c.mem.pools != nil {
+		return *c.mem.pools
+	}
+
 	defaultPool := defaultBackendAddressPool(c.appGwIdentifier)
 	managedPoolsByName := map[string]*n.ApplicationGatewayBackendAddressPool{
 		*defaultPool.Name: &defaultPool,
@@ -69,6 +73,7 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 		return brownfield.MergePools(existingBlacklisted, agicCreatedPools)
 	}
 
+	c.mem.pools = &agicCreatedPools
 	return agicCreatedPools
 }
 

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -28,7 +28,19 @@ type ConfigBuilder interface {
 }
 
 type memoization struct {
-	listeners *[]n.ApplicationGatewayHTTPListener
+	listeners                    *[]n.ApplicationGatewayHTTPListener
+	listenerConfigs              *map[listenerIdentifier]listenerAzConfig
+	routingRules                 *[]n.ApplicationGatewayRequestRoutingRule
+	pathMaps                     *[]n.ApplicationGatewayURLPathMap
+	probesByName                 *map[string]n.ApplicationGatewayProbe
+	probesByBackend              *map[backendIdentifier]*n.ApplicationGatewayProbe
+	backendIDs                   *map[backendIdentifier]interface{}
+	settings                     *[]n.ApplicationGatewayBackendHTTPSettings
+	settingsByBackend            *map[backendIdentifier]*n.ApplicationGatewayBackendHTTPSettings
+	serviceBackendPairsByBackend *map[backendIdentifier]serviceBackendPortPair
+	pools                        *[]n.ApplicationGatewayBackendAddressPool
+	certs                        *[]n.ApplicationGatewaySslCertificate
+	secretToCert                 *map[secretIdentifier]*string
 }
 
 type appGwConfigBuilder struct {

--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -62,11 +62,15 @@ func (c *appGwConfigBuilder) getListeners(cbCtx *ConfigBuilderContext) *[]n.Appl
 
 // getListenerConfigs creates an intermediary representation of the listener configs based on the passed list of ingresses
 func (c *appGwConfigBuilder) getListenerConfigs(cbCtx *ConfigBuilderContext) map[listenerIdentifier]listenerAzConfig {
+	if c.mem.listenerConfigs != nil {
+		return *c.mem.listenerConfigs
+	}
+
 	// TODO(draychev): Emit an error event if 2 namespaces define different TLS for the same domain!
 	allListeners := make(map[listenerIdentifier]listenerAzConfig)
 	for _, ingress := range cbCtx.IngressList {
 		glog.V(5).Infof("Processing Rules for Ingress: %s/%s", ingress.Namespace, ingress.Name)
-		_, azListenerConfigs := c.processIngressRules(ingress, cbCtx.EnvVariables)
+		azListenerConfigs := c.getListenersFromIngress(ingress, cbCtx.EnvVariables)
 		for listenerID, azConfig := range azListenerConfigs {
 			allListeners[listenerID] = azConfig
 		}
@@ -80,6 +84,7 @@ func (c *appGwConfigBuilder) getListenerConfigs(cbCtx *ConfigBuilderContext) map
 		}
 	}
 
+	c.mem.listenerConfigs = &allListeners
 	return allListeners
 }
 

--- a/pkg/appgw/frontend_ports.go
+++ b/pkg/appgw/frontend_ports.go
@@ -27,7 +27,7 @@ func (c *appGwConfigBuilder) getFrontendPorts(cbCtx *ConfigBuilderContext) *[]n.
 	}
 
 	for _, ingress := range cbCtx.IngressList {
-		fePorts, _ := c.processIngressRules(ingress, cbCtx.EnvVariables)
+		fePorts := c.getFrontendPortsFromIngress(ingress, cbCtx.EnvVariables)
 		for port := range fePorts {
 			allPorts[port] = nil
 		}
@@ -71,7 +71,7 @@ func (c *appGwConfigBuilder) getFrontendPorts(cbCtx *ConfigBuilderContext) *[]n.
 
 func (c *appGwConfigBuilder) lookupFrontendPortByListenerIdentifier(listenerIdentifier listenerIdentifier) *n.ApplicationGatewayFrontendPort {
 	for _, port := range *c.appGw.FrontendPorts {
-		if *port.Port == int32(listenerIdentifier.FrontendPort) {
+		if Port(*port.Port) == listenerIdentifier.FrontendPort {
 			return &port
 		}
 	}

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -42,6 +42,10 @@ func (c *appGwConfigBuilder) HealthProbesCollection(cbCtx *ConfigBuilderContext)
 }
 
 func (c *appGwConfigBuilder) newProbesMap(cbCtx *ConfigBuilderContext) (map[string]n.ApplicationGatewayProbe, map[backendIdentifier]*n.ApplicationGatewayProbe) {
+	if c.mem.probesByName != nil && c.mem.probesByBackend != nil {
+		return *c.mem.probesByName, *c.mem.probesByBackend
+	}
+
 	healthProbeCollection := make(map[string]n.ApplicationGatewayProbe)
 	probesMap := make(map[backendIdentifier]*n.ApplicationGatewayProbe)
 	defaultProbe := defaultProbe(c.appGwIdentifier)
@@ -49,7 +53,7 @@ func (c *appGwConfigBuilder) newProbesMap(cbCtx *ConfigBuilderContext) (map[stri
 	glog.V(5).Info("Adding default probe:", *defaultProbe.Name)
 	healthProbeCollection[*defaultProbe.Name] = defaultProbe
 
-	for backendID := range newBackendIdsFiltered(cbCtx) {
+	for backendID := range c.newBackendIdsFiltered(cbCtx) {
 		probe := c.generateHealthProbe(backendID)
 
 		if probe != nil {
@@ -61,6 +65,9 @@ func (c *appGwConfigBuilder) newProbesMap(cbCtx *ConfigBuilderContext) (map[stri
 			probesMap[backendID] = &defaultProbe
 		}
 	}
+
+	c.mem.probesByName = &healthProbeCollection
+	c.mem.probesByBackend = &probesMap
 	return healthProbeCollection, probesMap
 }
 

--- a/pkg/appgw/ingress_rules.go
+++ b/pkg/appgw/ingress_rules.go
@@ -13,9 +13,23 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 )
 
-// processIngressRules creates the sets of front end listeners and ports, and a map of azure config per listener for the given ingress.
-func (c *appGwConfigBuilder) processIngressRules(ingress *v1beta1.Ingress, env environment.EnvVariables) (map[Port]interface{}, map[listenerIdentifier]listenerAzConfig) {
+func (c *appGwConfigBuilder) getFrontendPortsFromIngress(ingress *v1beta1.Ingress, env environment.EnvVariables) map[Port]interface{} {
 	frontendPorts := make(map[Port]interface{})
+	for ruleIdx := range ingress.Spec.Rules {
+		rule := &ingress.Spec.Rules[ruleIdx]
+		if rule.HTTP == nil {
+			continue
+		}
+
+		ruleFrontendPorts, _ := c.processIngressRule(rule, ingress, env)
+		for port, _ := range ruleFrontendPorts {
+			frontendPorts[port] = nil
+		}
+	}
+	return frontendPorts
+}
+
+func (c *appGwConfigBuilder) getListenersFromIngress(ingress *v1beta1.Ingress, env environment.EnvVariables) map[listenerIdentifier]listenerAzConfig {
 	listeners := make(map[listenerIdentifier]listenerAzConfig)
 	for ruleIdx := range ingress.Spec.Rules {
 		rule := &ingress.Spec.Rules[ruleIdx]
@@ -23,15 +37,12 @@ func (c *appGwConfigBuilder) processIngressRules(ingress *v1beta1.Ingress, env e
 			continue
 		}
 
-		ruleFrontendPorts, ruleListeners := c.processIngressRule(rule, ingress, env)
-		for port, _ := range ruleFrontendPorts {
-			frontendPorts[port] = nil
-		}
-		for listener, listenerConfig := range ruleListeners {
-			listeners[listener] = listenerConfig
+		_, ruleListeners := c.processIngressRule(rule, ingress, env)
+		for k, v := range ruleListeners {
+			listeners[k] = v
 		}
 	}
-	return frontendPorts, listeners
+	return listeners
 }
 
 func (c *appGwConfigBuilder) processIngressRule(rule *v1beta1.IngressRule, ingress *v1beta1.Ingress, env environment.EnvVariables) (map[Port]interface{}, map[listenerIdentifier]listenerAzConfig) {
@@ -50,7 +61,7 @@ func (c *appGwConfigBuilder) processIngressRule(rule *v1beta1.IngressRule, ingre
 	// we enable HTTPS as well as HTTP, and redirect HTTP to HTTPS.
 	if hasTLS {
 		listenerID := generateListenerID(rule, n.HTTPS, nil, usePrivateIPForIngress)
-		frontendPorts[listenerID.FrontendPort] = nil
+		frontendPorts[Port(listenerID.FrontendPort)] = nil
 		// Only associate the Listener with a Redirect if redirect is enabled
 		redirect := ""
 		if sslRedirect {
@@ -67,11 +78,10 @@ func (c *appGwConfigBuilder) processIngressRule(rule *v1beta1.IngressRule, ingre
 	// Enable HTTP only if HTTPS is not configured OR if ingress annotated with 'ssl-redirect'
 	if sslRedirect || !hasTLS {
 		listenerID := generateListenerID(rule, n.HTTP, nil, usePrivateIPForIngress)
-		frontendPorts[listenerID.FrontendPort] = nil
+		frontendPorts[Port(listenerID.FrontendPort)] = nil
 		listeners[listenerID] = listenerAzConfig{
 			Protocol: n.HTTP,
 		}
 	}
-
 	return frontendPorts, listeners
 }

--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -55,7 +55,8 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 		ingress.Spec.TLS = nil
 
 		// !! Action !!
-		frontendPorts, listenerConfigs := cb.processIngressRules(ingress, cbCtx.EnvVariables)
+		frontendPorts := cb.getFrontendPortsFromIngress(ingress, cbCtx.EnvVariables)
+		listenerConfigs := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables)
 
 		// Verify front end listeners
 		It("should have correct count of frontend listeners", func() {
@@ -124,7 +125,8 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 		}
 
 		// !! Action !!
-		frontendPorts, frontendListeners := cb.processIngressRules(ingress, cbCtx.EnvVariables)
+		frontendPorts := cb.getFrontendPortsFromIngress(ingress, cbCtx.EnvVariables)
+		frontendListeners := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables)
 
 		httpListenersAzureConfigMap := cb.getListenerConfigs(cbCtx)
 
@@ -180,8 +182,8 @@ func getMapKeys(m *map[listenerIdentifier]listenerAzConfig) []listenerIdentifier
 
 func getPortsList(m *map[Port]interface{}) []Port {
 	ports := make([]Port, 0, len(*m))
-	for k := range *m {
-		ports = append(ports, k)
+	for port := range *m {
+		ports = append(ports, port)
 	}
 	return ports
 }

--- a/pkg/appgw/istio_settings.go
+++ b/pkg/appgw/istio_settings.go
@@ -58,7 +58,7 @@ func (c *appGwConfigBuilder) getIstioDestinationsAndSettingsMap(cbCtx *ConfigBui
 		resolvedBackendPorts := make(map[serviceBackendPortPair]interface{})
 
 		service := c.k8sContext.GetService(destinationID.serviceKey())
-		destinationPortNum := int32(destinationID.DestinationPort)
+		destinationPortNum := Port(destinationID.DestinationPort)
 		if service == nil {
 			// Once services are filtered in the istioMatchDestinationIDs function, this should never happen
 			logLine := fmt.Sprintf("Unable to get the service [%s]", destinationID.serviceKey())
@@ -79,7 +79,7 @@ func (c *appGwConfigBuilder) getIstioDestinationsAndSettingsMap(cbCtx *ConfigBui
 				}
 
 				// TODO(delqn): implement correctly port lookup by name
-				if sp.Port == destinationPortNum || sp.TargetPort.String() == fmt.Sprint(destinationPortNum) {
+				if Port(sp.Port) == destinationPortNum || sp.TargetPort.String() == fmt.Sprint(destinationPortNum) {
 					// matched a service port with a port from the service
 					if sp.TargetPort.String() == "" {
 						// targetPort is not defined, by default targetPort == port
@@ -105,7 +105,7 @@ func (c *appGwConfigBuilder) getIstioDestinationsAndSettingsMap(cbCtx *ConfigBui
 							for targetPort := range targetPortsResolved {
 								pair := serviceBackendPortPair{
 									ServicePort: Port(sp.Port),
-									BackendPort: targetPort,
+									BackendPort: Port(targetPort),
 								}
 								resolvedBackendPorts[pair] = nil
 							}

--- a/pkg/appgw/redirects_test.go
+++ b/pkg/appgw/redirects_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		})
 
 		It("should have created correct ApplicationGatewayRedirectConfiguration struct", func() {
-			Expect(len(*actualRedirects)).To(Equal(0))
+			Expect(len(*actualRedirects)).To(Equal(1))
 			Expect(len(actualListeners)).To(Equal(1))
 			Expect(actualListeners[listenerID1]).To(Equal(expectedListenerConfigs[listenerID1]), fmt.Sprintf("Actual: %+v", actualListeners))
 			Expect(actualListeners[listenerID1].SslRedirectConfigurationName).To(Equal(""), fmt.Sprintf("Actual: %+v", actualListeners))
@@ -137,7 +137,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 
 		It("should have created correct ApplicationGatewayRedirectConfiguration struct", func() {
 			// Obviously there should be NO redirects since the annotation has been removed
-			Expect(len(*actualRedirects)).To(Equal(0))
+			Expect(len(*actualRedirects)).To(Equal(1))
 			Expect(len(actualListeners)).To(Equal(1))
 			expectedListenerConfig := listenerAzConfig{
 				Protocol: "Https",

--- a/pkg/appgw/redirects_test.go
+++ b/pkg/appgw/redirects_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 			ID:   to.StringPtr(cb.appGwIdentifier.redirectConfigurationID("sslr-fl-bye.com-443")),
 		}
 
-		_, actualListeners := cb.processIngressRules(ingress, cbCtx.EnvVariables)
+		actualListeners := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables)
 
 		It("test was setup correctly", func() {
 			Expect(ingress.Spec.TLS).ToNot(BeNil())
@@ -103,7 +103,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		actualRedirects := cb.getRedirectConfigurations(&cbCtx)
 
 		// Run this to link the listeners and the redirect config
-		_, actualListeners := cb.processIngressRules(ingress, cbCtx.EnvVariables)
+		actualListeners := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables)
 
 		It("test was setup correctly", func() {
 			Expect(ingress.Spec.TLS).To(BeNil())
@@ -128,7 +128,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		actualRedirects := cb.getRedirectConfigurations(&cbCtx)
 
 		// Run this to link the listeners and the redirect config
-		_, actualListeners := cb.processIngressRules(ingress, cbCtx.EnvVariables)
+		actualListeners := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables)
 
 		It("test was setup correctly", func() {
 			Expect(ingress.Spec.TLS).ToNot(BeNil())

--- a/pkg/appgw/redirects_test.go
+++ b/pkg/appgw/redirects_test.go
@@ -20,8 +20,6 @@ import (
 
 var _ = Describe("Test SSL Redirect Annotations", func() {
 
-	cb := newConfigBuilderFixture(nil)
-
 	listenerID1 := listenerIdentifier{
 		FrontendPort: 80,
 		HostName:     "bye.com",
@@ -46,6 +44,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 	}
 
 	Context("Test RequestRoutingRules with TLS and with SSL Redirect Annotation", func() {
+		cb := newConfigBuilderFixture(nil)
 		ingress := tests.NewIngressFixture()
 		ingressList := []*v1beta1.Ingress{ingress}
 		cbCtx := ConfigBuilderContext{
@@ -94,6 +93,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 	})
 
 	Context("Test RequestRoutingRules without TLS but with SSL Redirect Annotation", func() {
+		cb := newConfigBuilderFixture(nil)
 		ingress := tests.NewIngressFixture()
 		ingress.Spec.TLS = nil
 		ingressList := []*v1beta1.Ingress{ingress}
@@ -111,7 +111,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		})
 
 		It("should have created correct ApplicationGatewayRedirectConfiguration struct", func() {
-			Expect(len(*actualRedirects)).To(Equal(1))
+			Expect(len(*actualRedirects)).To(Equal(0))
 			Expect(len(actualListeners)).To(Equal(1))
 			Expect(actualListeners[listenerID1]).To(Equal(expectedListenerConfigs[listenerID1]), fmt.Sprintf("Actual: %+v", actualListeners))
 			Expect(actualListeners[listenerID1].SslRedirectConfigurationName).To(Equal(""), fmt.Sprintf("Actual: %+v", actualListeners))
@@ -119,6 +119,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 	})
 
 	Context("Test RequestRoutingRules with TLS but without SSL Redirect Annotation", func() {
+		cb := newConfigBuilderFixture(nil)
 		ingress := tests.NewIngressFixture()
 		delete(ingress.Annotations, annotations.SslRedirectKey)
 		ingressList := []*v1beta1.Ingress{ingress}
@@ -137,7 +138,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 
 		It("should have created correct ApplicationGatewayRedirectConfiguration struct", func() {
 			// Obviously there should be NO redirects since the annotation has been removed
-			Expect(len(*actualRedirects)).To(Equal(1))
+			Expect(len(*actualRedirects)).To(Equal(0))
 			Expect(len(actualListeners)).To(Equal(1))
 			expectedListenerConfig := listenerAzConfig{
 				Protocol: "Https",

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -60,6 +60,9 @@ func (c *appGwConfigBuilder) RequestRoutingRules(cbCtx *ConfigBuilderContext) er
 }
 
 func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.ApplicationGatewayRequestRoutingRule, []n.ApplicationGatewayURLPathMap) {
+	if c.mem.routingRules != nil && c.mem.pathMaps != nil {
+		return *c.mem.routingRules, *c.mem.pathMaps
+	}
 	httpListenersMap := c.groupListenersByListenerIdentifier(c.getListeners(cbCtx))
 	var pathMap []n.ApplicationGatewayURLPathMap
 	var requestRoutingRules []n.ApplicationGatewayRequestRoutingRule
@@ -93,6 +96,9 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 		}
 		requestRoutingRules = append(requestRoutingRules, rule)
 	}
+
+	c.mem.routingRules = &requestRoutingRules
+	c.mem.pathMaps = &pathMap
 	return requestRoutingRules, pathMap
 }
 
@@ -158,7 +164,7 @@ func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listen
 }
 
 func (c *appGwConfigBuilder) getPathMap(cbCtx *ConfigBuilderContext, listenerID listenerIdentifier, listenerAzConfig listenerAzConfig, ingress *v1beta1.Ingress, rule *v1beta1.IngressRule) *n.ApplicationGatewayURLPathMap {
-	// initilize a path map for this listener if doesn't exists
+	// initialize a path map for this listener if doesn't exists
 	pathMap := n.ApplicationGatewayURLPathMap{
 		Etag: to.StringPtr("*"),
 		Name: to.StringPtr(generateURLPathMapName(listenerID)),

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -7,7 +7,6 @@ package tests
 
 import (
 	"fmt"
-
 	"io/ioutil"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"


### PR DESCRIPTION
This PR introduces more memoizations around often used functions.

In addition here we also attempt to increase readability and maintainability of code base, I'd like to introduce the alias `type Port int32`

This is primarily helpful in creating structures like `map[Port]interface{}`, which is arguably much more semantically clear (self explanatory) compared to `map[int32]interface{}`

Also in this PR - audaciously split `processIngressRules` in `getListenersFromIngress` and `getFrontendPortsFromIngress`