### PR TITLE
azcontext: mount azure.json and file out azcontext

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -88,15 +88,22 @@ func main() {
 	agicPod := k8sContext.GetAGICPod(env)
 	metricStore := metricstore.NewMetricStore(env)
 
+	// get the details from Azure Context
+	azContext, err := azure.NewAzContext(env.AzContextLocation)
+	if err != nil {
+		glog.Info("Unable to load Azure Context file:", env.AzContextLocation)
+	}
+
+	// adjust env variable
 	if env.AppGwName == "" {
 		env.AppGwName = env.ReleaseName
 	}
 
-	if infraSubID, infraResourceGp, err := k8sContext.GetInfrastructureResourceGroupID(); env.SubscriptionID == "" && err != nil {
-		env.SubscriptionID = string(infraSubID)
-		if env.ResourceGroupName == "" {
-			env.ResourceGroupName = string(infraResourceGp)
-		}
+	if azContext != nil && env.SubscriptionID == "" {
+		env.SubscriptionID = string(azContext.SubscriptionID)
+	}
+	if azContext != nil && env.ResourceGroupName == "" {
+		env.ResourceGroupName = string(azContext.ResourceGroup)
 	}
 
 	if err := environment.ValidateEnv(env); err != nil {
@@ -105,7 +112,6 @@ func main() {
 
 	glog.V(3).Infof("App Gateway Details: Subscription: %s, Resource Group: %s, Name: %s", env.SubscriptionID, env.ResourceGroupName, env.AppGwName)
 
-	var err error
 	var authorizer autorest.Authorizer
 	if authorizer, err = azure.GetAuthorizerWithRetry(env.AuthLocation, maxAuthRetryCount, retryPause); err != nil {
 		glog.Fatal("Failed obtaining authentication token for Azure Resource Manager")

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -1,6 +1,3 @@
-{{- if required "A valid armAuth entry is required!" .Values.armAuth }}
-{{- end}}
-
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -43,6 +40,8 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         env:
+        - name: AZURE_LOCATION
+          value: /etc/appgw/azure.json
         - name: AGIC_POD_NAME
           valueFrom:
             fieldRef:
@@ -58,17 +57,23 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ template "application-gateway-kubernetes-ingress.configmapname" . }}
-        {{- if eq .Values.armAuth.type "servicePrincipal"}}
         volumeMounts:
-          - name: networking-appgw-k8s-azure-service-principal-mount
-            mountPath: /etc/Azure/Networking-AppGW/auth
-            readOnly: true
-        {{- end}}
-      {{- if eq .Values.armAuth.type "servicePrincipal"}}
-      volumes:
+        - mountPath: /etc/appgw/azure.json
+          name: azure
+        {{- if eq .Values.armAuth.type "servicePrincipal"}}
         - name: networking-appgw-k8s-azure-service-principal-mount
-          secret:
-            secretName: networking-appgw-k8s-azure-service-principal
+          mountPath: /etc/Azure/Networking-AppGW/auth
+          readOnly: true
+        {{- end}}
+      volumes:
+      - name: azure
+        hostPath:
+          path: /etc/kubernetes/azure.json
+          type: File
+      {{- if eq .Values.armAuth.type "servicePrincipal"}}
+      - name: networking-appgw-k8s-azure-service-principal-mount
+        secret:
+          secretName: networking-appgw-k8s-azure-service-principal
       {{- end}}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         env:
-        - name: AZURE_LOCATION
+        - name: AZURE_CONTEXT_LOCATION
           value: /etc/appgw/azure.json
         - name: AGIC_POD_NAME
           valueFrom:

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/azure/tags"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 )
 
@@ -103,29 +102,9 @@ func (c *appGwConfigBuilder) Build(cbCtx *ConfigBuilderContext) (*n.ApplicationG
 		return nil, ErrGeneratingRoutingRules
 	}
 
-	c.removeOrphaned()
-
 	c.addTags()
 
 	return &c.appGw, nil
-}
-
-func (c *appGwConfigBuilder) removeOrphaned() {
-	// Remove orphaned HTTP Settings -- not referenced by any Request Routing Rule
-	if c.appGw.BackendHTTPSettingsCollection != nil && c.appGw.RequestRoutingRules != nil {
-		referencedHTTPSettings := make(map[string]interface{})
-		for _, rule := range *c.appGw.RequestRoutingRules {
-			settingName := utils.GetLastChunkOfSlashed(*rule.BackendHTTPSettings.ID)
-			referencedHTTPSettings[settingName] = nil
-		}
-		var sett []n.ApplicationGatewayBackendHTTPSettings
-		for _, hs := range *c.appGw.BackendHTTPSettingsCollection {
-			if _, referenced := referencedHTTPSettings[*hs.Name]; referenced {
-				sett = append(sett, hs)
-			}
-		}
-		c.appGw.BackendHTTPSettingsCollection = &sett
-	}
 }
 
 type valFunc func(eventRecorder record.EventRecorder, config *n.ApplicationGatewayPropertiesFormat, envVariables environment.EnvVariables, ingressList []*v1beta1.Ingress, serviceList []*v1.Service) error

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -6,6 +6,7 @@
 package azure
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -79,6 +80,51 @@ var _ = Describe("Azure", func() {
 			It("should try and panic", func() {
 				err := WaitForAzureAuth(client, 0, time.Duration(10))
 				Ω(err).To(HaveOccurred())
+			})
+		})
+
+		Context("test AzContext struct", func() {
+			contextFile := `{
+				"cloud": "xxxx",
+				"tenantId": "t",
+				"subscriptionId": "s",
+				"aadClientId": "c",
+				"aadClientSecret": "cs",
+				"resourceGroup": "r",
+				"location": "l",
+				"vmType": "xxxx",
+				"subnetName": "xxxx",
+				"securityGroupName": "xxxx",
+				"vnetName": "xxxx",
+				"vnetResourceGroup": "xxxx",
+				"routeTableName": "xxxx",
+				"primaryAvailabilitySetName": "xxxx",
+				"primaryScaleSetName": "xxxx",
+				"cloudProviderBackoff": "xxxx",
+				"cloudProviderBackoffRetries": "xxxx",
+				"cloudProviderBackoffExponent": "xxxx",
+				"cloudProviderBackoffDuration": "xxxx",
+				"cloudProviderBackoffJitter": "xxxx",
+				"cloudProviderRatelimit": "xxxx",
+				"cloudProviderRateLimitQPS": "xxxx",
+				"cloudProviderRateLimitBucket": "xxxx",
+				"useManagedIdentityExtension": "xxxx",
+				"userAssignedIdentityID": "xxxx",
+				"useInstanceMetadata": true,
+				"loadBalancerSku": "xxxx",
+				"excludeMasterFromStandardLB": "xxxx",
+				"providerVaultName": "xxxx",
+				"maximumLoadBalancerRuleCount": "xxxx",
+				"providerKeyName": "xxxx",
+				"providerKeyVersion": "xxxx"
+			}`
+
+			It("should deserialize correctly", func() {
+				var context AzContext
+				err := json.Unmarshal([]byte(contextFile), &context)
+				Ω(err).ToNot(HaveOccurred())
+				Ω(context.TenantID).To(Equal("t"))
+				Ω(context.Region).To(Equal("l"))
 			})
 		})
 	})

--- a/pkg/azure/context.go
+++ b/pkg/azure/context.go
@@ -1,0 +1,43 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package azure
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+// AzContext represents the Azure context file
+type AzContext struct {
+	Cloud                  string `json:"cloud"`
+	TenantID               string `json:"tenantId"`
+	SubscriptionID         string `json:"subscriptionId"`
+	ClientID               string `json:"aadClientId"`
+	ClientSecret           string `json:"aadClientSecret"`
+	ResourceGroup          string `json:"resourceGroup"`
+	Region                 string `json:"location"`
+	VNetName               string `json:"vnetName"`
+	VNetResourceGroup      string `json:"vnetResourceGroup"`
+	RouteTableName         string `json:"routeTableName"`
+	UserAssignedIdentityID string `json:"userAssignedIdentityID"`
+}
+
+// NewAzContext returns an AzContext struct from file path
+func NewAzContext(path string) (*AzContext, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("Reading Az Context file %q failed: %v", path, err)
+	}
+
+	// Unmarshal the authentication file.
+	var context AzContext
+	if err := json.Unmarshal(b, &context); err != nil {
+		return nil, err
+	}
+
+	return &context, nil
+}

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -14,6 +14,9 @@ import (
 )
 
 const (
+	// AzContextLocationVarName is an environment variable name. This file is available on azure cluster.
+	AzContextLocationVarName = "AZURE_CONTEXT_LOCATION"
+
 	// SubscriptionIDVarName is the name of the APPGW_SUBSCRIPTION_ID
 	SubscriptionIDVarName = "APPGW_SUBSCRIPTION_ID"
 
@@ -23,7 +26,7 @@ const (
 	// AppGwNameVarName is the name of the APPGW_NAME
 	AppGwNameVarName = "APPGW_NAME"
 
-	// AppGwSubnetIDVarName is the name of the APPGW_SUBNET_ID
+	// AppGwSubnetIDVarName is the name of the APPGW_SUBNETID
 	AppGwSubnetIDVarName = "APPGW_SUBNETID"
 
 	// ReleaseNameVarName is the name of the RELEASE_NAME
@@ -68,6 +71,7 @@ const (
 
 // EnvVariables is a struct storing values for environment variables.
 type EnvVariables struct {
+	AzContextLocation          string
 	SubscriptionID             string
 	ResourceGroupName          string
 	AppGwName                  string
@@ -93,6 +97,7 @@ var boolValidator = regexp.MustCompile(`^(?i)(true|false)$`)
 // GetEnv returns values for defined environment variables for Ingress Controller.
 func GetEnv() EnvVariables {
 	env := EnvVariables{
+		AzContextLocation:          os.Getenv(AzContextLocationVarName),
 		SubscriptionID:             os.Getenv(SubscriptionIDVarName),
 		ResourceGroupName:          os.Getenv(ResourceGroupNameVarName),
 		AppGwName:                  os.Getenv(AppGwNameVarName),
@@ -117,10 +122,8 @@ func GetEnv() EnvVariables {
 
 // ValidateEnv validates environment variables.
 func ValidateEnv(env EnvVariables) error {
-	if env.EnableDeployAppGateway {
-		if len(env.AppGwSubnetID) == 0 {
-			return errors.New("Missing required Environment variables: Provide APPGW_SUBNETID (ENVT001)")
-		}
+	if env.EnableDeployAppGateway && len(env.AppGwSubnetID) == 0 {
+		return errors.New("Missing required Environment variables: Provide APPGW_SUBNETID (ENVT001)")
 	} else if len(env.SubscriptionID) == 0 || len(env.ResourceGroupName) == 0 || len(env.AppGwName) == 0 {
 		return errors.New("Missing required Environment variables: Provide APPGW_SUBSCRIPTION_ID, APPGW_RESOURCE_GROUP and APPGW_NAME (ENVT002)")
 	}


### PR DESCRIPTION
This PR adds the code to mount the azure.json file and fill out the az context data struct.

This context will provide us with credentials and vnet details.
Following PR will be about using this.

Sample azure.json
```json
{
    "cloud": "xxxx",
    "tenantId": "t",
    "subscriptionId": "s",
    "aadClientId": "c",
    "aadClientSecret": "cs",
    "resourceGroup": "r",
    "location": "l",
    "vmType": "xxxx",
    "subnetName": "xxxx",
    "securityGroupName": "xxxx",
    "vnetName": "xxxx",
    "vnetResourceGroup": "xxxx",
    "routeTableName": "xxxx",
    "primaryAvailabilitySetName": "xxxx",
    "primaryScaleSetName": "xxxx",
    "cloudProviderBackoff": "xxxx",
    "cloudProviderBackoffRetries": "xxxx",
    "cloudProviderBackoffExponent": "xxxx",
    "cloudProviderBackoffDuration": "xxxx",
    "cloudProviderBackoffJitter": "xxxx",
    "cloudProviderRatelimit": "xxxx",
    "cloudProviderRateLimitQPS": "xxxx",
    "cloudProviderRateLimitBucket": "xxxx",
    "useManagedIdentityExtension": "xxxx",
    "userAssignedIdentityID": "xxxx",
    "useInstanceMetadata": true,
    "loadBalancerSku": "xxxx",
    "excludeMasterFromStandardLB": "xxxx",
    "providerVaultName": "xxxx",
    "maximumLoadBalancerRuleCount": "xxxx",
    "providerKeyName": "xxxx",
    "providerKeyVersion": "xxxx"
}
```