### PR TITLE
Do not break on unresolved backends

### DIFF
--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -158,7 +158,7 @@ func (c *appGwConfigBuilder) getBackendsAndSettingsMap(cbCtx *ConfigBuilderConte
 	}
 
 	if len(unresolvedBackendID) > 0 {
-		return nil, nil, nil, ErrResolvingBackendPortForService
+		glog.Warningf("Unable to resolve %d backends: %+v", len(unresolvedBackendID), unresolvedBackendID)
 	}
 
 	httpSettingsCollection := make(map[string]n.ApplicationGatewayBackendHTTPSettings)


### PR DESCRIPTION
It is possible to get in a situation where some pods are in Pending state, hence we cant find resolve here - and the `unresolvedBackendID` below has non-zero length.

The ingress controller should not break in this situation. There are already plenty of logs around this issue. Adding one more warning and continue.