### PR TITLE
Remove RingChannel in lieu of a goode olde buffered channel

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -6,7 +6,7 @@
 package appgw
 
 import (
-	go_flag "flag"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"time"
@@ -28,7 +28,6 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/fake"
 	istio_fake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned/fake"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
@@ -191,8 +190,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 	pod := tests.NewPodFixture(serviceName, ingressNS, backendName, int32(backendPort))
 
-	_ = go_flag.Lookup("logtostderr").Value.Set("true")
-	_ = go_flag.Set("v", "3")
+	_ = flag.Lookup("logtostderr").Value.Set("true")
+	_ = flag.Set("v", "3")
 
 	// Method to test all the ingress that have been added to the K8s context.
 	testIngress := func() []*v1beta1.Ingress {
@@ -388,8 +387,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	ingressEvent := func() {
 		for {
 			select {
-			case obj := <-ctxt.UpdateChannel.Out():
-				event := obj.(events.Event)
+			case event := <-ctxt.Work:
 				// Check if we got an event of type secret.
 				if _, ok := event.Value.(*v1beta1.Ingress); ok {
 					return

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -62,7 +62,7 @@ func (c *AppGwIngressController) Start(envVariables environment.EnvVariables) er
 	}
 
 	// Starts Worker processing events from k8sContext
-	go c.worker.Run(c.k8sContext.UpdateChannel, c.stopChannel)
+	go c.worker.Run(c.k8sContext.Work, c.stopChannel)
 	return nil
 }
 

--- a/pkg/k8scontext/handlers.go
+++ b/pkg/k8scontext/handlers.go
@@ -12,7 +12,7 @@ type handlers struct {
 
 // general resource handlers
 func (h handlers) addFunc(obj interface{}) {
-	h.context.UpdateChannel.In() <- events.Event{
+	h.context.Work <- events.Event{
 		Type:  events.Create,
 		Value: obj,
 	}
@@ -22,14 +22,14 @@ func (h handlers) updateFunc(oldObj, newObj interface{}) {
 	if reflect.DeepEqual(oldObj, newObj) {
 		return
 	}
-	h.context.UpdateChannel.In() <- events.Event{
+	h.context.Work <- events.Event{
 		Type:  events.Update,
 		Value: newObj,
 	}
 }
 
 func (h handlers) deleteFunc(obj interface{}) {
-	h.context.UpdateChannel.In() <- events.Event{
+	h.context.Work <- events.Event{
 		Type:  events.Delete,
 		Value: obj,
 	}

--- a/pkg/k8scontext/ingress_handlers.go
+++ b/pkg/k8scontext/ingress_handlers.go
@@ -39,7 +39,7 @@ func (h handlers) ingressAdd(obj interface{}) {
 			h.context.ingressSecretsMap.Insert(ingKey, secKey)
 		}
 	}
-	h.context.UpdateChannel.In() <- events.Event{
+	h.context.Work <- events.Event{
 		Type:  events.Create,
 		Value: obj,
 	}
@@ -64,7 +64,7 @@ func (h handlers) ingressDelete(obj interface{}) {
 	ingKey := utils.GetResourceKey(ing.Namespace, ing.Name)
 	h.context.ingressSecretsMap.Erase(ingKey)
 
-	h.context.UpdateChannel.In() <- events.Event{
+	h.context.Work <- events.Event{
 		Type:  events.Delete,
 		Value: obj,
 	}
@@ -101,7 +101,7 @@ func (h handlers) ingressUpdate(oldObj, newObj interface{}) {
 		}
 	}
 
-	h.context.UpdateChannel.In() <- events.Event{
+	h.context.Work <- events.Event{
 		Type:  events.Update,
 		Value: newObj,
 	}

--- a/pkg/k8scontext/k8scontext_test.go
+++ b/pkg/k8scontext/k8scontext_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/fake"
 	istioFake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned/fake"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
@@ -59,8 +58,7 @@ var _ = ginkgo.Describe("K8scontext", func() {
 
 		for {
 			select {
-			case in := <-ctxt.UpdateChannel.Out():
-				event := in.(events.Event)
+			case event := <-ctxt.Work:
 				for _, resource := range resourceList {
 					if reflect.DeepEqual(resource, event.Value) {
 						exists[resource] = ""

--- a/pkg/k8scontext/secrets_handlers.go
+++ b/pkg/k8scontext/secrets_handlers.go
@@ -22,7 +22,7 @@ func (h handlers) secretAdd(obj interface{}) {
 	if h.context.ingressSecretsMap.ContainsValue(secKey) {
 		// find if this secKey exists in the map[string]UnorderedSets
 		if err := h.context.CertificateSecretStore.convertSecret(secKey, sec); err == nil {
-			h.context.UpdateChannel.In() <- events.Event{
+			h.context.Work <- events.Event{
 				Type:  events.Create,
 				Value: obj,
 			}
@@ -39,7 +39,7 @@ func (h handlers) secretUpdate(oldObj, newObj interface{}) {
 	secKey := utils.GetResourceKey(sec.Namespace, sec.Name)
 	if h.context.ingressSecretsMap.ContainsValue(secKey) {
 		if err := h.context.CertificateSecretStore.convertSecret(secKey, sec); err == nil {
-			h.context.UpdateChannel.In() <- events.Event{
+			h.context.Work <- events.Event{
 				Type:  events.Update,
 				Value: newObj,
 			}
@@ -64,7 +64,7 @@ func (h handlers) secretDelete(obj interface{}) {
 	secKey := utils.GetResourceKey(sec.Namespace, sec.Name)
 	h.context.CertificateSecretStore.delete(secKey)
 	if h.context.ingressSecretsMap.ContainsValue(secKey) {
-		h.context.UpdateChannel.In() <- events.Event{
+		h.context.Work <- events.Event{
 			Type:  events.Delete,
 			Value: obj,
 		}

--- a/pkg/k8scontext/types.go
+++ b/pkg/k8scontext/types.go
@@ -1,12 +1,12 @@
 package k8scontext
 
 import (
-	"github.com/eapache/channels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned"
 	istio_versioned "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
@@ -51,7 +51,7 @@ type Context struct {
 
 	ingressSecretsMap utils.ThreadsafeMultiMap
 
-	UpdateChannel *channels.RingChannel
+	Work chan events.Event
 
 	CacheSynced chan interface{}
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -8,7 +8,6 @@ package worker
 import (
 	"time"
 
-	"github.com/eapache/channels"
 	"github.com/golang/glog"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
@@ -17,11 +16,10 @@ import (
 const sleepOnErrorSeconds = 5
 
 // Run starts the worker which listens for events in eventChannel; stops when stopChannel is closed.
-func (w *Worker) Run(eventChannel *channels.RingChannel, stopChannel chan struct{}) {
+func (w *Worker) Run(work chan events.Event, stopChannel chan struct{}) {
 	for {
 		select {
-		case in := <-eventChannel.Out():
-			event := in.(events.Event)
+		case event := <-work:
 			if shouldProcess, reason := w.ShouldProcess(event); !shouldProcess {
 				if reason != "" {
 					glog.V(5).Infof("Skipping event: %s", reason)

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -8,7 +8,6 @@ package worker
 import (
 	"time"
 
-	"github.com/eapache/channels"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -18,11 +17,11 @@ import (
 
 var _ = Describe("Worker Test", func() {
 	var stopChannel chan struct{}
-	var eventChannel *channels.RingChannel
+	var work chan events.Event
 
 	BeforeEach(func() {
 		stopChannel = make(chan struct{})
-		eventChannel = channels.NewRingChannel(1024)
+		work = make(chan events.Event)
 	})
 
 	AfterEach(func() {
@@ -39,10 +38,10 @@ var _ = Describe("Worker Test", func() {
 			worker := Worker{
 				EventProcessor: eventProcessor,
 			}
-			go worker.Run(eventChannel, stopChannel)
+			go worker.Run(work, stopChannel)
 
 			ingress := *tests.NewIngressFixture()
-			eventChannel.In() <- events.Event{
+			work <- events.Event{
 				Type:  events.Create,
 				Value: ingress,
 			}


### PR DESCRIPTION
Removing our dependency on the RingChannel and using a buffered channel, typed specifically to the `Event` struct.

Initial concern with using the RingChannel was that we could potentially lose events.
Given that we always construct App Gateway config from scratch (and not using cumulative updates), this would have not been an issues (dropping events). 