### PR TITLE
tests: Improve k8scontext tests

### DIFF
--- a/pkg/k8scontext/k8scontext_suite_test.go
+++ b/pkg/k8scontext/k8scontext_suite_test.go
@@ -1,13 +1,13 @@
-package k8scontext_test
+package k8scontext
 
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 )
 
 func TestK8scontext(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "K8scontext Suite")
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "K8scontext Suite")
 }


### PR DESCRIPTION
This PR Improves test coverage.

Most significant change is renaming `k8scontext_test` package to `k8scontext`, which seems to have done in the first place due to collision of `Context` within `k8scontext` and `ginkgo`.  To avoid the redefinition - prefixing all ginkgo imports with the package name.