### PR TITLE
Adding a new User Tag to App Gateway with the Last Update from AGIC

### DIFF
--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -7,7 +7,6 @@ package functests
 
 import (
 	"flag"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/mocks"
 	"testing"
 	"time"
 
@@ -23,16 +22,16 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	. "github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/fake"
 	istio_fake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned/fake"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
-
-	. "github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/mocks"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 )
 
 func TestFunctional(t *testing.T) {

--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -7,6 +7,7 @@ package functests
 
 import (
 	"flag"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/mocks"
 	"testing"
 	"time"
 
@@ -345,7 +346,7 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 			ApplicationGatewayPropertiesFormat: NewAppGwyConfigFixture(),
 		}
 
-		configBuilder = NewConfigBuilder(ctxt, &appGwIdentifier, appGwy, record.NewFakeRecorder(100))
+		configBuilder = NewConfigBuilder(ctxt, &appGwIdentifier, appGwy, record.NewFakeRecorder(100), mocks.Clock{})
 	})
 
 	ginkgo.AfterEach(func() {

--- a/functional_tests/one_ingress_slash_nothing.json
+++ b/functional_tests/one_ingress_slash_nothing.json
@@ -169,6 +169,7 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/one_ingress_slash_slashnothing.json
+++ b/functional_tests/one_ingress_slash_slashnothing.json
@@ -239,6 +239,7 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/three_ingresses.json
+++ b/functional_tests/three_ingresses.json
@@ -392,6 +392,7 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/two_ingresses_same_domain_tls_notls.json
+++ b/functional_tests/two_ingresses_same_domain_tls_notls.json
@@ -303,6 +303,7 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/two_ingresses_slash_slashsomething.json
+++ b/functional_tests/two_ingresses_slash_slashsomething.json
@@ -239,6 +239,7 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	go.opencensus.io v0.22.0 // indirect
 	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 // indirect
+	golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	google.golang.org/api v0.7.0 // indirect
 	google.golang.org/appengine v1.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,8 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac h1:8R1esu+8QioDxo4E4mX6bFztO+dMTM49DNAaWfO5OeY=
+golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -322,6 +324,7 @@ golang.org/x/time v0.0.0-20161028155119-f51c12702a4d/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/tools v0.0.0-20190313210603-aa82965741a9 h1:7Pf/N3ln54fsGsAPsSwSfFhxXGKWHMIRUI/T5x1GP90=
 golang.org/x/tools v0.0.0-20190313210603-aa82965741a9/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/mocks"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 )
@@ -379,10 +380,11 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// Check tags
-		Expect(len(appGW.Tags)).To(Equal(2))
+		Expect(len(appGW.Tags)).To(Equal(3))
 		expected := map[string]*string{
-			tags.ManagedByK8sIngress:    to.StringPtr("a/b/c"),
-			tags.IngressForAKSClusterID: to.StringPtr("/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname"),
+			tags.ManagedByK8sIngress:     to.StringPtr("a/b/c"),
+			tags.IngressForAKSClusterID:  to.StringPtr("/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname"),
+			tags.LastUpdatedByK8sIngress: to.StringPtr("2009-11-17 20:34:58.651387237 +0000 UTC"),
 		}
 		Expect(appGW.Tags).To(Equal(expected))
 	}
@@ -446,7 +448,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		appGw := &n.ApplicationGateway{
 			ApplicationGatewayPropertiesFormat: NewAppGwyConfigFixture(),
 		}
-		configBuilder = NewConfigBuilder(ctxt, &appGwIdentifier, appGw, record.NewFakeRecorder(100))
+		configBuilder = NewConfigBuilder(ctxt, &appGwIdentifier, appGw, record.NewFakeRecorder(100), mocks.Clock{})
 
 		_, ok := configBuilder.(*appGwConfigBuilder)
 		Expect(ok).Should(BeTrue(), "Unable to get the more specific configBuilder implementation")

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -7,6 +7,7 @@ package appgw
 
 import (
 	"fmt"
+	"time"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -202,4 +203,5 @@ func (c *appGwConfigBuilder) addTags() {
 	} else {
 		glog.V(5).Infof("Error while parsing cluster resource ID for tagging: %s", err)
 	}
+	c.appGw.Tags[tags.LastUpdatedByK8sIngress] = to.StringPtr(time.Now().String())
 }

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 )
 
+// Clock is an interface, which allows you to implement your own Time.
 type Clock interface {
 	Now() time.Time
 	After(d time.Duration) <-chan time.Time

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -26,7 +26,7 @@ import (
 // Clock is an interface, which allows you to implement your own Time.
 type Clock interface {
 	Now() time.Time
-	After(d time.Duration) <-chan time.Time
+
 }
 
 // ConfigBuilder is a builder for application gateway configuration

--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -643,6 +643,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --    },
 --    "tags": {
 --        "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+--        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
 --        "managed-by-k8s-ingress": "a/b/c"
 --    }
 --}`

--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			ApplicationGatewayPropertiesFormat: NewAppGwyConfigFixture(),
 		}
 
-		configBuilder := NewConfigBuilder(ctxt, &appGwIdentifier, appGwy, record.NewFakeRecorder(100), mocks.Clock{})
+		configBuilder = NewConfigBuilder(ctxt, &appGwIdentifier, appGwy, record.NewFakeRecorder(100), mocks.Clock{})
 	})
 
 	AfterEach(func() {

--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/mocks"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 )
 
@@ -206,7 +207,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			ApplicationGatewayPropertiesFormat: NewAppGwyConfigFixture(),
 		}
 
-		configBuilder = NewConfigBuilder(ctxt, &appGwIdentifier, appGwy, record.NewFakeRecorder(100))
+		configBuilder := NewConfigBuilder(ctxt, &appGwIdentifier, appGwy, record.NewFakeRecorder(100), mocks.Clock{})
 	})
 
 	AfterEach(func() {
@@ -413,6 +414,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --    },
 --    "tags": {
 --        "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+--        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
 --        "managed-by-k8s-ingress": "a/b/c"
 --    }
 --}`

--- a/pkg/appgw/public_and_private_ip_test.go
+++ b/pkg/appgw/public_and_private_ip_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/mocks"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 )
@@ -275,7 +276,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	}
 
 	// Initialize the `ConfigBuilder`
-	configBuilder := NewConfigBuilder(ctxt, &appGwIdentifier, appGwy, record.NewFakeRecorder(100))
+	configBuilder := NewConfigBuilder(ctxt, &appGwIdentifier, appGwy, record.NewFakeRecorder(100), mocks.Clock{})
 
 	Context("Tests Application Gateway config creation", func() {
 		cbCtx := &ConfigBuilderContext{
@@ -517,6 +518,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --    },
 --    "tags": {
 --        "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+--        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
 --        "managed-by-k8s-ingress": "a/b/c"
 --    }
 --}`

--- a/pkg/azure/tags/consts.go
+++ b/pkg/azure/tags/consts.go
@@ -7,6 +7,7 @@ package tags
 
 // An App Gateway tag: Resources tagged with this are exclusively managed by a Kubernetes Ingress.
 const (
-	ManagedByK8sIngress    = "managed-by-k8s-ingress"
-	IngressForAKSClusterID = "ingress-for-aks-cluster-id"
+	ManagedByK8sIngress     = "managed-by-k8s-ingress"
+	IngressForAKSClusterID  = "ingress-for-aks-cluster-id"
+	LastUpdatedByK8sIngress = "last-updated-by-k8s-ingress"
 )

--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -25,6 +25,11 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
 )
 
+type realClock struct{}
+
+func (realClock) Now() time.Time                         { return time.Now() }
+func (realClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
 // Process is the callback function that will be executed for every event
 // in the EventQueue.
 func (c AppGwIngressController) Process(event events.Event) error {
@@ -99,7 +104,7 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	}
 
 	// Create a configbuilder based on current appgw config
-	configBuilder := appgw.NewConfigBuilder(c.k8sContext, &c.appGwIdentifier, &appGw, c.recorder)
+	configBuilder := appgw.NewConfigBuilder(c.k8sContext, &c.appGwIdentifier, &appGw, c.recorder, realClock)
 
 	// Run validations on the Kubernetes resources which can suggest misconfiguration.
 	if err = configBuilder.PreBuildValidate(cbCtx); err != nil {

--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -104,7 +104,7 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	}
 
 	// Create a configbuilder based on current appgw config
-	configBuilder := appgw.NewConfigBuilder(c.k8sContext, &c.appGwIdentifier, &appGw, c.recorder, realClock)
+	configBuilder := appgw.NewConfigBuilder(c.k8sContext, &c.appGwIdentifier, &appGw, c.recorder, realClock{})
 
 	// Run validations on the Kubernetes resources which can suggest misconfiguration.
 	if err = configBuilder.PreBuildValidate(cbCtx); err != nil {

--- a/pkg/k8scontext/k8scontext_test.go
+++ b/pkg/k8scontext/k8scontext_test.go
@@ -239,7 +239,7 @@ var _ = ginkgo.Describe("K8scontext", func() {
 			// Search Pod list with a subset matching filter
 			service := v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "service",
+					Name:      "service",
 					Namespace: "test-ingress-controller",
 				},
 				Spec: v1.ServiceSpec{
@@ -268,7 +268,7 @@ var _ = ginkgo.Describe("K8scontext", func() {
 			// Filter with a same pod label but different namespace
 			service = v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "service",
+					Name:      "service",
 					Namespace: "different-namespace",
 				},
 				Spec: v1.ServiceSpec{

--- a/pkg/tests/mocks/clock.go
+++ b/pkg/tests/mocks/clock.go
@@ -4,11 +4,13 @@ import (
 	"time"
 )
 
+// Clock is a custom implementation of Time.
 type Clock struct{}
 
+// Now is a static never changing Time.
 func (Clock) Now() time.Time {
 	return time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
-
 }
 
+// After is what it was before.
 func (Clock) After(d time.Duration) <-chan time.Time { return time.After(d) }

--- a/pkg/tests/mocks/clock.go
+++ b/pkg/tests/mocks/clock.go
@@ -1,0 +1,14 @@
+package mocks
+
+import (
+	"time"
+)
+
+type Clock struct{}
+
+func (Clock) Now() time.Time {
+	return time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
+
+}
+
+func (Clock) After(d time.Duration) <-chan time.Time { return time.After(d) }


### PR DESCRIPTION
A very handy tool when troubleshooting App Gateway - AGIC - AKS issues would be a time stamp of the last configuration applied to App Gateway.

What it looks like in the JSON config:
```json
"last-updated-by-k8s-ingress": "2019-09-26 15:01:44.7357874 -0700 PDT m=+2.198648801",
```

What this looks like on [portal](https://portal.azure.com):

![image](https://user-images.githubusercontent.com/49918230/65728195-13d18280-e06f-11e9-9e75-9f60de7abccf.png)
