### PR TITLE
fix: missing repopath variable, move validateEnv

### DIFF
--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -36,6 +36,7 @@ steps:
   displayName: 'Go vet'
 
 - script: |
+    set -u
     go version
     echo -e "\e[44;97m Compiling ... \e[0m"
 
@@ -53,6 +54,7 @@ steps:
     echo "VERSION $VERSION_VAR:$VERSION, BUILD_DATE $DATE_VAR:$BUILD_DATE, GIT_HASH $COMMIT_VAR:$GIT_HASH"
     if  go install -ldflags "-s -X ${VERSION_VAR}=${VERSION} -X ${DATE_VAR}=${BUILD_DATE} -X ${COMMIT_VAR}=${GIT_HASH}" -v ./cmd/appgw-ingress; then
         chmod -R 777 $(GOBIN)
+        $(GOBIN)/appgw-ingress --version
         echo -e "\e[42;97m Build SUCCEEDED \e[0m"
     else
         echo -e "\e[101;97m Build FAILED \e[0m"

--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -40,6 +40,9 @@ steps:
     echo -e "\e[44;97m Compiling ... \e[0m"
 
     # set version
+    ORG_PATH="github.com/Azure"
+    PROJECT_NAME="application-gateway-kubernetes-ingress"
+    REPO_PATH="${ORG_PATH}/${PROJECT_NAME}"
     VERSION_VAR="${REPO_PATH}/pkg/version.Version"
     VERSION=$(git describe --abbrev=0 --tags)
     DATE_VAR="${REPO_PATH}/pkg/version.BuildDate"

--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -50,7 +50,7 @@ steps:
     COMMIT_VAR="${REPO_PATH}/pkg/version.GitCommit"
     GIT_HASH=$(git rev-parse --short HEAD)
 
-    echo "VERSION $VERSION, BUILD_DATE $BUILD_DATE, GIT_HASH $GIT_HASH"
+    echo "VERSION $VERSION_VAR:$VERSION, BUILD_DATE $DATE_VAR:$BUILD_DATE, GIT_HASH $COMMIT_VAR:$GIT_HASH"
     if  go install -ldflags "-s -X ${VERSION_VAR}=${VERSION} -X ${DATE_VAR}=${BUILD_DATE} -X ${COMMIT_VAR}=${GIT_HASH}" -v ./cmd/appgw-ingress; then
         chmod -R 777 $(GOBIN)
         echo -e "\e[42;97m Build SUCCEEDED \e[0m"

--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -70,14 +70,14 @@ func main() {
 	}
 
 	env := environment.GetEnv()
-	if err := environment.ValidateEnv(env); err != nil {
-		glog.Fatal("Error while initializing values from environment. Please check helm configuration for missing values.", err)
-	}
 
 	verbosity = to.IntPtr(getVerbosity(*verbosity, env.VerbosityLevel))
-
 	if *versionInfo {
 		version.PrintVersionAndExit()
+	}
+
+	if err := environment.ValidateEnv(env); err != nil {
+		glog.Fatal("Error while initializing values from environment. Please check helm configuration for missing values.", err)
 	}
 
 	// Workaround for "ERROR: logging before flag.Parse"


### PR DESCRIPTION
```bash
VERSION github.com/Azure/application-gateway-kubernetes-ingress/pkg/version.Version:1.0.0-rc1, BUILD_DATE github.com/Azure/application-gateway-kubernetes-ingress/pkg/version.BuildDate:2019-08-29-01:29T+0000, GIT_HASH github.com/Azure/application-gateway-kubernetes-ingress/pkg/version.GitCommit:6bd98fd0
github.com/Azure/application-gateway-kubernetes-ingress/cmd/appgw-ingress
ERROR: logging before flag.Parse: I0829 01:29:25.305017   11870 main.go:291] Using verbosity level 1 from CLI flag verbosity
Version: 1.0.0-rc1; Commit: 6bd98fd0; Date: 2019-08-29-01:29T+0000
```