### PR TITLE
deploy: add support for Vnet and Subnet Prefix

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -114,7 +114,12 @@ func main() {
 	azClient := azure.NewAzClient(azure.SubscriptionID(env.SubscriptionID), azure.ResourceGroup(env.ResourceGroupName), azure.ResourceName(env.AppGwName), authorizer)
 	if err = azure.WaitForAzureAuth(azClient, maxAuthRetryCount, retryPause); err != nil {
 		if err == azure.ErrAppGatewayNotFound && env.EnableDeployAppGateway {
-			err = azClient.DeployGateway(env.AppGwSubnetID)
+			if env.AppGwSubnetID != "" {
+				err = azClient.DeployGatewayWithSubnet(env.AppGwSubnetID)
+			} else {
+				err = azClient.DeployGatewayWithVnet(env.AppGwVnetID, env.AppGwSubnetPrefix)
+			}
+
 			if err != nil {
 				glog.Fatal("Failed in deploying App gateway", err)
 			}

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -8,6 +8,7 @@ package azure
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	r "github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
@@ -19,17 +20,20 @@ import (
 type AzClient interface {
 	GetGateway() (n.ApplicationGateway, error)
 	UpdateGateway(*n.ApplicationGateway) error
-	DeployGateway(string) error
+	DeployGatewayWithVnet(string, string) error
+	DeployGatewayWithSubnet(string) error
 
 	GetPublicIP(string) (n.PublicIPAddress, error)
 }
 
 type azClient struct {
-	appGatewaysClient n.ApplicationGatewaysClient
-	publicIPsClient   n.PublicIPAddressesClient
-	groupsClient      r.GroupsClient
-	deploymentsClient r.DeploymentsClient
-	authorizer        autorest.Authorizer
+	appGatewaysClient     n.ApplicationGatewaysClient
+	publicIPsClient       n.PublicIPAddressesClient
+	virtualNetworksClient n.VirtualNetworksClient
+	subnetsClient         n.SubnetsClient
+	groupsClient          r.GroupsClient
+	deploymentsClient     r.DeploymentsClient
+	authorizer            autorest.Authorizer
 
 	subscriptionID    SubscriptionID
 	resourceGroupName ResourceGroup
@@ -41,13 +45,15 @@ type azClient struct {
 // NewAzClient returns an Azure Client
 func NewAzClient(subscriptionID SubscriptionID, resourceGroupName ResourceGroup, appGwName ResourceName, authorizer autorest.Authorizer) AzClient {
 	az := &azClient{
-		appGatewaysClient: n.NewApplicationGatewaysClient(string(subscriptionID)),
-		publicIPsClient:   n.NewPublicIPAddressesClient(string(subscriptionID)),
-		groupsClient:      r.NewGroupsClient(string(subscriptionID)),
-		deploymentsClient: r.NewDeploymentsClient(string(subscriptionID)),
-		subscriptionID:    subscriptionID,
-		resourceGroupName: resourceGroupName,
-		appGwName:         appGwName,
+		appGatewaysClient:     n.NewApplicationGatewaysClient(string(subscriptionID)),
+		publicIPsClient:       n.NewPublicIPAddressesClient(string(subscriptionID)),
+		virtualNetworksClient: n.NewVirtualNetworksClient(string(subscriptionID)),
+		subnetsClient:         n.NewSubnetsClient(string(subscriptionID)),
+		groupsClient:          r.NewGroupsClient(string(subscriptionID)),
+		deploymentsClient:     r.NewDeploymentsClient(string(subscriptionID)),
+		subscriptionID:        subscriptionID,
+		resourceGroupName:     resourceGroupName,
+		appGwName:             appGwName,
 
 		ctx:        context.Background(),
 		authorizer: authorizer,
@@ -55,6 +61,8 @@ func NewAzClient(subscriptionID SubscriptionID, resourceGroupName ResourceGroup,
 
 	az.appGatewaysClient.Authorizer = az.authorizer
 	az.publicIPsClient.Authorizer = az.authorizer
+	az.virtualNetworksClient.Authorizer = az.authorizer
+	az.subnetsClient.Authorizer = az.authorizer
 	az.groupsClient.Authorizer = az.authorizer
 	az.publicIPsClient.Authorizer = az.authorizer
 	az.deploymentsClient.Authorizer = az.authorizer
@@ -83,8 +91,32 @@ func (az *azClient) GetPublicIP(resourceID string) (n.PublicIPAddress, error) {
 }
 
 // DeployGateway is a method that deploy the appgw and related resources
-func (az *azClient) DeployGateway(subnetID string) (err error) {
+func (az *azClient) DeployGatewayWithVnet(vnetID string, subnetPrefix string) (err error) {
+	vnet, err := az.getVnet(vnetID)
+	if err != nil {
+		return
+	}
+
+	glog.Infof("Checking the Vnet %s for a subnet with prefix %s", vnetID, subnetPrefix)
+	subnet, err := az.findSubnet(vnet, subnetPrefix)
+	if err != nil {
+		subnetName := string(az.appGwName) + "subnet"
+		glog.Infof("Unable to find a subnet. Creating a subnet %s with prefix %s in Vnet %s", subnetName, subnetPrefix, vnetID)
+		subnet, err = az.createSubnet(vnet, subnetName, subnetPrefix)
+		if err != nil {
+			return
+		}
+	}
+
+	err = az.DeployGatewayWithSubnet(*subnet.ID)
+	return
+}
+
+// DeployGateway is a method that deploy the appgw and related resources
+func (az *azClient) DeployGatewayWithSubnet(subnetID string) (err error) {
 	glog.Infof("Deploying Gateway")
+
+	// Check if group exists
 	group, err := az.getGroup()
 	if err != nil {
 		return
@@ -109,6 +141,42 @@ func (az *azClient) DeployGateway(subnetID string) (err error) {
 // Create a resource group for the deployment.
 func (az *azClient) getGroup() (r.Group, error) {
 	return az.groupsClient.Get(az.ctx, string(az.resourceGroupName))
+}
+
+func (az *azClient) getVnet(vnetID string) (n.VirtualNetwork, error) {
+	_, resourceGroup, vnetName := ParseResourceID(vnetID)
+	return az.virtualNetworksClient.Get(az.ctx, string(resourceGroup), string(vnetName), "")
+}
+
+func (az *azClient) findSubnet(vnet n.VirtualNetwork, subnetPrefix string) (subnet n.Subnet, err error) {
+	for _, subnet := range *vnet.Subnets {
+		if *subnet.AddressPrefix == subnetPrefix {
+			return subnet, nil
+		}
+	}
+	err = errors.New("Unable to find subnet")
+	return
+}
+
+func (az *azClient) createSubnet(vnet n.VirtualNetwork, subnetName string, subnetPrefix string) (subnet n.Subnet, err error) {
+	_, resourceGroup, vnetName := ParseResourceID(*vnet.ID)
+	subnet = n.Subnet{
+		SubnetPropertiesFormat: &n.SubnetPropertiesFormat{
+			AddressPrefix: &subnetPrefix,
+		},
+	}
+	subnetFuture, err := az.subnetsClient.CreateOrUpdate(az.ctx, string(resourceGroup), string(vnetName), subnetName, subnet)
+	if err != nil {
+		return
+	}
+
+	// Wait until deployment finshes and save the error message
+	err = subnetFuture.WaitForCompletionRef(az.ctx, az.subnetsClient.BaseClient.Client)
+	if err != nil {
+		return
+	}
+
+	return az.subnetsClient.Get(az.ctx, string(resourceGroup), string(vnetName), subnetName, "")
 }
 
 // Create the deployment

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -23,8 +23,14 @@ const (
 	// AppGwNameVarName is the name of the APPGW_NAME
 	AppGwNameVarName = "APPGW_NAME"
 
-	// AppGwSubnetIDVarName is the name of the APPGW_SUBNET_ID
+	// AppGwSubnetIDVarName is the name of the APPGW_SUBNETID
 	AppGwSubnetIDVarName = "APPGW_SUBNETID"
+
+	// AppGwVnetIDVarName is the name of the APPGW_VNETID
+	AppGwVnetIDVarName = "APPGW_VNETID"
+
+	// AppGwSubnetPrefixVarName is the name of the APPGW_SUBNETPREFIX
+	AppGwSubnetPrefixVarName = "APPGW_SUBNETPREFIX"
 
 	// ReleaseNameVarName is the name of the RELEASE_NAME
 	ReleaseNameVarName = "RELEASE_NAME"
@@ -72,6 +78,8 @@ type EnvVariables struct {
 	ResourceGroupName          string
 	AppGwName                  string
 	AppGwSubnetID              string
+	AppGwVnetID                string
+	AppGwSubnetPrefix          string
 	ReleaseName                string
 	AuthLocation               string
 	WatchNamespace             string
@@ -97,6 +105,8 @@ func GetEnv() EnvVariables {
 		ResourceGroupName:          os.Getenv(ResourceGroupNameVarName),
 		AppGwName:                  os.Getenv(AppGwNameVarName),
 		AppGwSubnetID:              os.Getenv(AppGwSubnetIDVarName),
+		AppGwVnetID:                os.Getenv(AppGwVnetIDVarName),
+		AppGwSubnetPrefix:          os.Getenv(AppGwSubnetPrefixVarName),
 		ReleaseName:                os.Getenv(ReleaseNameVarName),
 		AuthLocation:               os.Getenv(AuthLocationVarName),
 		WatchNamespace:             os.Getenv(WatchNamespaceVarName),
@@ -118,8 +128,8 @@ func GetEnv() EnvVariables {
 // ValidateEnv validates environment variables.
 func ValidateEnv(env EnvVariables) error {
 	if env.EnableDeployAppGateway {
-		if len(env.AppGwSubnetID) == 0 {
-			return errors.New("Missing required Environment variables: Provide APPGW_SUBNETID (ENVT001)")
+		if (len(env.AppGwVnetID) == 0 || len(env.AppGwSubnetPrefix) == 0) && len(env.AppGwSubnetID) == 0 {
+			return errors.New("Missing required Environment variables: Either provide APPGW_VNETID and APPGW_SUBNETPREFIX or provide APPGW_SUBNETID (ENVT001)")
 		}
 	} else if len(env.SubscriptionID) == 0 || len(env.ResourceGroupName) == 0 || len(env.AppGwName) == 0 {
 		return errors.New("Missing required Environment variables: Provide APPGW_SUBSCRIPTION_ID, APPGW_RESOURCE_GROUP and APPGW_NAME (ENVT002)")


### PR DESCRIPTION
This PR adds support to deploy a AppGW given a Vnet and Subnet Prefix.

Here, we look up the subnet prefix in the Vnet, if we missing we create the gateway, otherwise, we use this subnet for deploying the gateway.