### PR TITLE
Retry getting auth token

### DIFF
--- a/cmd/appgw-ingress/main_test.go
+++ b/cmd/appgw-ingress/main_test.go
@@ -76,12 +76,30 @@ var _ = Describe("Test functions used in main.go", func() {
 		})
 	})
 
+	Context("test getAuthorizer", func() {
+		It("should try and get some authorizer", func() {
+			env := environment.EnvVariables{}
+			authorizer, err := getAuthorizer(env)
+			Ω(authorizer).ToNot(BeNil())
+			Ω(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("test getAuthorizerWithRetry", func() {
+		It("should try and get some authorizer", func() {
+			env := environment.EnvVariables{}
+			authorizer, err := getAuthorizerWithRetry(env, 0)
+			Ω(authorizer).ToNot(BeNil())
+			Ω(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("test waitForAzureAuth", func() {
 		client := n.ApplicationGatewaysClient{}
 		It("should try and panic", func() {
 			env := environment.EnvVariables{}
 			fn := func() {
-				_ = waitForAzureAuth(env, &client, 0)
+				_ = waitForAzureAuth(env, client, 0)
 			}
 			Ω(fn).Should(Panic())
 		})

--- a/cmd/appgw-ingress/main_test.go
+++ b/cmd/appgw-ingress/main_test.go
@@ -98,10 +98,8 @@ var _ = Describe("Test functions used in main.go", func() {
 		client := n.ApplicationGatewaysClient{}
 		It("should try and panic", func() {
 			env := environment.EnvVariables{}
-			fn := func() {
-				_ = waitForAzureAuth(env, client, 0)
-			}
-			Ω(fn).Should(Panic())
+			err := waitForAzureAuth(env, client, 0)
+			Ω(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
In this PR - small tweaks to ensure that we retry `auth.NewAuthorizer...()` a few times before giving up. (Same as verifying the auth token)

- removed `initAppGwClient` - moved inline
- renamed `getAzAuth` to `getAuthorizer`
- carved `getAuthorizerWithRetry` out of `waitForAzureAuth`
- fixed a bug w/ checking Response codes - `panic: runtime error: invalid memory address or nil pointer dereference` is possible when there's no response (example: DNS failure / wrong hostname etc)