### PR TITLE
Test with an Ingress with no Rules

### DIFF
--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -78,7 +78,7 @@ func (c *appGwConfigBuilder) newProbesMap(cbCtx *ConfigBuilderContext) (map[stri
 func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n.ApplicationGatewayProbe {
 	// TODO(draychev): remove GetService
 	service := c.k8sContext.GetService(backendID.serviceKey())
-	if service == nil {
+	if service == nil || backendID.Path == nil {
 		return nil
 	}
 	probe := defaultProbe(c.appGwIdentifier, n.HTTP)

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
 )
 
 // appgw_suite_test.go launches these Ginkgo tests
@@ -157,4 +158,23 @@ var _ = Describe("configure App Gateway health probes", func() {
 			Expect(*actual).To(ContainElement(defaultProbe(cb.appGwIdentifier, n.HTTPS)))
 		})
 	})
+
+	Context("test generateHealthProbe()", func() {
+		cb := newConfigBuilderFixture(nil)
+		be := backendIdentifier{
+			serviceIdentifier: serviceIdentifier{
+				Namespace: "default",
+				Name:      "blah",
+			},
+			Ingress: fixtures.GetIngress(),
+			Rule:    nil,
+			Path:    nil,
+			Backend: &v1beta1.IngressBackend{},
+		}
+		pb := cb.generateHealthProbe(be)
+		It("should return nil and not crash", func() {
+			Expect(pb).To(BeNil())
+		})
+	})
+
 })

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -248,9 +248,21 @@ func (c *Context) ListHTTPIngresses() []*v1beta1.Ingress {
 	var ingressList []*v1beta1.Ingress
 	for _, ingressInterface := range c.Caches.Ingress.List() {
 		ingress := ingressInterface.(*v1beta1.Ingress)
-		if hasHTTPRule(ingress) && IsIngressApplicationGateway(ingress) {
-			ingressList = append(ingressList, ingress)
+		ingressList = append(ingressList, ingress)
+	}
+	return filterAndSort(ingressList)
+}
+
+func filterAndSort(ingList []*v1beta1.Ingress) []*v1beta1.Ingress {
+	var ingressList []*v1beta1.Ingress
+	for _, ingress := range ingList {
+		if !IsIngressApplicationGateway(ingress) {
+			continue
 		}
+		if len(ingress.Spec.Rules) > 0 && !hasHTTPRule(ingress) {
+			continue
+		}
+		ingressList = append(ingressList, ingress)
 	}
 	// Sorting the return list ensures that the iterations over this list and
 	// subsequently created structs have deterministic order. This increases

--- a/pkg/k8scontext/k8scontext_test.go
+++ b/pkg/k8scontext/k8scontext_test.go
@@ -411,4 +411,15 @@ var _ = ginkgo.Describe("K8scontext", func() {
 			Expect(len(updatedIngress.Status.LoadBalancer.Ingress)).To(Equal(1))
 		})
 	})
+
+	ginkgo.Context("Filtering Ingress Resources", func() {
+		ginkgo.It("keep ingress, which does not have rules, but has a default backend", func() {
+			ingr, _ := tests.GetVerySimpleIngress()
+			ingrList := []*v1beta1.Ingress{
+				ingr,
+			}
+			finalList := filterAndSort(ingrList)
+			Expect(finalList).To(ContainElement(ingr))
+		})
+	})
 })

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -56,7 +56,7 @@ func GetIngress() (*v1beta1.Ingress, error) {
 	return getIngress("ingress.yaml")
 }
 
-// GetIngress creates an Ingress test fixture.
+// GetVerySimpleIngress creates one very simple Ingress test fixture with no rules.
 func GetVerySimpleIngress() (*v1beta1.Ingress, error) {
 	ingr := []byte(`
 ---
@@ -66,7 +66,6 @@ metadata:
   name: websocket-ingress
   annotations:
     kubernetes.io/ingress.class: azure/application-gateway
-    appgw.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   backend:
     serviceName: websocket-service

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -56,6 +56,30 @@ func GetIngress() (*v1beta1.Ingress, error) {
 	return getIngress("ingress.yaml")
 }
 
+// GetIngress creates an Ingress test fixture.
+func GetVerySimpleIngress() (*v1beta1.Ingress, error) {
+	ingr := []byte(`
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: websocket-ingress
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  backend:
+    serviceName: websocket-service
+    servicePort: 80
+---
+    `)
+	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(ingr, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Ingress), nil
+}
+
 // GetIngressComplex creates an Ingress test fixture with multiple backends and path rules.
 func GetIngressComplex() (*v1beta1.Ingress, error) {
 	return getIngress("ingress-complex.yaml")


### PR DESCRIPTION
In this PR we:

 -- fix a bug, where for an Ingress resource with no Rules we panic (pkg/appgw/health_probes.go)
 -- refactor `ListHTTPIngresses` so it is easier to test
 -- add a new fixture with the simplest possible Ingress -- most importantly - no **Rules**

```yaml
---
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: websocket-ingress
  annotations:
    kubernetes.io/ingress.class: azure/application-gateway
spec:
  backend:
    serviceName: websocket-service
    servicePort: 80
---
```