### PR TITLE
pipeline: modify registry based in env- prod,staging

### DIFF
--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 verbosityLevel: 3
 
 image:
-  repository: mcr.microsoft.com/azure-application-gateway/kubernetes-ingress
+  repository: XXREGISTRYXX
   tag: XXVERSIONXX
   pullPolicy: Always
 

--- a/helm/release.sh
+++ b/helm/release.sh
@@ -4,6 +4,8 @@ set -eauo pipefail
 
 TAG=${1:-$(git describe --abbrev=0 --tags)}
 
+OFFICIAL_REGISTRY="mcr.microsoft.com/azure-application-gateway/kubernetes-ingress"
+STAGING_REGISTRY="mcr.microsoft.com/azure-application-gateway/kubernetes-ingress-staging"
 HELM_GIT_REPO_URL="https://azure.github.io/application-gateway-kubernetes-ingress/helm"
 HELM_REPO_URL=${2:-$HELM_GIT_REPO_URL}
 
@@ -15,9 +17,22 @@ if [ -f $TGZ_FILE ]; then
   exit 0
 fi
 
+ENV=${3:-""}
+REGISTRY=""
+if [ "$ENV" = "prod" ]; then
+  REGISTRY=$OFFICIAL_REGISTRY  
+elif [ "$ENV" = "staging" ]; then
+  REGISTRY=$OFFICIAL_REGISTRY
+else
+  echo " - exiting bad/unknown environment provided: " $ENV
+  exit 1
+fi
+
+echo " - deployment will use production registry: " $REGISTRY
+
 echo " - update helm templates"
 cat ingress-azure/Chart-template.yaml | sed "s/XXVERSIONXX/$TAG/g" > ingress-azure/Chart.yaml
-cat ingress-azure/values-template.yaml | sed "s/XXVERSIONXX/$TAG/g" > ingress-azure/values.yaml
+cat ingress-azure/values-template.yaml | sed "s/XXVERSIONXX/$TAG/g" | sed "s#XXREGISTRYXX#$REGISTRY#g" > ingress-azure/values.yaml
 
 echo " - running helm package"
 helm package ingress-azure --version "$TAG"

--- a/helm/release.sh
+++ b/helm/release.sh
@@ -22,13 +22,13 @@ REGISTRY=""
 if [ "$ENV" = "prod" ]; then
   REGISTRY=$OFFICIAL_REGISTRY  
 elif [ "$ENV" = "staging" ]; then
-  REGISTRY=$OFFICIAL_REGISTRY
+  REGISTRY=$STAGING_REGISTRY
 else
   echo " - exiting bad/unknown environment provided: " $ENV
   exit 1
 fi
 
-echo " - deployment will use production registry: " $REGISTRY
+echo " - deployment will use registry: " $REGISTRY
 
 echo " - update helm templates"
 cat ingress-azure/Chart-template.yaml | sed "s/XXVERSIONXX/$TAG/g" > ingress-azure/Chart.yaml


### PR DESCRIPTION
```bash
./release.sh 0.9.0-test https://repo bad
 - tagging with [0.9.0-test]
 - exiting bad/unknown environment provided:  bad
```
Prod using mcr.microsoft.com/azure-application-gateway/kubernetes-ingress
```bash
./release.sh 0.9.0-test https://repo prod
 - tagging with [0.9.0-test]
 - deployment will use registry:  mcr.microsoft.com/azure-application-gateway/kubernetes-ingress
 - update helm templates
 - running helm package
Successfully packaged chart and saved it to: /c/Users/aksgupta/go/src/github.com/Azure/application-gateway-kubernetes-ingress/helm/ingress-azure-0.9.0-test.tgz
 - check if helm index [https://repo/index.yaml] exists in helm repo [https://repo]
```
Staging using mcr.microsoft.com/azure-application-gateway/kubernetes-ingress-staging
```bash
./release.sh 0.9.0-test https://repo staging
- tagging with [0.9.0-test]
 - deployment will use registry:  mcr.microsoft.com/azure-application-gateway/kubernetes-ingress-staging
 - update helm templates
 - running helm package
Successfully packaged chart and saved it to: /c/Users/aksgupta/go/src/github.com/Azure/application-gateway-kubernetes-ingress/helm/ingress-azure-0.9.0-test.tgz
 - check if helm index [https://repo/index.yaml] exists in helm repo [https://repo]
```