### PR TITLE
auth: use AzContext for auth and add env variable for Managed Identity

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -113,7 +113,7 @@ func main() {
 	glog.V(3).Infof("App Gateway Details: Subscription: %s, Resource Group: %s, Name: %s", env.SubscriptionID, env.ResourceGroupName, env.AppGwName)
 
 	var authorizer autorest.Authorizer
-	if authorizer, err = azure.GetAuthorizerWithRetry(env.AuthLocation, maxAuthRetryCount, retryPause); err != nil {
+	if authorizer, err = azure.GetAuthorizerWithRetry(env.AuthLocation, env.UseManagedIdentityForPod, azContext, maxAuthRetryCount, retryPause); err != nil {
 		glog.Fatal("Failed obtaining authentication token for Azure Resource Manager")
 	}
 

--- a/helm/ingress-azure/templates/NOTES.txt
+++ b/helm/ingress-azure/templates/NOTES.txt
@@ -6,12 +6,12 @@ The controller is deployed in deployment {{ template "application-gateway-kubern
 Configuration Details:
 ----------------------
  * AzureRM Authentication Method:
+{{- if.Values.armAuth }}
 {{- if eq .Values.armAuth.type "aadPodIdentity"}}
     - Use AAD-Pod-Identity
 {{- else if eq .Values.armAuth.type "servicePrincipal"}}
     - Use Service Principal
-{{- else }}
-    - ERROR!
+{{- end }}
 {{- end }}
  * Application Gateway:
     - Subscription ID : {{ .Values.appgw.subscriptionId }}
@@ -33,7 +33,9 @@ Configuration Details:
     - Multi-cluster / Shared App Gateway is enabled; Use "kubectl get AzureIngressProhibitedTargets" to view and modify config
 {{- end }}
 {{- end }}
+{{- if.Values.armAuth }}
 {{ if eq .Values.armAuth.type "aadPodIdentity"}}
 Please make sure the associated aadpodidentity and aadpodidbinding is configured.
 For more information on AAD-Pod-Identity, please visit https://github.com/Azure/aad-pod-identity
-{{ end }}
+{{- end }}
+{{- end }}

--- a/helm/ingress-azure/templates/aadpodidbinding.yaml
+++ b/helm/ingress-azure/templates/aadpodidbinding.yaml
@@ -1,5 +1,4 @@
-{{- if required "A valid armAuth entry is required!" .Values.armAuth }}
-{{- end}}
+{{- if .Values.armAuth -}}
 {{- if eq .Values.armAuth.type "aadPodIdentity"}}
 
 # Please see https://github.com/Azure/aad-pod-identity for more inromation
@@ -11,4 +10,5 @@ spec:
   AzureIdentity: {{ template "application-gateway-kubernetes-ingress.azureidentity" . }}
   Selector: {{ template "application-gateway-kubernetes-ingress.fullname" . }}
 
+{{- end}}
 {{- end}}

--- a/helm/ingress-azure/templates/aadpodidentity.yaml
+++ b/helm/ingress-azure/templates/aadpodidentity.yaml
@@ -1,5 +1,4 @@
-{{- if required "A valid armAuth entry is required!" .Values.armAuth }}
-{{- end}}
+{{- if .Values.armAuth -}}
 {{- if eq .Values.armAuth.type "aadPodIdentity"}}
 
 # Please see https://github.com/Azure/aad-pod-identity for more information
@@ -16,4 +15,5 @@ spec:
   ResourceID: {{ required "armAuth.identityResourceID is required if using AAD-Pod-Identity" .Values.armAuth.identityResourceID }}
   ClientID: {{ required "armAuth.identityClientID is required if using AAD-Pod-Identity" .Values.armAuth.identityClientID }}
 
+{{- end}}
 {{- end}}

--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -31,3 +31,8 @@ data:
   APPGW_ENABLE_SHARED_APPGW: "{{ .Values.appgw.shared }}"
 {{- end }}
 {{- end }}
+{{- if .Values.armAuth -}}
+{{- if eq .Values.armAuth.type "aadPodIdentity"}}
+  USE_MANAGED_IDENTITY_FOR_POD: "true"
+{{- end }}
+{{- end }}

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -18,8 +18,10 @@ spec:
       labels:
         app: {{ template "application-gateway-kubernetes-ingress.name" . }}
         release: {{ .Release.Name }}
+        {{- if eq .Values.armAuth }}
         {{- if eq .Values.armAuth.type "aadPodIdentity"}}
         aadpodidbinding: {{ template "application-gateway-kubernetes-ingress.fullname" . }}
+        {{- end }}
         {{- end }}
     spec:
       serviceAccountName: {{ template "application-gateway-kubernetes-ingress.serviceaccountname" . }}
@@ -50,9 +52,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if eq .Values.armAuth }}
         {{- if eq .Values.armAuth.type "servicePrincipal"}}
         - name: AZURE_AUTH_LOCATION
             value: /etc/Azure/Networking-AppGW/auth/armAuth.json
+        {{- end}}
         {{- end}}
         envFrom:
         - configMapRef:
@@ -60,20 +64,24 @@ spec:
         volumeMounts:
         - mountPath: /etc/appgw/azure.json
           name: azure
+        {{- if eq .Values.armAuth }}
         {{- if eq .Values.armAuth.type "servicePrincipal"}}
         - name: networking-appgw-k8s-azure-service-principal-mount
           mountPath: /etc/Azure/Networking-AppGW/auth
           readOnly: true
+        {{- end}}
         {{- end}}
       volumes:
       - name: azure
         hostPath:
           path: /etc/kubernetes/azure.json
           type: File
+      {{- if eq .Values.armAuth }}
       {{- if eq .Values.armAuth.type "servicePrincipal"}}
       - name: networking-appgw-k8s-azure-service-principal-mount
         secret:
           secretName: networking-appgw-k8s-azure-service-principal
+      {{- end}}
       {{- end}}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Azure", func() {
 
 		Context("test getAuthorizer", func() {
 			It("should try and get some authorizer", func() {
-				authorizer, err := getAuthorizer("")
+				authorizer, err := getAuthorizer("", false, nil)
 				Ω(authorizer).ToNot(BeNil())
 				Ω(err).ToNot(HaveOccurred())
 			})
@@ -66,7 +66,7 @@ var _ = Describe("Azure", func() {
 
 		Context("test getAuthorizerWithRetry", func() {
 			It("should try and get some authorizer", func() {
-				authorizer, err := GetAuthorizerWithRetry("", 0, time.Duration(10))
+				authorizer, err := GetAuthorizerWithRetry("", false, nil, 0, time.Duration(10))
 				Ω(authorizer).ToNot(BeNil())
 				Ω(err).ToNot(HaveOccurred())
 			})

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -67,6 +67,9 @@ const (
 
 	// AGICPodNamespaceVarName is an environment variable name.
 	AGICPodNamespaceVarName = "AGIC_POD_NAMESPACE"
+
+	// UseManagedIdentityForPodVarName is an environment variable name.
+	UseManagedIdentityForPodVarName = "USE_MANAGED_IDENTITY_FOR_POD"
 )
 
 // EnvVariables is a struct storing values for environment variables.
@@ -88,6 +91,7 @@ type EnvVariables struct {
 	EnableSaveConfigToFile     bool
 	EnablePanicOnPutError      bool
 	EnableDeployAppGateway     bool
+	UseManagedIdentityForPod   bool
 	HTTPServicePort            string
 }
 
@@ -114,6 +118,7 @@ func GetEnv() EnvVariables {
 		EnableSaveConfigToFile:     GetEnvironmentVariable(EnableSaveConfigToFileVarName, "false", boolValidator) == "true",
 		EnablePanicOnPutError:      GetEnvironmentVariable(EnablePanicOnPutErrorVarName, "false", boolValidator) == "true",
 		EnableDeployAppGateway:     GetEnvironmentVariable(EnableDeployAppGatewayVarName, "false", boolValidator) == "true",
+		UseManagedIdentityForPod:   GetEnvironmentVariable(UseManagedIdentityForPodVarName, "false", boolValidator) == "true",
 		HTTPServicePort:            GetEnvironmentVariable(HTTPServicePortVarName, "8123", portNumberValidator),
 	}
 


### PR DESCRIPTION
This PR modifies the authorization section.
We now have three sources of authorizations:
1) through a Auth File aka Service Principal
2) through a Managed Identity
3) through AzContext
4) Fall back to whatever is configured on the environment

Also, when user specifies a managed identity (uses AAD Pod Identity), there is no straight way for us to know if they using managed identity, so added a new environment variable.