### PR TITLE
Adding DefaultAddressPooID and DefaultHTTPSettingsID fields to ConfigBuilderContext

### DIFF
--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -239,7 +239,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		httpSettings := &n.ApplicationGatewayBackendHTTPSettings{
 			Etag: to.StringPtr("*"),
 			Name: &httpSettingsName,
-			ID:   to.StringPtr(appGwIdentifier.httpSettingsID(httpSettingsName)),
+			ID:   to.StringPtr(appGwIdentifier.HTTPSettingsID(httpSettingsName)),
 			ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 				Protocol: n.HTTP,
 				Port:     to.Int32Ptr(int32(backendPort)),
@@ -263,7 +263,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		addressPool := &n.ApplicationGatewayBackendAddressPool{
 			Etag: to.StringPtr("*"),
 			Name: &addressPoolName,
-			ID:   to.StringPtr(appGwIdentifier.addressPoolID(addressPoolName)),
+			ID:   to.StringPtr(appGwIdentifier.AddressPoolID(addressPoolName)),
 			ApplicationGatewayBackendAddressPoolPropertiesFormat: &n.ApplicationGatewayBackendAddressPoolPropertiesFormat{
 				BackendAddresses: &addressPoolAddresses,
 			},
@@ -541,7 +541,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 				httpSettings := &n.ApplicationGatewayBackendHTTPSettings{
 					Etag: to.StringPtr("*"),
 					Name: &httpSettingsName,
-					ID:   to.StringPtr(appGwIdentifier.httpSettingsID(httpSettingsName)),
+					ID:   to.StringPtr(appGwIdentifier.HTTPSettingsID(httpSettingsName)),
 					ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 						Protocol: n.HTTP,
 						Port:     to.Int32Ptr(int32(servicePort)),
@@ -768,7 +768,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 				httpSettings := &n.ApplicationGatewayBackendHTTPSettings{
 					Etag: to.StringPtr("*"),
 					Name: &httpSettingsName,
-					ID:   to.StringPtr(appGwIdentifier.httpSettingsID(httpSettingsName)),
+					ID:   to.StringPtr(appGwIdentifier.HTTPSettingsID(httpSettingsName)),
 					ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 						Protocol:            n.HTTP,
 						Port:                to.Int32Ptr(int32(backendPort)),

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -133,7 +133,7 @@ func (c *appGwConfigBuilder) newPool(poolName string, subset v1.EndpointSubset) 
 	return &n.ApplicationGatewayBackendAddressPool{
 		Etag: to.StringPtr("*"),
 		Name: &poolName,
-		ID:   to.StringPtr(c.appGwIdentifier.addressPoolID(poolName)),
+		ID:   to.StringPtr(c.appGwIdentifier.AddressPoolID(poolName)),
 		ApplicationGatewayBackendAddressPoolPropertiesFormat: &n.ApplicationGatewayBackendAddressPoolPropertiesFormat{
 			BackendAddresses: getAddressesForSubset(subset),
 		},

--- a/pkg/appgw/backendaddresspools_test.go
+++ b/pkg/appgw/backendaddresspools_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 			expectedPoolName := "pool-" + tests.Namespace + "-" + tests.ServiceName + "-4321-bp-9876"
 			expected := n.ApplicationGatewayBackendAddressPool{
 				Name: to.StringPtr(expectedPoolName),
-				ID:   to.StringPtr(cb.appGwIdentifier.addressPoolID(expectedPoolName)),
+				ID:   to.StringPtr(cb.appGwIdentifier.AddressPoolID(expectedPoolName)),
 				Etag: to.StringPtr("*"),
 				ApplicationGatewayBackendAddressPoolPropertiesFormat: &n.ApplicationGatewayBackendAddressPoolPropertiesFormat{
 					BackendIPConfigurations: nil,

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -249,7 +249,7 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 	httpSettings := n.ApplicationGatewayBackendHTTPSettings{
 		Etag: to.StringPtr("*"),
 		Name: &httpSettingsName,
-		ID:   to.StringPtr(c.appGwIdentifier.httpSettingsID(httpSettingsName)),
+		ID:   to.StringPtr(c.appGwIdentifier.HTTPSettingsID(httpSettingsName)),
 		ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 			Protocol: n.HTTP,
 			Port:     to.Int32Ptr(int32(port)),

--- a/pkg/appgw/backendhttpsettings_test.go
+++ b/pkg/appgw/backendhttpsettings_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Test the creation of Backend http settings from Ingress defini
 			httpSettings, _, _, _ := configBuilder.getBackendsAndSettingsMap(cbCtx)
 
 			for _, setting := range httpSettings {
-				if *setting.Name == defaultBackendHTTPSettingsName {
+				if *setting.Name == DefaultBackendHTTPSettingsName {
 					Expect(setting.Protocol).To(Equal(n.HTTP), "default backend %s should have %s", *setting.Name, n.HTTP)
 					Expect(probes[utils.GetLastChunkOfSlashed(*setting.Probe.ID)].Protocol).To(Equal(n.HTTP), "default probe should have http")
 					continue

--- a/pkg/appgw/identifier.go
+++ b/pkg/appgw/identifier.go
@@ -29,7 +29,7 @@ func (agw Identifier) gatewayResourceID(subResourceKind string, resourceName str
 	return agw.resourceID("Microsoft.Network", "applicationGateways", resourcePath)
 }
 
-func (agw Identifier) addressPoolID(poolName string) string {
+func (agw Identifier) AddressPoolID(poolName string) string {
 	return agw.gatewayResourceID("backendAddressPools", poolName)
 }
 
@@ -45,7 +45,7 @@ func (agw Identifier) sslCertificateID(certname string) string {
 	return agw.gatewayResourceID("sslCertificates", certname)
 }
 
-func (agw Identifier) httpSettingsID(settingsName string) string {
+func (agw Identifier) HTTPSettingsID(settingsName string) string {
 	return agw.gatewayResourceID("backendHttpSettingsCollection", settingsName)
 }
 

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -148,19 +148,19 @@ func generatePathRuleName(namespace, ingress, suffix string) string {
 	return formatPropName(fmt.Sprintf("%s%s-%s-%s-%s", agPrefix, prefixPathRule, namespace, ingress, suffix))
 }
 
-var defaultBackendHTTPSettingsName = fmt.Sprintf("%sdefaulthttpsetting", agPrefix)
-var defaultBackendAddressPoolName = fmt.Sprintf("%sdefaultaddresspool", agPrefix)
+var DefaultBackendHTTPSettingsName = fmt.Sprintf("%sdefaulthttpsetting", agPrefix)
+var DefaultBackendAddressPoolName = fmt.Sprintf("%sdefaultaddresspool", agPrefix)
 
 func defaultProbeName(protocol n.ApplicationGatewayProtocol) string {
 	return fmt.Sprintf("%sdefaultprobe-%s", agPrefix, protocol)
 }
 
 func defaultBackendHTTPSettings(appGWIdentifier Identifier, protocol n.ApplicationGatewayProtocol) n.ApplicationGatewayBackendHTTPSettings {
-	defHTTPSettingsName := defaultBackendHTTPSettingsName
+	defHTTPSettingsName := DefaultBackendHTTPSettingsName
 	defHTTPSettingsPort := int32(80)
 	return n.ApplicationGatewayBackendHTTPSettings{
 		Name: &defHTTPSettingsName,
-		ID:   to.StringPtr(appGWIdentifier.httpSettingsID(defHTTPSettingsName)),
+		ID:   to.StringPtr(appGWIdentifier.HTTPSettingsID(defHTTPSettingsName)),
 		ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 			Protocol: protocol,
 			Port:     &defHTTPSettingsPort,
@@ -192,8 +192,8 @@ func defaultProbe(appGWIdentifier Identifier, protocol n.ApplicationGatewayProto
 
 func defaultBackendAddressPool(appGWIdentifier Identifier) n.ApplicationGatewayBackendAddressPool {
 	return n.ApplicationGatewayBackendAddressPool{
-		Name: &defaultBackendAddressPoolName,
-		ID:   to.StringPtr(appGWIdentifier.addressPoolID(defaultBackendAddressPoolName)),
+		Name: &DefaultBackendAddressPoolName,
+		ID:   to.StringPtr(appGWIdentifier.AddressPoolID(DefaultBackendAddressPoolName)),
 		ApplicationGatewayBackendAddressPoolPropertiesFormat: &n.ApplicationGatewayBackendAddressPoolPropertiesFormat{
 			BackendAddresses: &[]n.ApplicationGatewayBackendAddress{},
 		},

--- a/pkg/appgw/istio_pools.go
+++ b/pkg/appgw/istio_pools.go
@@ -35,7 +35,7 @@ func (c *appGwConfigBuilder) getIstioBackendAddressPool(destinationID istioDesti
 				return pool
 			}
 			pool := c.newPool(poolName, subset)
-			pool.ID = to.StringPtr(c.appGwIdentifier.addressPoolID(poolName))
+			pool.ID = to.StringPtr(c.appGwIdentifier.AddressPoolID(poolName))
 			return pool
 		}
 		logLine := fmt.Sprintf("Backend target port %d does not have matching endpoint port", serviceBackendPair.BackendPort)

--- a/pkg/appgw/istio_routing_rules.go
+++ b/pkg/appgw/istio_routing_rules.go
@@ -14,8 +14,8 @@ import (
 )
 
 func (c *appGwConfigBuilder) getIstioPathMaps(cbCtx *ConfigBuilderContext) map[listenerIdentifier]*n.ApplicationGatewayURLPathMap {
-	defaultAddressPoolID := to.StringPtr(c.appGwIdentifier.addressPoolID(defaultBackendAddressPoolName))
-	defaultHTTPSettingsID := to.StringPtr(c.appGwIdentifier.httpSettingsID(defaultBackendHTTPSettingsName))
+	defaultAddressPoolID := to.StringPtr(c.appGwIdentifier.AddressPoolID(DefaultBackendAddressPoolName))
+	defaultHTTPSettingsID := to.StringPtr(c.appGwIdentifier.HTTPSettingsID(DefaultBackendHTTPSettingsName))
 
 	// TODO(delqn)
 	istioHTTPSettings, _, _, _ := c.getIstioDestinationsAndSettingsMap(cbCtx)
@@ -95,8 +95,8 @@ func (c *appGwConfigBuilder) getIstioPathMaps(cbCtx *ConfigBuilderContext) map[l
 	// if no url pathmaps were created, then add a default path map since this will be translated to
 	// a basic request routing rule which is needed on Application Gateway to avoid validation error.
 	if len(urlPathMaps) == 0 {
-		defaultAddressPoolID := c.appGwIdentifier.addressPoolID(defaultBackendAddressPoolName)
-		defaultHTTPSettingsID := c.appGwIdentifier.httpSettingsID(defaultBackendHTTPSettingsName)
+		defaultAddressPoolID := c.appGwIdentifier.AddressPoolID(DefaultBackendAddressPoolName)
+		defaultHTTPSettingsID := c.appGwIdentifier.HTTPSettingsID(DefaultBackendHTTPSettingsName)
 		listenerID := defaultFrontendListenerIdentifier()
 		urlPathMaps[listenerID] = &n.ApplicationGatewayURLPathMap{
 			Etag: to.StringPtr("*"),

--- a/pkg/appgw/istio_settings.go
+++ b/pkg/appgw/istio_settings.go
@@ -185,7 +185,7 @@ func (c *appGwConfigBuilder) generateIstioHTTPSettings(destinationID istioDestin
 	httpSettings := n.ApplicationGatewayBackendHTTPSettings{
 		Etag: to.StringPtr("*"),
 		Name: &httpSettingsName,
-		ID:   to.StringPtr(c.appGwIdentifier.httpSettingsID(httpSettingsName)),
+		ID:   to.StringPtr(c.appGwIdentifier.HTTPSettingsID(httpSettingsName)),
 		ApplicationGatewayBackendHTTPSettingsPropertiesFormat: &n.ApplicationGatewayBackendHTTPSettingsPropertiesFormat{
 			Protocol: n.HTTP,
 			Port:     to.Int32Ptr(int32(port)),

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -103,8 +103,8 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 }
 
 func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listenerIdentifier]*n.ApplicationGatewayURLPathMap {
-	defaultAddressPoolID := to.StringPtr(c.appGwIdentifier.addressPoolID(defaultBackendAddressPoolName))
-	defaultHTTPSettingsID := to.StringPtr(c.appGwIdentifier.httpSettingsID(defaultBackendHTTPSettingsName))
+	defaultAddressPoolID := to.StringPtr(c.appGwIdentifier.AddressPoolID(DefaultBackendAddressPoolName))
+	defaultHTTPSettingsID := to.StringPtr(c.appGwIdentifier.HTTPSettingsID(DefaultBackendHTTPSettingsName))
 	urlPathMaps := make(map[listenerIdentifier]*n.ApplicationGatewayURLPathMap)
 	for ingressIdx := range cbCtx.IngressList {
 		ingress := cbCtx.IngressList[ingressIdx]
@@ -138,8 +138,8 @@ func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listen
 	// if no url pathmaps were created, then add a default path map since this will be translated to
 	// a basic request routing rule which is needed on Application Gateway to avoid validation error.
 	if len(urlPathMaps) == 0 {
-		defaultAddressPoolID := c.appGwIdentifier.addressPoolID(defaultBackendAddressPoolName)
-		defaultHTTPSettingsID := c.appGwIdentifier.httpSettingsID(defaultBackendHTTPSettingsName)
+		defaultAddressPoolID := c.appGwIdentifier.AddressPoolID(DefaultBackendAddressPoolName)
+		defaultHTTPSettingsID := c.appGwIdentifier.HTTPSettingsID(DefaultBackendHTTPSettingsName)
 		listenerID := defaultFrontendListenerIdentifier()
 		urlPathMaps[listenerID] = &n.ApplicationGatewayURLPathMap{
 			Etag: to.StringPtr("*"),
@@ -219,8 +219,8 @@ func (c *appGwConfigBuilder) getDefaultFromRule(cbCtx *ConfigBuilderContext, lis
 		defaultHTTPSettings := backendHTTPSettingsMap[defaultBackendID]
 		defaultAddressPool := backendPools[defaultBackendID]
 		if defaultAddressPool != nil && defaultHTTPSettings != nil {
-			defaultAddressPoolID = to.StringPtr(c.appGwIdentifier.addressPoolID(*defaultAddressPool.Name))
-			defaultHTTPSettingsID = to.StringPtr(c.appGwIdentifier.httpSettingsID(*defaultHTTPSettings.Name))
+			defaultAddressPoolID = to.StringPtr(c.appGwIdentifier.AddressPoolID(*defaultAddressPool.Name))
+			defaultHTTPSettingsID = to.StringPtr(c.appGwIdentifier.HTTPSettingsID(*defaultHTTPSettings.Name))
 		}
 	}
 

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -76,8 +76,8 @@ var _ = Describe("Test routing rules generations", func() {
 				for _, rule := range ingress.Spec.Rules {
 					for _, path := range rule.HTTP.Paths {
 						backendID := generateBackendID(ingress, &rule, &path, &path.Backend)
-						backendPoolID := configBuilder.appGwIdentifier.addressPoolID(generateAddressPoolName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), Port(tests.ContainerPort)))
-						httpSettingID := configBuilder.appGwIdentifier.httpSettingsID(generateHTTPSettingsName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), Port(tests.ContainerPort), backendID.Ingress.Name))
+						backendPoolID := configBuilder.appGwIdentifier.AddressPoolID(generateAddressPoolName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), Port(tests.ContainerPort)))
+						httpSettingID := configBuilder.appGwIdentifier.HTTPSettingsID(generateHTTPSettingsName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), Port(tests.ContainerPort), backendID.Ingress.Name))
 						expectedPathRule := n.ApplicationGatewayPathRule{
 							Name: to.StringPtr(generatePathRuleName(backendID.Ingress.Namespace, backendID.Ingress.Name, "0")),
 							Etag: to.StringPtr("*"),
@@ -140,11 +140,11 @@ var _ = Describe("Test routing rules generations", func() {
 		generatedPathMap := pathMaps[sharedListenerID]
 		backendIDBasic := generateBackendID(ingressBasic, &ruleBasic, pathBasic, backendBasic)
 		It("has default backend pool coming from basic ingress", func() {
-			backendPoolID := configBuilder.appGwIdentifier.addressPoolID(generateAddressPoolName(backendIDBasic.serviceFullName(), backendIDBasic.Backend.ServicePort.String(), Port(tests.ContainerPort)))
+			backendPoolID := configBuilder.appGwIdentifier.AddressPoolID(generateAddressPoolName(backendIDBasic.serviceFullName(), backendIDBasic.Backend.ServicePort.String(), Port(tests.ContainerPort)))
 			Expect(*generatedPathMap.DefaultBackendAddressPool.ID).To(Equal(backendPoolID))
 		})
 		It("has default backend http settings coming from basic ingress", func() {
-			httpSettingID := configBuilder.appGwIdentifier.httpSettingsID(generateHTTPSettingsName(backendIDBasic.serviceFullName(), backendIDBasic.Backend.ServicePort.String(), Port(tests.ContainerPort), ingressBasic.Name))
+			httpSettingID := configBuilder.appGwIdentifier.HTTPSettingsID(generateHTTPSettingsName(backendIDBasic.serviceFullName(), backendIDBasic.Backend.ServicePort.String(), Port(tests.ContainerPort), ingressBasic.Name))
 			Expect(*generatedPathMap.DefaultBackendHTTPSettings.ID).To(Equal(httpSettingID))
 		})
 		It("should has 2 path rules", func() {
@@ -154,8 +154,8 @@ var _ = Describe("Test routing rules generations", func() {
 			for _, rule := range ingressPathBased.Spec.Rules {
 				for _, path := range rule.HTTP.Paths {
 					backendID := generateBackendID(ingressPathBased, &rule, &path, &path.Backend)
-					backendPoolID := configBuilder.appGwIdentifier.addressPoolID(generateAddressPoolName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), Port(tests.ContainerPort)))
-					httpSettingID := configBuilder.appGwIdentifier.httpSettingsID(generateHTTPSettingsName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), Port(tests.ContainerPort), backendID.Ingress.Name))
+					backendPoolID := configBuilder.appGwIdentifier.AddressPoolID(generateAddressPoolName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), Port(tests.ContainerPort)))
+					httpSettingID := configBuilder.appGwIdentifier.HTTPSettingsID(generateHTTPSettingsName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), Port(tests.ContainerPort), backendID.Ingress.Name))
 					expectedPathRule := n.ApplicationGatewayPathRule{
 						Name: to.StringPtr(generatePathRuleName(backendID.Ingress.Namespace, backendID.Ingress.Name, "0")),
 						Etag: to.StringPtr("*"),

--- a/pkg/appgw/types.go
+++ b/pkg/appgw/types.go
@@ -23,6 +23,9 @@ type ConfigBuilderContext struct {
 	EnvVariables         environment.EnvVariables
 	IstioGateways        []*v1alpha3.Gateway
 	IstioVirtualServices []*v1alpha3.VirtualService
+
+	DefaultAddressPoolID  *string
+	DefaultHTTPSettingsID *string
 }
 
 // InIngressList returns true if an ingress is in the ingress list

--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -48,6 +48,9 @@ func (c AppGwIngressController) Process(event events.Event) error {
 		ServiceList:  c.k8sContext.ListServices(),
 		IngressList:  c.k8sContext.ListHTTPIngresses(),
 		EnvVariables: environment.GetEnv(),
+
+		DefaultAddressPoolID:  to.StringPtr(c.appGwIdentifier.AddressPoolID(appgw.DefaultBackendAddressPoolName)),
+		DefaultHTTPSettingsID: to.StringPtr(c.appGwIdentifier.HTTPSettingsID(appgw.DefaultBackendHTTPSettingsName)),
 	}
 
 	if cbCtx.EnvVariables.EnableBrownfieldDeployment {


### PR DESCRIPTION
This PR adds `DefaultAddressPoolD` and `DefaultHTTPSettingsID` fields to `ConfigBuilderContext` in preparation for these being used in https://github.com/Azure/application-gateway-kubernetes-ingress/pull/501