### PR TITLE
Export k8scontext convertSecret function

### DIFF
--- a/pkg/k8scontext/ingress_handlers.go
+++ b/pkg/k8scontext/ingress_handlers.go
@@ -30,7 +30,7 @@ func (h handlers) ingressAdd(obj interface{}) {
 
 			if secret, exists, err := h.context.Caches.Secret.GetByKey(secKey); exists && err == nil {
 				if !h.context.ingressSecretsMap.ContainsValue(secKey) {
-					if err := h.context.CertificateSecretStore.convertSecret(secKey, secret.(*v1.Secret)); err != nil {
+					if err := h.context.CertificateSecretStore.ConvertSecret(secKey, secret.(*v1.Secret)); err != nil {
 						continue
 					}
 				}
@@ -91,7 +91,7 @@ func (h handlers) ingressUpdate(oldObj, newObj interface{}) {
 
 			if secret, exists, err := h.context.Caches.Secret.GetByKey(secKey); exists && err == nil {
 				if !h.context.ingressSecretsMap.ContainsValue(secKey) {
-					if err := h.context.CertificateSecretStore.convertSecret(secKey, secret.(*v1.Secret)); err != nil {
+					if err := h.context.CertificateSecretStore.ConvertSecret(secKey, secret.(*v1.Secret)); err != nil {
 						continue
 					}
 				}

--- a/pkg/k8scontext/secrets_handlers.go
+++ b/pkg/k8scontext/secrets_handlers.go
@@ -21,7 +21,7 @@ func (h handlers) secretAdd(obj interface{}) {
 	secKey := utils.GetResourceKey(sec.Namespace, sec.Name)
 	if h.context.ingressSecretsMap.ContainsValue(secKey) {
 		// find if this secKey exists in the map[string]UnorderedSets
-		if err := h.context.CertificateSecretStore.convertSecret(secKey, sec); err == nil {
+		if err := h.context.CertificateSecretStore.ConvertSecret(secKey, sec); err == nil {
 			h.context.Work <- events.Event{
 				Type:  events.Create,
 				Value: obj,
@@ -38,7 +38,7 @@ func (h handlers) secretUpdate(oldObj, newObj interface{}) {
 	sec := newObj.(*v1.Secret)
 	secKey := utils.GetResourceKey(sec.Namespace, sec.Name)
 	if h.context.ingressSecretsMap.ContainsValue(secKey) {
-		if err := h.context.CertificateSecretStore.convertSecret(secKey, sec); err == nil {
+		if err := h.context.CertificateSecretStore.ConvertSecret(secKey, sec); err == nil {
 			h.context.Work <- events.Event{
 				Type:  events.Update,
 				Value: newObj,

--- a/pkg/k8scontext/secretstore.go
+++ b/pkg/k8scontext/secretstore.go
@@ -26,7 +26,7 @@ const (
 // SecretsKeeper is the interface definition for secret store
 type SecretsKeeper interface {
 	GetPfxCertificate(secretKey string) []byte
-	convertSecret(secretKey string, secret *v1.Secret) error
+	ConvertSecret(secretKey string, secret *v1.Secret) error
 	delete(secretKey string)
 }
 
@@ -45,8 +45,7 @@ func NewSecretStore() SecretsKeeper {
 
 // GetPfxCertificate returns the certificate for the given secret key.
 func (s *SecretsStore) GetPfxCertificate(secretKey string) []byte {
-	certInterface, exists := s.Cache.Get(secretKey)
-	if exists {
+	if certInterface, exists := s.Cache.Get(secretKey); exists {
 		if cert, ok := certInterface.([]byte); ok {
 			return cert
 		}
@@ -61,7 +60,7 @@ func (s *SecretsStore) delete(secretKey string) {
 	s.Cache.Delete(secretKey)
 }
 
-func (s *SecretsStore) convertSecret(secretKey string, secret *v1.Secret) error {
+func (s *SecretsStore) ConvertSecret(secretKey string, secret *v1.Secret) error {
 	s.conversionSync.Lock()
 	defer s.conversionSync.Unlock()
 

--- a/pkg/k8scontext/secretstore_test.go
+++ b/pkg/k8scontext/secretstore_test.go
@@ -13,16 +13,16 @@ import (
 
 var _ = ginkgo.Describe("Testing K8sContext.SecretStore", func() {
 	secretsStore := NewSecretStore()
-	ginkgo.Context("Test convertSecret function", func() {
+	ginkgo.Context("Test ConvertSecret function", func() {
 		secret := v1.Secret{}
 		ginkgo.It("Should have returned an error - unrecognized type of secret", func() {
-			err := secretsStore.convertSecret("someKey", &secret)
+			err := secretsStore.ConvertSecret("someKey", &secret)
 			Expect(err).To(Equal(ErrorUnknownSecretType))
 		})
 		ginkgo.It("", func() {
 			malformed := secret
 			malformed.Type = recognizedSecretType
-			err := secretsStore.convertSecret("someKey", &malformed)
+			err := secretsStore.ConvertSecret("someKey", &malformed)
 			Expect(err).To(Equal(ErrorMalformedSecret))
 		})
 		ginkgo.It("", func() {
@@ -31,7 +31,7 @@ var _ = ginkgo.Describe("Testing K8sContext.SecretStore", func() {
 			malformed.Data = make(map[string][]byte)
 			malformed.Data[tlsKey] = []byte("X")
 			malformed.Data[tlsCrt] = []byte("Y")
-			err := secretsStore.convertSecret("someKey", &malformed)
+			err := secretsStore.ConvertSecret("someKey", &malformed)
 			Expect(err).To(Equal(ErrorExportingWithOpenSSL))
 		})
 		ginkgo.It("", func() {
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("Testing K8sContext.SecretStore", func() {
 				"o1nu88fKxKLEH6kcBzx35dt3CmMsHCXgX58R+OHD8boJteLkkuc+h+mzO7G8h/Bv\n" +
 				"LloWsUALcQTN0LMl33F8\n" +
 				"-----END CERTIFICATE-----\n")
-			err := secretsStore.convertSecret("someKey", &goodSecret)
+			err := secretsStore.ConvertSecret("someKey", &goodSecret)
 			Expect(err).ToNot(HaveOccurred())
 			actual := secretsStore.GetPfxCertificate("someKey")
 			Expect(len(actual)).To(Equal(2477))


### PR DESCRIPTION
This PR renames `convertSecret` to `ConvertSecret`, which makes it accessible by external entities, and allows easier unit test setup.