### PR TITLE
Handle Ingress w/ no Rules (simplest Ingress YAML)

### DIFF
--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -38,7 +38,10 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 	managedPoolsByName := map[string]*n.ApplicationGatewayBackendAddressPool{
 		*defaultPool.Name: &defaultPool,
 	}
-	_, _, serviceBackendPairMap, _ := c.getBackendsAndSettingsMap(cbCtx)
+	_, _, serviceBackendPairMap, err := c.getBackendsAndSettingsMap(cbCtx)
+	if err != nil {
+		glog.Error("Error fetching Backends and Settings: ", err)
+	}
 	for backendID, serviceBackendPair := range serviceBackendPairMap {
 		if pool := c.getBackendAddressPool(backendID, serviceBackendPair, managedPoolsByName); pool != nil {
 			managedPoolsByName[*pool.Name] = pool

--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -429,7 +429,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	})
 
 	Context("Tests Application Gateway config creation with the SIMPLEST possible K8s YAML", func() {
-		ingr := &v1beta1.Ingress{
+		ingressNoRules := &v1beta1.Ingress{
 			Spec: v1beta1.IngressSpec{
 				Backend: &v1beta1.IngressBackend{
 					ServiceName: tests.ServiceName,
@@ -450,7 +450,10 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		cbCtx := &ConfigBuilderContext{
-			IngressList:  []*v1beta1.Ingress{ingr},
+			IngressList: []*v1beta1.Ingress{
+				ingress,
+				ingressNoRules,
+			},
 			ServiceList:  serviceList,
 			EnvVariables: environment.GetFakeEnv(),
 		}

--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -478,7 +478,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --    "properties": {
 --        "backendAddressPools": [
 --            {
---                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/defaultaddresspool",    
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/defaultaddresspool",
 --                "name": "defaultaddresspool",
 --                "properties": {
 --                    "backendAddresses": []
@@ -490,6 +490,18 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --                "etag": "*",
 --                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace-----service-name---80-80---name--",
 --                "name": "bp---namespace-----service-name---80-80---name--",
+--                "properties": {
+--                    "port": 80,
+--                    "probe": {
+--                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http"
+--                    },
+--                    "protocol": "Http"
+--                }
+--            },
+--            {
+--                "etag": "*",
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-80-80---name--",
+--                "name": "bp-test-ingress-controller-hello-world-80-80---name--",
 --                "properties": {
 --                    "port": 80,
 --                    "probe": {
@@ -596,10 +608,10 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/defaultaddresspool"
 --                    },
 --                    "backendHttpSettings": {
---                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace-----service-name---80-80---name--"
+--                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-80-80---name--"
 --                    },
 --                    "httpListener": {
---                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-80"        
+--                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-80"
 --                    },
 --                    "ruleType": "Basic"
 --                }

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -146,7 +146,7 @@ func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listen
 		ingress := cbCtx.IngressList[ingressIdx]
 
 		if len(ingress.Spec.Rules) == 0 {
-			// c.noRulesIngress(cbCtx, ingress, &urlPathMaps)
+			c.noRulesIngress(cbCtx, ingress, &urlPathMaps)
 		}
 
 		for ruleIdx := range ingress.Spec.Rules {

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -146,7 +146,7 @@ func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listen
 		ingress := cbCtx.IngressList[ingressIdx]
 
 		if len(ingress.Spec.Rules) == 0 {
-			c.noRulesIngress(cbCtx, ingress, &urlPathMaps)
+			// c.noRulesIngress(cbCtx, ingress, &urlPathMaps)
 		}
 
 		for ruleIdx := range ingress.Spec.Rules {


### PR DESCRIPTION
This change will add a missing piece in AGIC so that it can properly configure App Gateway for the simplest possible Ingress resource:

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: aspnetapp
  annotations:
    kubernetes.io/ingress.class: azure/application-gateway
spec:
  backend:
    serviceName: aspnetapp
    servicePort: 80
```