### PR TITLE
Correcting a typo in the naming of frontendPorts resources

### DIFF
--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -318,7 +318,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --        "frontendPorts": [
 --            {
 --                "etag": "*",
---                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontEndPorts/fp-80",
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80",
 --                "name": "fp-80",
 --                "properties": {
 --                    "port": 80
@@ -335,7 +335,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --                        "id": "--front-end-ip-id-1--"
 --                    },
 --                    "frontendPort": {
---                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontEndPorts/fp-80"
+--                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
 --                    },
 --                    "hostName": "foo.baz",
 --                    "protocol": "Http"
@@ -556,7 +556,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --        "frontendPorts": [
 --            {
 --                "etag": "*",
---                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontEndPorts/fp-80",
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80",
 --                "name": "fp-80",
 --                "properties": {
 --                    "port": 80
@@ -573,7 +573,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --                        "id": "--front-end-ip-id-1--"
 --                    },
 --                    "frontendPort": {
---                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontEndPorts/fp-80"
+--                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
 --                    },
 --                    "hostName": "",
 --                    "protocol": "Http"

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			},
 			Name: to.StringPtr("fp-80"),
 			Etag: to.StringPtr("*"),
-			ID:   to.StringPtr(resPref + "frontEndPorts/fp-80"),
+			ID:   to.StringPtr(resPref + "frontendPorts/fp-80"),
 		}
 
 		expectedPort443 = n.ApplicationGatewayFrontendPort{
@@ -91,7 +91,7 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			},
 			Name: to.StringPtr("fp-443"),
 			Etag: to.StringPtr("*"),
-			ID:   to.StringPtr(resPref + "frontEndPorts/fp-443"),
+			ID:   to.StringPtr(resPref + "frontendPorts/fp-443"),
 		}
 
 		expectedListener80 = n.ApplicationGatewayHTTPListener{
@@ -100,7 +100,7 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			ID:   to.StringPtr(resPref + "httpListeners/fl-bye.com-80"),
 			ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
 				FrontendIPConfiguration: resourceRef(tests.PublicIPID),
-				FrontendPort:            resourceRef(resPref + "frontEndPorts/fp-80"),
+				FrontendPort:            resourceRef(resPref + "frontendPorts/fp-80"),
 				Protocol:                n.ApplicationGatewayProtocol("Http"),
 				HostName:                to.StringPtr(tests.Host),
 			},
@@ -112,7 +112,7 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			ID:   to.StringPtr(resPref + "httpListeners/fl-bye.com-80-privateip"),
 			ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
 				FrontendIPConfiguration: resourceRef(tests.PrivateIPID),
-				FrontendPort:            resourceRef(resPref + "frontEndPorts/fp-80"),
+				FrontendPort:            resourceRef(resPref + "frontendPorts/fp-80"),
 				Protocol:                n.ApplicationGatewayProtocol("Http"),
 				HostName:                to.StringPtr(tests.Host),
 			},
@@ -124,7 +124,7 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			ID:   to.StringPtr(resPref + "httpListeners/fl-bye.com-443"),
 			ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
 				FrontendIPConfiguration: resourceRef(tests.PublicIPID),
-				FrontendPort:            resourceRef(resPref + "frontEndPorts/fp-443"),
+				FrontendPort:            resourceRef(resPref + "frontendPorts/fp-443"),
 				Protocol:                n.ApplicationGatewayProtocol("Https"),
 				HostName:                to.StringPtr(tests.Host),
 				SslCertificate:          resourceRef(resPref + "sslCertificates/--namespace-----the-name-of-the-secret--"),
@@ -137,7 +137,7 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 			ID:   to.StringPtr(resPref + "httpListeners/fl-bye.com-443-privateip"),
 			ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
 				FrontendIPConfiguration: resourceRef(tests.PrivateIPID),
-				FrontendPort:            resourceRef(resPref + "frontEndPorts/fp-443"),
+				FrontendPort:            resourceRef(resPref + "frontendPorts/fp-443"),
 				Protocol:                n.ApplicationGatewayProtocol("Https"),
 				HostName:                to.StringPtr(tests.Host),
 				SslCertificate:          resourceRef(resPref + "sslCertificates/--namespace-----the-name-of-the-secret--"),

--- a/pkg/appgw/identifier.go
+++ b/pkg/appgw/identifier.go
@@ -35,11 +35,11 @@ func (agw Identifier) AddressPoolID(poolName string) string {
 }
 
 func (agw Identifier) frontendIPID(fipName string) string {
-	return agw.gatewayResourceID("frontEndIPConfigurations", fipName)
+	return agw.gatewayResourceID("frontendIPConfigurations", fipName)
 }
 
 func (agw Identifier) frontendPortID(portName string) string {
-	return agw.gatewayResourceID("frontEndPorts", portName)
+	return agw.gatewayResourceID("frontendPorts", portName)
 }
 
 func (agw Identifier) sslCertificateID(certname string) string {

--- a/pkg/appgw/public_and_private_ip_test.go
+++ b/pkg/appgw/public_and_private_ip_test.go
@@ -380,7 +380,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --        "frontendPorts": [
 --            {
 --                "etag": "*",
---                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontEndPorts/fp-443",
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-443",
 --                "name": "fp-443",
 --                "properties": {
 --                    "port": 443
@@ -388,7 +388,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --            },
 --            {
 --                "etag": "*",
---                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontEndPorts/fp-80",
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80",
 --                "name": "fp-80",
 --                "properties": {
 --                    "port": 80
@@ -405,7 +405,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --                        "id": "--front-end-ip-id-1--"
 --                    },
 --                    "frontendPort": {
---                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontEndPorts/fp-443"
+--                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-443"
 --                    },
 --                    "hostName": "",
 --                    "protocol": "Https",
@@ -423,7 +423,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --                        "id": "--front-end-ip-id-2--"
 --                    },
 --                    "frontendPort": {
---                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontEndPorts/fp-80"
+--                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
 --                    },
 --                    "hostName": "",
 --                    "protocol": "Http"


### PR DESCRIPTION
When we create IDs for certain resources we capitalize the `E`
App Gateway (or ARM) corrects that automatically.
This results in a difference between the config we create and the config we get from App Gwy.

`frontendPorts` (App Gateway) vs `frontEndPorts` (AGIC)
`frontendIPConfigurations` (App Gateway) vs `frontEndIPConfigurations` (AGIC)

```json
-- Existing App Gwy Config --        "httpListeners": [
-- Existing App Gwy Config --            {
-- Existing App Gwy Config --                "etag": "W/\"aaa\"",
-- Existing App Gwy Config --                "id": "/subscriptions/aaa/resourceGroups/derayche-rg-A/providers/Microsoft.Network/applicationGateways/applicationgatewayd0f0/httpListeners/fl-80",
-- Existing App Gwy Config --                "name": "fl-80",
-- Existing App Gwy Config --                "properties": {
-- Existing App Gwy Config --                    "frontendIPConfiguration": {
-- Existing App Gwy Config --                        "id": "/subscriptions/aaa/resourceGroups/derayche-rg-A/providers/Microsoft.Network/applicationGateways/applicationgatewayd0f0/frontendIPConfigurations/appGatewayFrontendIP"
-- Existing App Gwy Config --                    },
-- Existing App Gwy Config --                    "frontendPort": {
-- Existing App Gwy Config --                        "id": "/subscriptions/aaa/resourceGroups/derayche-rg-A/providers/Microsoft.Network/applicationGateways/applicationgatewayd0f0/frontendPorts/fp-80"
-- Existing App Gwy Config --                    },
-- Existing App Gwy Config --                    "hostName": "",
-- Existing App Gwy Config --                    "protocol": "Http",
-- Existing App Gwy Config --                    "provisioningState": "Succeeded",
-- Existing App Gwy Config --                    "requireServerNameIndication": false
-- Existing App Gwy Config --                },
-- Existing App Gwy Config --                "type": "Microsoft.Network/applicationGateways/httpListeners"
-- Existing App Gwy Config --            }
-- Existing App Gwy Config --        ],
```