### PR TITLE
Fix spacing and format of error messages

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -109,10 +109,10 @@ func main() {
 		if err == ErrAppGatewayNotFound {
 			err = azClient.DeployGateway(env.AppGwSubnetID)
 			if err != nil {
-				glog.Fatal("Failed in deploying App gateway", err)
+				glog.Fatal("Error deploying App Gateway: ", err)
 			}
 		} else {
-			glog.Fatal("Failed authenticating with Azure Resource Manager", err)
+			glog.Fatal("Error authenticating with Azure Resource Manager: ", err)
 		}
 	}
 
@@ -199,7 +199,7 @@ func getKubeClientConfig() *rest.Config {
 	if *inCluster {
 		config, err := rest.InClusterConfig()
 		if err != nil {
-			glog.Fatal("Error creating client configuration:", err)
+			glog.Fatal("Error creating client configuration: ", err)
 		}
 		return config
 	}
@@ -211,7 +211,7 @@ func getKubeClientConfig() *rest.Config {
 	// use the current context in kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeConfigFile)
 	if err != nil {
-		glog.Fatal("error creating client configuration:", err)
+		glog.Fatal("Error creating client configuration: ", err)
 	}
 
 	return config
@@ -224,7 +224,7 @@ func getEventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {
 	eventBroadcaster.StartRecordingToSink(sink)
 	hostname, err := os.Hostname()
 	if err != nil {
-		glog.Error("Could not obtain host name from the operating system", err)
+		glog.Error("Error getting host name from the OS: ", err)
 		hostname = "unknown-hostname"
 	}
 	source := v1.EventSource{

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -68,20 +68,20 @@ func NewConfigBuilder(context *k8scontext.Context, appGwIdentifier *Identifier, 
 func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationGateway, error) {
 	err := c.HealthProbesCollection(cbCtx)
 	if err != nil {
-		glog.Errorf("unable to generate Health Probes, error [%v]", err)
+		glog.Error("Error creating Health Probes: ", err)
 		return nil, ErrGeneratingProbes
 	}
 
 	err = c.BackendHTTPSettingsCollection(cbCtx)
 	if err != nil {
-		glog.Errorf("unable to generate backend http settings, error [%v]", err)
+		glog.Error("Error creating Backend HTTP Settings: ", err)
 		return nil, ErrGeneratingBackendSettings
 	}
 
 	// BackendAddressPools depend on BackendHTTPSettings
 	err = c.BackendAddressPools(cbCtx)
 	if err != nil {
-		glog.Errorf("unable to generate backend address pools, error [%v]", err)
+		glog.Error("Error creating Backend Address Pools: ", err)
 		return nil, ErrCreatingBackendPools
 	}
 
@@ -91,14 +91,14 @@ func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationG
 	// The order of operations matters.
 	err = c.Listeners(cbCtx)
 	if err != nil {
-		glog.Errorf("unable to generate frontend listeners, error [%v]", err)
+		glog.Error("Error creating Frontend Listeners: ", err)
 		return nil, ErrGeneratingListeners
 	}
 
 	// SSL redirection configurations created elsewhere will be attached to the appropriate rule in this step.
 	err = c.RequestRoutingRules(cbCtx)
 	if err != nil {
-		glog.Errorf("unable to generate request routing rules, error [%v]", err)
+		glog.Error("Error creating Request Routing Rules: ", err)
 		return nil, ErrGeneratingRoutingRules
 	}
 
@@ -144,7 +144,7 @@ func (c *appGwConfigBuilder) resolvePortName(portName string, backendID *backend
 	resolvedPorts := make(map[int32]interface{})
 	endpoints, err := c.k8sContext.GetEndpointsByService(backendID.serviceKey())
 	if err != nil {
-		glog.Error("Could not fetch endpoint by service key from cache", err)
+		glog.Errorf("Could not fetch endpoints for service %s key from cache: %s", backendID.serviceKey(), err)
 		return resolvedPorts
 	}
 
@@ -200,6 +200,6 @@ func (c *appGwConfigBuilder) addTags() {
 	if aksResourceID, err := azure.ConvertToClusterResourceGroup(c.k8sContext.GetInfrastructureResourceGroupID()); err == nil {
 		c.appGw.Tags[tags.IngressForAKSClusterID] = to.StringPtr(aksResourceID)
 	} else {
-		glog.V(5).Infof("Error while parsing cluster resource ID for tagging: %s", err)
+		glog.Error("Error parsing AKS ID for tag: ", err)
 	}
 }

--- a/pkg/appgw/istio_config.go
+++ b/pkg/appgw/istio_config.go
@@ -14,7 +14,7 @@ func (c *appGwConfigBuilder) resolveIstioPortName(portName string, destinationID
 	resolvedPorts := make(map[Port]interface{})
 	endpoints, err := c.k8sContext.GetEndpointsByService(destinationID.serviceKey())
 	if err != nil {
-		glog.Error("Could not fetch endpoint by service key from cache", err)
+		glog.Error("Error getting endpoints for service %s from cache: %s", destinationID.serviceKey(), err)
 		return resolvedPorts
 	}
 

--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -26,14 +26,14 @@ var keysToDeleteForCache = []string{
 func (c *AppGwIngressController) updateCache(appGw *n.ApplicationGateway) {
 	jsonConfig, err := appGw.MarshalJSON()
 	if err != nil {
-		glog.Error("Could not marshal App Gwy to update cache; Wiping cache.", err)
+		glog.Error("Error marshalling App Gateway config for AGIC cache (will clear cache): ", err)
 		c.configCache = nil
 		return
 	}
 	var sanitized []byte
 	if sanitized, err = deleteKeyFromJSON(jsonConfig, keysToDeleteForCache...); err != nil {
 		// Ran into an error; Wipe the existing cache
-		glog.Error("Failed stripping ETag key from App Gwy config. Wiping cache.", err)
+		glog.Error("Error stripping ETag key from App Gateway config (will clear cache): ", err)
 		c.configCache = nil
 		return
 	}
@@ -47,7 +47,7 @@ func (c *AppGwIngressController) configIsSame(appGw *n.ApplicationGateway) bool 
 	}
 	jsonConfig, err := appGw.MarshalJSON()
 	if err != nil {
-		glog.Error("Could not marshal App Gwy to compare w/ cache; Will not use cache.", err)
+		glog.Error("Error marshalling App Gateway config in order to compare w/ cache (will not use cache): ", err)
 		return false
 	}
 	// The JSON stored in the cache and the newly marshaled JSON will have different ETags even if configs are the same.
@@ -55,7 +55,7 @@ func (c *AppGwIngressController) configIsSame(appGw *n.ApplicationGateway) bool 
 	var sanitized []byte
 	if sanitized, err = deleteKeyFromJSON(jsonConfig, keysToDeleteForCache...); err != nil {
 		// Ran into an error; Don't use cache; Refresh cache w/ new JSON
-		glog.Error("Failed stripping ETag key from App Gwy config. Will not use cache.", err)
+		glog.Error("Error stripping ETag key from App Gwy config (will not use cache): ", err)
 		return false
 	}
 	// The result will be 0 if a==b, -1 if a < b, and +1 if a > b.
@@ -136,7 +136,7 @@ func deleteKey(m *map[string]interface{}, keyToDelete string) {
 func deleteKeyFromJSON(jsonWithEtag []byte, keysToDelete ...string) ([]byte, error) {
 	var m map[string]interface{}
 	if err := json.Unmarshal([]byte(jsonWithEtag), &m); err != nil {
-		glog.Error("Could not unmarshal config App Gwy JSON to delete Etag.", err)
+		glog.Error("Error unmarshalling App Gateway config in order to delete Etag. Error: ", err)
 		return nil, err
 	}
 	for _, keyToDelete := range keysToDelete {

--- a/pkg/controller/process.go
+++ b/pkg/controller/process.go
@@ -94,7 +94,7 @@ func (c AppGwIngressController) Process(event events.Event) error {
 
 	// Run fatal validations on the existing config of the Application Gateway.
 	if err := appgw.FatalValidateOnExistingConfig(c.recorder, appGw.ApplicationGatewayPropertiesFormat, cbCtx.EnvVariables); err != nil {
-		glog.Error("Got a fatal validation error on existing Application Gateway config. Will retry getting Application Gateway until error is resolved:", err)
+		glog.Error("Validation error on existing App Gateway config. Will retry getting App Gateway until error is resolved: ", err)
 		return err
 	}
 
@@ -103,19 +103,19 @@ func (c AppGwIngressController) Process(event events.Event) error {
 
 	// Run validations on the Kubernetes resources which can suggest misconfiguration.
 	if err = configBuilder.PreBuildValidate(cbCtx); err != nil {
-		glog.Error("ConfigBuilder PostBuildValidate returned error:", err)
+		glog.Error("ConfigBuilder PostBuildValidate returned error: ", err)
 	}
 
 	var generatedAppGw *n.ApplicationGateway
 	// Replace the current appgw config with the generated one
 	if generatedAppGw, err = configBuilder.Build(cbCtx); err != nil {
-		glog.Error("ConfigBuilder Build returned error:", err)
+		glog.Error("ConfigBuilder Build returned error: ", err)
 		return err
 	}
 
 	// Run post validations to report errors in the config generation.
 	if err = configBuilder.PostBuildValidate(cbCtx); err != nil {
-		glog.Error("ConfigBuilder PostBuildValidate returned error:", err)
+		glog.Error("ConfigBuilder PostBuildValidate returned error: ", err)
 	}
 
 	if c.configIsSame(&appGw) {
@@ -156,7 +156,7 @@ func (c AppGwIngressController) Process(event events.Event) error {
 	if err != nil {
 		// Reset cache
 		c.configCache = nil
-		glog.Warning("Unable to deploy App Gateway config.", err)
+		glog.Error("Error deploying App Gateway config: ", err)
 		return ErrDeployingAppGatewayConfig
 	}
 

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -56,7 +56,7 @@ func (s *httpServer) Start() {
 	go func() {
 		glog.Infof("Starting API Server on %s", s.server.Addr)
 		if err := s.server.ListenAndServe(); err != nil {
-			glog.Fatal("Failed to start API server", err)
+			glog.Fatal("Error starting API server: ", err)
 		}
 	}()
 }
@@ -65,6 +65,6 @@ func (s *httpServer) Stop() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := s.server.Shutdown(ctx); err != nil {
-		glog.Error("Unable to shutdown API server gracefully", err)
+		glog.Error("Error shuting down API server: ", err)
 	}
 }

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -175,7 +175,7 @@ func (c *Context) Run(stopChannel chan struct{}, omitCRDs bool, envVariables env
 func (c *Context) GetAGICPod(envVariables environment.EnvVariables) *v1.Pod {
 	pod, err := c.kubeClient.CoreV1().Pods(envVariables.AGICPodNamespace).Get(envVariables.AGICPodName, metav1.GetOptions{})
 	if err != nil {
-		glog.Error("Error fetching AGIC Pod (This may happen if AGIC is running in a test environment), error occurred ", err)
+		glog.Error("Error fetching AGIC Pod (is AGIC running in a test environment?): ", err)
 		return nil
 	}
 	return pod
@@ -198,7 +198,7 @@ func (c *Context) GetEndpointsByService(serviceKey string) (*v1.Endpoints, error
 	endpointsInterface, exist, err := c.Caches.Endpoints.GetByKey(serviceKey)
 
 	if err != nil {
-		glog.Error("Error fetching endpoints from store, error occurred ", err)
+		glog.Error("Error fetching endpoints from store: ", err)
 		return nil, err
 	}
 
@@ -303,7 +303,7 @@ func (c *Context) GetService(serviceKey string) *v1.Service {
 	serviceInterface, exist, err := c.Caches.Service.GetByKey(serviceKey)
 
 	if err != nil {
-		glog.V(3).Infof("unable to get service from store, error occurred %s", err)
+		glog.Error("Error getting service from store: ", err)
 		return nil
 	}
 
@@ -326,7 +326,7 @@ func (c *Context) GetSecret(secretKey string) *v1.Secret {
 	}
 
 	if !exist {
-		glog.Error("Error fetching secret from store! Service does not exist:", secretKey)
+		glog.Errorf("Error fetching secret from store! Service %s does not exist!", secretKey)
 		return nil
 	}
 

--- a/pkg/k8scontext/secretstore.go
+++ b/pkg/k8scontext/secretstore.go
@@ -108,7 +108,7 @@ func (s *SecretsStore) ConvertSecret(secretKey string, secret *v1.Secret) error 
 
 	// if openssl exited with an error or the output is empty, report error
 	if err := cmd.Run(); err != nil || len(cout.Bytes()) == 0 {
-		glog.Errorf("unable to export using openssl, error=[%v], stderr=[%v]", err, cerr.String())
+		glog.Errorf("Error exporting certificate using openssl, error=[%v], stderr=[%v]", err, cerr.String())
 		return ErrorExportingWithOpenSSL
 	}
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -46,7 +46,7 @@ func (w *Worker) Run(work chan events.Event, stopChannel chan struct{}) {
 			lastEvent := drainChan(work, event)
 
 			if err := w.Process(lastEvent); err != nil {
-				glog.Error("Processing event failed:", err)
+				glog.Error("Processing event failed: ", err)
 				time.Sleep(sleepOnErrorSeconds * time.Second)
 			}
 


### PR DESCRIPTION
Running through `glog.Error` statements to ensure these are consistently formatted.

This fixes error messages like this:
```
F1001 11:00:09.830006   21788 main.go:115] Failed authenticating with Azure Resource Managernot found (AZUR005)
```