### PR TITLE
rbac: Allow for AGIC to query k8s nodes

### DIFF
--- a/helm/ingress-azure/templates/clusterrole.yaml
+++ b/helm/ingress-azure/templates/clusterrole.yaml
@@ -19,6 +19,7 @@ rules:
     - namespaces
     - services
     - events
+    - nodes
   verbs:
     - get
     - list


### PR DESCRIPTION
We introduced a functionality which queries K8s nodes.
For RBAC clusters this requires we allow for AGIC to query `nodes`.
This PR fixes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/566