### PR TITLE
Drain the Work channel; Use the last event only

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -62,7 +62,7 @@ func (c *AppGwIngressController) Start(envVariables environment.EnvVariables) er
 	}
 
 	// Starts Worker processing events from k8sContext
-	go c.worker.Run(c.k8sContext.Work, c.k8sContext.LastSync, c.stopChannel)
+	go c.worker.Run(c.k8sContext.Work, c.stopChannel)
 	return nil
 }
 

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -21,7 +21,6 @@ const (
 
 // Event is the combined type and actual object we received from Kubernetes
 type Event struct {
-	Type      EventType
-	Value     interface{}
-	Timestamp int64
+	Type  EventType
+	Value interface{}
 }

--- a/pkg/k8scontext/handlers.go
+++ b/pkg/k8scontext/handlers.go
@@ -2,9 +2,6 @@ package k8scontext
 
 import (
 	"reflect"
-	"time"
-
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 )
@@ -15,12 +12,9 @@ type handlers struct {
 
 // general resource handlers
 func (h handlers) addFunc(obj interface{}) {
-	currentTime := time.Now().UnixNano()
-	h.context.LastSync = to.Int64Ptr(currentTime)
 	h.context.Work <- events.Event{
-		Type:      events.Create,
-		Value:     obj,
-		Timestamp: currentTime,
+		Type:  events.Create,
+		Value: obj,
 	}
 }
 
@@ -28,21 +22,15 @@ func (h handlers) updateFunc(oldObj, newObj interface{}) {
 	if reflect.DeepEqual(oldObj, newObj) {
 		return
 	}
-	currentTime := time.Now().UnixNano()
-	h.context.LastSync = to.Int64Ptr(currentTime)
 	h.context.Work <- events.Event{
-		Type:      events.Update,
-		Value:     newObj,
-		Timestamp: currentTime,
+		Type:  events.Update,
+		Value: newObj,
 	}
 }
 
 func (h handlers) deleteFunc(obj interface{}) {
-	currentTime := time.Now().UnixNano()
-	h.context.LastSync = to.Int64Ptr(currentTime)
 	h.context.Work <- events.Event{
-		Type:      events.Delete,
-		Value:     obj,
-		Timestamp: currentTime,
+		Type:  events.Delete,
+		Value: obj,
 	}
 }

--- a/pkg/k8scontext/ingress_handlers.go
+++ b/pkg/k8scontext/ingress_handlers.go
@@ -2,9 +2,7 @@ package k8scontext
 
 import (
 	"reflect"
-	"time"
 
-	"github.com/Azure/go-autorest/autorest/to"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
@@ -41,13 +39,9 @@ func (h handlers) ingressAdd(obj interface{}) {
 			h.context.ingressSecretsMap.Insert(ingKey, secKey)
 		}
 	}
-
-	currentTime := time.Now().UnixNano()
-	h.context.LastSync = to.Int64Ptr(currentTime)
 	h.context.Work <- events.Event{
-		Type:      events.Create,
-		Value:     obj,
-		Timestamp: currentTime,
+		Type:  events.Create,
+		Value: obj,
 	}
 }
 
@@ -70,12 +64,9 @@ func (h handlers) ingressDelete(obj interface{}) {
 	ingKey := utils.GetResourceKey(ing.Namespace, ing.Name)
 	h.context.ingressSecretsMap.Erase(ingKey)
 
-	currentTime := time.Now().UnixNano()
-	h.context.LastSync = to.Int64Ptr(currentTime)
 	h.context.Work <- events.Event{
-		Type:      events.Delete,
-		Value:     obj,
-		Timestamp: currentTime,
+		Type:  events.Delete,
+		Value: obj,
 	}
 }
 
@@ -110,11 +101,8 @@ func (h handlers) ingressUpdate(oldObj, newObj interface{}) {
 		}
 	}
 
-	currentTime := time.Now().UnixNano()
-	h.context.LastSync = to.Int64Ptr(currentTime)
 	h.context.Work <- events.Event{
-		Type:      events.Update,
-		Value:     newObj,
-		Timestamp: currentTime,
+		Type:  events.Update,
+		Value: newObj,
 	}
 }

--- a/pkg/k8scontext/secrets_handlers.go
+++ b/pkg/k8scontext/secrets_handlers.go
@@ -7,9 +7,7 @@ package k8scontext
 
 import (
 	"reflect"
-	"time"
 
-	"github.com/Azure/go-autorest/autorest/to"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -24,12 +22,9 @@ func (h handlers) secretAdd(obj interface{}) {
 	if h.context.ingressSecretsMap.ContainsValue(secKey) {
 		// find if this secKey exists in the map[string]UnorderedSets
 		if err := h.context.CertificateSecretStore.ConvertSecret(secKey, sec); err == nil {
-			currentTime := time.Now().UnixNano()
-			h.context.LastSync = to.Int64Ptr(currentTime)
 			h.context.Work <- events.Event{
-				Type:      events.Create,
-				Value:     obj,
-				Timestamp: currentTime,
+				Type:  events.Create,
+				Value: obj,
 			}
 		}
 	}
@@ -44,12 +39,9 @@ func (h handlers) secretUpdate(oldObj, newObj interface{}) {
 	secKey := utils.GetResourceKey(sec.Namespace, sec.Name)
 	if h.context.ingressSecretsMap.ContainsValue(secKey) {
 		if err := h.context.CertificateSecretStore.ConvertSecret(secKey, sec); err == nil {
-			currentTime := time.Now().UnixNano()
-			h.context.LastSync = to.Int64Ptr(currentTime)
 			h.context.Work <- events.Event{
-				Type:      events.Update,
-				Value:     newObj,
-				Timestamp: currentTime,
+				Type:  events.Update,
+				Value: newObj,
 			}
 		}
 	}
@@ -72,12 +64,9 @@ func (h handlers) secretDelete(obj interface{}) {
 	secKey := utils.GetResourceKey(sec.Namespace, sec.Name)
 	h.context.CertificateSecretStore.delete(secKey)
 	if h.context.ingressSecretsMap.ContainsValue(secKey) {
-		currentTime := time.Now().UnixNano()
-		h.context.LastSync = to.Int64Ptr(currentTime)
 		h.context.Work <- events.Event{
-			Type:      events.Delete,
-			Value:     obj,
-			Timestamp: currentTime,
+			Type:  events.Delete,
+			Value: obj,
 		}
 	}
 }

--- a/pkg/k8scontext/types.go
+++ b/pkg/k8scontext/types.go
@@ -54,8 +54,6 @@ type Context struct {
 	Work chan events.Event
 
 	CacheSynced chan interface{}
-
-	LastSync *int64
 }
 
 // IPAddress is type for IP address string

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -29,7 +29,7 @@ func drainChan(ch chan events.Event, defaultEvent events.Event) events.Event {
 }
 
 // Run starts the worker which listens for events in eventChannel; stops when stopChannel is closed.
-func (w *Worker) Run(work chan events.Event, lastSync *int64, stopChannel chan struct{}) {
+func (w *Worker) Run(work chan events.Event, stopChannel chan struct{}) {
 	glog.V(1).Infoln("Worker started")
 	for {
 		select {
@@ -40,11 +40,6 @@ func (w *Worker) Run(work chan events.Event, lastSync *int64, stopChannel chan s
 					// innocuous - for instance: "endpoint default/aad-pod-identity-mic is not used by any Ingress"
 					glog.V(9).Infof("Skipping event. Reason: %s", *reason)
 				}
-				continue
-			}
-
-			if lastSync != nil && event.Timestamp < *lastSync {
-				glog.V(5).Infof("Skipping event %d as time stamp is before last sync %d", event.Timestamp, *lastSync)
 				continue
 			}
 

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -38,15 +38,12 @@ var _ = Describe("Worker Test", func() {
 			worker := Worker{
 				EventProcessor: eventProcessor,
 			}
-			var lastSync *int64
-
-			go worker.Run(work, lastSync, stopChannel)
+			go worker.Run(work, stopChannel)
 
 			ingress := *tests.NewIngressFixture()
 			work <- events.Event{
-				Type:      events.Create,
-				Value:     ingress,
-				Timestamp: time.Now().Add(999 * time.Hour).UnixNano(),
+				Type:  events.Create,
+				Value: ingress,
 			}
 
 			processCalled := false

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -61,4 +61,40 @@ var _ = Describe("Worker Test", func() {
 			Expect(processCalled).To(Equal(true), "Worker was not able to call process function within timeout")
 		})
 	})
+
+	Context("Verify that drainChan works", func() {
+		It("Should drain the channel and return the last element", func() {
+			buffSize := 10
+			counter := int64(0)
+
+			// Create and fill the channel
+			work := make(chan events.Event, buffSize)
+		Fill:
+			for {
+				select {
+				case work <- events.Event{Timestamp: counter}:
+					counter++
+				default:
+					break Fill
+				}
+			}
+			def := events.Event{Timestamp: int64(1234567890)}
+
+			lastEvent := drainChan(work, def)
+
+			Expect(lastEvent).To(Equal(events.Event{Timestamp: int64(9)}))
+		})
+	})
+
+	Context("Verify that drainChan works", func() {
+		It("Should drain the channel and return the default element", func() {
+			buffSize := 10
+
+			// Keep the channel empty
+			work := make(chan events.Event, buffSize)
+			def := events.Event{Timestamp: int64(1234567890)}
+			lastEvent := drainChan(work, def)
+			Expect(lastEvent).To(Equal(def))
+		})
+	})
 })

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -78,10 +78,10 @@ var _ = Describe("Worker Test", func() {
 					break Fill
 				}
 			}
+			Expect(counter).To(Equal(int64(len(work))))
 			def := events.Event{Timestamp: int64(1234567890)}
-
 			lastEvent := drainChan(work, def)
-
+			Expect(len(work)).To(Equal(0))
 			Expect(lastEvent).To(Equal(events.Event{Timestamp: int64(9)}))
 		})
 	})

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -69,17 +69,17 @@ var _ = Describe("Worker Test", func() {
 		Fill:
 			for {
 				select {
-				case work <- events.Event{Timestamp: counter}:
+				case work <- events.Event{}:
 					counter++
 				default:
 					break Fill
 				}
 			}
 			Expect(counter).To(Equal(int64(len(work))))
-			def := events.Event{Timestamp: int64(1234567890)}
+			def := events.Event{}
 			lastEvent := drainChan(work, def)
 			Expect(len(work)).To(Equal(0))
-			Expect(lastEvent).To(Equal(events.Event{Timestamp: int64(9)}))
+			Expect(lastEvent).To(Equal(events.Event{}))
 		})
 	})
 
@@ -89,7 +89,7 @@ var _ = Describe("Worker Test", func() {
 
 			// Keep the channel empty
 			work := make(chan events.Event, buffSize)
-			def := events.Event{Timestamp: int64(1234567890)}
+			def := events.Event{}
 			lastEvent := drainChan(work, def)
 			Expect(lastEvent).To(Equal(def))
 		})


### PR DESCRIPTION
This PR introduces a new function - `drainChan()`

The goal is to always work on the very last event within our buffered channel.
This is acceptable, since the Ingress Controller always queries for the Ingress, Service, Endpoints etc. and does not need the entire chain of events.

This will prevent overwhelming ARM with too many consecutive PUTs when the channel fills up quicker than ARM can apply config.