### PR TITLE
Mentioned missing annotation appgw.ingress.kubernetes.io/backend-path…

### DIFF
--- a/docs/examples/guestbook/ing-guestbook-other.yaml
+++ b/docs/examples/guestbook/ing-guestbook-other.yaml
@@ -4,6 +4,7 @@ metadata:
   name: guestbook
   annotations:
     kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/backend-path-prefix: /
 spec:
   rules:
   - http:


### PR DESCRIPTION
…-prefix

We really had a hard time to set up a cluster from scratch deploying our ASP.NET Core based services. The missing part in the otherwise well written Tutorial was the information that one had to use the `appgw.ingress.kubernetes.io/backend-path-prefix` annotation to make it work.