### PR TITLE
Moving errors/errors.go -> annotations/errors.go

### DIFF
--- a/pkg/annotations/errors.go
+++ b/pkg/annotations/errors.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package errors
+package annotations
 
 import (
 	"fmt"

--- a/pkg/annotations/errors_test.go
+++ b/pkg/annotations/errors_test.go
@@ -11,9 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package errors
+package annotations
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestIsMissingAnnotations(t *testing.T) {
 	if !IsMissingAnnotations(ErrMissingAnnotations) {

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/knative/pkg/apis/istio/v1alpha3"
 	"k8s.io/api/extensions/v1beta1"
-
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/errors"
 )
 
 const (
@@ -86,7 +84,7 @@ func IsIstioGatewayIngress(gateway *v1alpha3.Gateway) (bool, error) {
 	if ok {
 		return val == ApplicationGatewayIngressClass, nil
 	}
-	return false, errors.ErrMissingAnnotations
+	return false, ErrMissingAnnotations
 }
 
 // IsSslRedirect for HTTP end points.
@@ -135,7 +133,7 @@ func BackendProtocol(ing *v1beta1.Ingress) (ProtocolEnum, error) {
 		return protocolEnum, nil
 	}
 
-	return HTTP, errors.NewInvalidAnnotationContent(BackendProtocolKey, protocol)
+	return HTTP, NewInvalidAnnotationContent(BackendProtocolKey, protocol)
 }
 
 func parseBool(ing *v1beta1.Ingress, name string) (bool, error) {
@@ -143,16 +141,16 @@ func parseBool(ing *v1beta1.Ingress, name string) (bool, error) {
 		if boolVal, err := strconv.ParseBool(val); err == nil {
 			return boolVal, nil
 		}
-		return false, errors.NewInvalidAnnotationContent(name, val)
+		return false, NewInvalidAnnotationContent(name, val)
 	}
-	return false, errors.ErrMissingAnnotations
+	return false, ErrMissingAnnotations
 }
 
 func parseString(ing *v1beta1.Ingress, name string) (string, error) {
 	if val, ok := ing.Annotations[name]; ok {
 		return val, nil
 	}
-	return "", errors.ErrMissingAnnotations
+	return "", ErrMissingAnnotations
 }
 
 func parseInt32(ing *v1beta1.Ingress, name string) (int32, error) {
@@ -160,8 +158,8 @@ func parseInt32(ing *v1beta1.Ingress, name string) (int32, error) {
 		if intVal, err := strconv.Atoi(val); err == nil {
 			return int32(intVal), nil
 		}
-		return 0, errors.NewInvalidAnnotationContent(name, val)
+		return 0, NewInvalidAnnotationContent(name, val)
 	}
 
-	return 0, errors.ErrMissingAnnotations
+	return 0, ErrMissingAnnotations
 }

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/knative/pkg/apis/istio/v1alpha3"
 	"testing"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/errors"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/extensions/v1beta1"
@@ -231,7 +230,7 @@ func TestParseBoolInvalid(t *testing.T) {
 	value := "nope"
 	ingress.Annotations[key] = value
 	parsedVal, err := parseBool(&ingress, key)
-	if !errors.IsInvalidContent(err) {
+	if !IsInvalidContent(err) {
 		t.Error(fmt.Sprintf(Error, err, parsedVal, err))
 	}
 }
@@ -240,8 +239,8 @@ func TestParseBoolMissingKey(t *testing.T) {
 	key := "key"
 	delete(ingress.Annotations, key)
 	parsedVal, err := parseBool(&ingress, key)
-	if !errors.IsMissingAnnotations(err) || parsedVal {
-		t.Error(fmt.Sprintf(Error, errors.ErrMissingAnnotations, parsedVal, err))
+	if !IsMissingAnnotations(err) || parsedVal {
+		t.Error(fmt.Sprintf(Error, ErrMissingAnnotations, parsedVal, err))
 	}
 }
 
@@ -260,7 +259,7 @@ func TestParseInt32Invalid(t *testing.T) {
 	value := "20asd"
 	ingress.Annotations[key] = value
 	parsedVal, err := parseInt32(&ingress, key)
-	if !errors.IsInvalidContent(err) {
+	if !IsInvalidContent(err) {
 		t.Error(fmt.Sprintf(Error, err, parsedVal, err))
 	}
 }
@@ -269,8 +268,8 @@ func TestParseInt32MissingKey(t *testing.T) {
 	key := "key"
 	delete(ingress.Annotations, key)
 	parsedVal, err := parseInt32(&ingress, key)
-	if !errors.IsMissingAnnotations(err) || parsedVal != 0 {
-		t.Error(fmt.Sprintf(Error, errors.ErrMissingAnnotations, parsedVal, err))
+	if !IsMissingAnnotations(err) || parsedVal != 0 {
+		t.Error(fmt.Sprintf(Error, ErrMissingAnnotations, parsedVal, err))
 	}
 }
 
@@ -288,7 +287,7 @@ func TestParseStringMissingKey(t *testing.T) {
 	key := "key"
 	delete(ingress.Annotations, key)
 	parsedVal, err := parseString(&ingress, key)
-	if !errors.IsMissingAnnotations(err) {
-		t.Error(fmt.Sprintf(Error, errors.ErrMissingAnnotations, parsedVal, err))
+	if !IsMissingAnnotations(err) {
+		t.Error(fmt.Sprintf(Error, ErrMissingAnnotations, parsedVal, err))
 	}
 }

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/brownfield"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/errors"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 )
@@ -222,7 +221,7 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 
 	if pathPrefix, err := annotations.BackendPathPrefix(backendID.Ingress); err == nil {
 		httpSettings.Path = to.StringPtr(pathPrefix)
-	} else if !errors.IsMissingAnnotations(err) {
+	} else if !annotations.IsMissingAnnotations(err) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
 	}
 
@@ -236,25 +235,25 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 		} else {
 			httpSettings.ConnectionDraining.DrainTimeoutInSec = to.Int32Ptr(DefaultConnDrainTimeoutInSec)
 		}
-	} else if err != nil && !errors.IsMissingAnnotations(err) {
+	} else if err != nil && !annotations.IsMissingAnnotations(err) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
 	}
 
 	if affinity, err := annotations.IsCookieBasedAffinity(backendID.Ingress); err == nil && affinity {
 		httpSettings.CookieBasedAffinity = n.Enabled
-	} else if err != nil && !errors.IsMissingAnnotations(err) {
+	} else if err != nil && !annotations.IsMissingAnnotations(err) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
 	}
 
 	if reqTimeout, err := annotations.RequestTimeout(backendID.Ingress); err == nil {
 		httpSettings.RequestTimeout = to.Int32Ptr(reqTimeout)
-	} else if !errors.IsMissingAnnotations(err) {
+	} else if !annotations.IsMissingAnnotations(err) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
 	}
 
 	if backendProtocol, err := annotations.BackendProtocol(backendID.Ingress); err == nil && backendProtocol == annotations.HTTPS {
 		httpSettings.Protocol = n.HTTPS
-	} else if err != nil && !errors.IsMissingAnnotations(err) {
+	} else if err != nil && !annotations.IsMissingAnnotations(err) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
 	}
 

--- a/pkg/controller/prune.go
+++ b/pkg/controller/prune.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/brownfield"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/errors"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 )
 
@@ -56,7 +55,7 @@ func pruneNoPrivateIP(c *AppGwIngressController, appGw *n.ApplicationGateway, cb
 	appGwHasPrivateIP := appgw.LookupIPConfigurationByType(appGw.FrontendIPConfigurations, true) != nil
 	for _, ingress := range ingressList {
 		usePrivateIP, err := annotations.UsePrivateIP(ingress)
-		if err != nil && errors.IsInvalidContent(err) {
+		if err != nil && annotations.IsInvalidContent(err) {
 			glog.Errorf("Ingress %s/%s has invalid value for annotation %s", ingress.Namespace, ingress.Name, annotations.UsePrivateIPKey)
 		}
 


### PR DESCRIPTION
Since `pkg/errors/errors.go` is used primarily for `pkg/annotations/errors.go` it would make sense to move it closer to where it used.