### PR TITLE
Lower the amount of Idle logs

### DIFF
--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -286,7 +286,7 @@ func (c *Context) GetService(serviceKey string) *v1.Service {
 	}
 
 	if !exist {
-		glog.V(3).Infof("unable to get service from store, no such service %s", serviceKey)
+		glog.V(9).Infof("Service %s does not exist", serviceKey)
 		return nil
 	}
 

--- a/pkg/worker/fake.go
+++ b/pkg/worker/fake.go
@@ -20,8 +20,8 @@ func (fp FakeProcessor) Process(event events.Event) error {
 }
 
 // ShouldProcess will return true
-func (fp FakeProcessor) ShouldProcess(event events.Event) (bool, string) {
-	return true, ""
+func (fp FakeProcessor) ShouldProcess(event events.Event) (bool, *string) {
+	return true, nil
 }
 
 // NewFakeProcessor returns a fake processor struct.

--- a/pkg/worker/types.go
+++ b/pkg/worker/types.go
@@ -12,7 +12,7 @@ import (
 // EventProcessor provides a mechanism to act on events in the internal queue.
 type EventProcessor interface {
 	Process(events.Event) error
-	ShouldProcess(events.Event) (bool, string)
+	ShouldProcess(events.Event) (bool, *string)
 }
 
 // Worker listens on the eventChannel and runs the EventProcessor.Process

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -21,19 +21,19 @@ func (w *Worker) Run(work chan events.Event, stopChannel chan struct{}) {
 		select {
 		case event := <-work:
 			if shouldProcess, reason := w.ShouldProcess(event); !shouldProcess {
-				if reason != "" {
-					glog.V(5).Infof("Skipping event: %s", reason)
+				if reason != nil {
+					// This log statement could potentially generate a large amount of log lines and most could be
+					// innocuous - for instance: "endpoint default/aad-pod-identity-mic is not used by any Ingress"
+					glog.V(9).Infof("Skipping event. Reason: %s", *reason)
 				}
 				continue
 			}
 
-			// Use callback to process event.
 			if err := w.Process(event); err != nil {
 				glog.Error("Processing event failed:", err)
 				time.Sleep(sleepOnErrorSeconds * time.Second)
-			} else {
-				glog.V(3).Infoln("Successfully processed event")
 			}
+
 		case <-stopChannel:
 			break
 		}


### PR DESCRIPTION
At log level 5 we generate log lines that provide little to no value.

Example:
```
I0903 16:23:29.852755   22730 context.go:289] Service default/aad-pod-identity-mic does not exist
I0903 16:23:29.852793   22730 worker.go:27] Skipping event. Reason: endpoint default/aad-pod-identity-mic is not used by any Ingress
```

These messages could be valuable to help understand why certain backends are not created. In the current state these are being emitted too often. I'm moving these to log level 9 (for dev purposes only) and will continue to iterate on a solution to surface this, but in less noisy and repetitive way.

This PR fixes issue https://github.com/Azure/application-gateway-kubernetes-ingress/issues/505