### PR TITLE
bug: Do not overwrite service specific default backend pool

### DIFF
--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
+	"github.com/Azure/go-autorest/autorest/to"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 
@@ -56,7 +56,6 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 	servicePort := Port(80)
 	backendName := "http"
 	backendPort := Port(1356)
-
 
 	// Create the "test-ingress-controller" namespace.
 	// We will create all our resources under this namespace.
@@ -416,8 +415,10 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 					ingressA,
 					ingressB,
 				},
-				ServiceList:  serviceList,
-				EnvVariables: environment.GetFakeEnv(),
+				ServiceList:           serviceList,
+				EnvVariables:          environment.GetFakeEnv(),
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 			check(cbCtx, "three_ingresses.json", stopChannel, ctxt, configBuilder)
 		})
@@ -427,8 +428,10 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 				IngressList: []*v1beta1.Ingress{
 					ingressSlashNothing,
 				},
-				ServiceList:  serviceList,
-				EnvVariables: environment.GetFakeEnv(),
+				ServiceList:           serviceList,
+				EnvVariables:          environment.GetFakeEnv(),
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 			check(cbCtx, "one_ingress_slash_nothing.json", stopChannel, ctxt, configBuilder)
 		})
@@ -439,8 +442,10 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 					ingressA,
 					ingressSlashNothing,
 				},
-				ServiceList:  serviceList,
-				EnvVariables: environment.GetFakeEnv(),
+				ServiceList:           serviceList,
+				EnvVariables:          environment.GetFakeEnv(),
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 			check(cbCtx, "one_ingress_slash_slashnothing.json", stopChannel, ctxt, configBuilder)
 		})
@@ -451,8 +456,10 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 					ingressSlashNothing,
 					ingressA,
 				},
-				ServiceList:  serviceList,
-				EnvVariables: environment.GetFakeEnv(),
+				ServiceList:           serviceList,
+				EnvVariables:          environment.GetFakeEnv(),
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 			check(cbCtx, "two_ingresses_slash_slashsomething.json", stopChannel, ctxt, configBuilder)
 		})

--- a/functional_tests/three_ingresses.json
+++ b/functional_tests/three_ingresses.json
@@ -260,8 +260,12 @@
                 "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-80",
                 "name": "url-80",
                 "properties": {
-                    "defaultBackendAddressPool": {},
-                    "defaultBackendHttpSettings": {},
+                    "defaultBackendAddressPool": {
+                        "id": "xx"
+                    },
+                    "defaultBackendHttpSettings": {
+                        "id": "yy"
+                    },
                     "pathRules": [
                         {
                             "etag": "*",

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -327,9 +327,11 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 	testAGConfig := func(ingressList []*v1beta1.Ingress, serviceList []*v1.Service, settings appGwConfigSettings) {
 		cbCtx := &ConfigBuilderContext{
-			IngressList:  ingressList,
-			ServiceList:  serviceList,
-			EnvVariables: environment.GetFakeEnv(),
+			IngressList:           ingressList,
+			ServiceList:           serviceList,
+			EnvVariables:          environment.GetFakeEnv(),
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		appGW, err := configBuilder.Build(cbCtx)

--- a/pkg/appgw/backendaddresspools_test.go
+++ b/pkg/appgw/backendaddresspools_test.go
@@ -52,6 +52,8 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		cbCtx := &ConfigBuilderContext{
 			IngressList: cb.k8sContext.ListHTTPIngresses(),
 			ServiceList: serviceList,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 		_ = cb.BackendAddressPools(cbCtx)
 
@@ -74,6 +76,8 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		cbCtx := &ConfigBuilderContext{
 			IngressList: cb.k8sContext.ListHTTPIngresses(),
 			ServiceList: serviceList,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 		_ = cb.BackendAddressPools(cbCtx)
 		actualPool := cb.newPool("pool-name", subset)
@@ -108,6 +112,8 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		cbCtx := &ConfigBuilderContext{
 			ServiceList: serviceList,
 			IngressList: cb.k8sContext.ListHTTPIngresses(),
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 		_ = cb.BackendAddressPools(cbCtx)
 
@@ -196,6 +202,8 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 			cbCtx := &ConfigBuilderContext{
 				IngressList: cb.k8sContext.ListHTTPIngresses(),
 				ServiceList: serviceList,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 			actual := cb.getIstioPathMaps(cbCtx)
 			expected := map[listenerIdentifier]*n.ApplicationGatewayURLPathMap{
@@ -232,6 +240,8 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 			cbCtx := &ConfigBuilderContext{
 				IngressList: cb.k8sContext.ListHTTPIngresses(),
 				ServiceList: serviceList,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 			expectedSettingsList := []n.ApplicationGatewayBackendHTTPSettings{}
 			expectedSettinsgPerDestination := map[istioDestinationIdentifier]*n.ApplicationGatewayBackendHTTPSettings{}

--- a/pkg/appgw/backendaddresspools_test.go
+++ b/pkg/appgw/backendaddresspools_test.go
@@ -50,8 +50,8 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 			tests.NewServiceFixture(),
 		}
 		cbCtx := &ConfigBuilderContext{
-			IngressList: cb.k8sContext.ListHTTPIngresses(),
-			ServiceList: serviceList,
+			IngressList:           cb.k8sContext.ListHTTPIngresses(),
+			ServiceList:           serviceList,
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
@@ -74,8 +74,8 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 			_ = cb.k8sContext.Caches.Ingress.Add(ingress)
 		}
 		cbCtx := &ConfigBuilderContext{
-			IngressList: cb.k8sContext.ListHTTPIngresses(),
-			ServiceList: serviceList,
+			IngressList:           cb.k8sContext.ListHTTPIngresses(),
+			ServiceList:           serviceList,
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
@@ -110,8 +110,8 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 			_ = cb.k8sContext.Caches.Ingress.Add(ingress)
 		}
 		cbCtx := &ConfigBuilderContext{
-			ServiceList: serviceList,
-			IngressList: cb.k8sContext.ListHTTPIngresses(),
+			ServiceList:           serviceList,
+			IngressList:           cb.k8sContext.ListHTTPIngresses(),
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
@@ -200,10 +200,10 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 
 		It("Should get path maps from istio", func() {
 			cbCtx := &ConfigBuilderContext{
-				IngressList: cb.k8sContext.ListHTTPIngresses(),
-				ServiceList: serviceList,
-			DefaultAddressPoolID:  to.StringPtr("xx"),
-			DefaultHTTPSettingsID: to.StringPtr("yy"),
+				IngressList:           cb.k8sContext.ListHTTPIngresses(),
+				ServiceList:           serviceList,
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 			actual := cb.getIstioPathMaps(cbCtx)
 			expected := map[listenerIdentifier]*n.ApplicationGatewayURLPathMap{
@@ -238,10 +238,10 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 
 		It("Should get destinations from istio", func() {
 			cbCtx := &ConfigBuilderContext{
-				IngressList: cb.k8sContext.ListHTTPIngresses(),
-				ServiceList: serviceList,
-			DefaultAddressPoolID:  to.StringPtr("xx"),
-			DefaultHTTPSettingsID: to.StringPtr("yy"),
+				IngressList:           cb.k8sContext.ListHTTPIngresses(),
+				ServiceList:           serviceList,
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 			expectedSettingsList := []n.ApplicationGatewayBackendHTTPSettings{}
 			expectedSettinsgPerDestination := map[istioDestinationIdentifier]*n.ApplicationGatewayBackendHTTPSettings{}

--- a/pkg/appgw/backendhttpsettings_test.go
+++ b/pkg/appgw/backendhttpsettings_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
@@ -45,6 +46,8 @@ var _ = Describe("Test the creation of Backend http settings from Ingress defini
 			cbCtx := &ConfigBuilderContext{
 				IngressList: []*v1beta1.Ingress{ingress},
 				ServiceList: []*v1.Service{service},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
 			// Action

--- a/pkg/appgw/backendhttpsettings_test.go
+++ b/pkg/appgw/backendhttpsettings_test.go
@@ -8,11 +8,11 @@ package appgw
 import (
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
@@ -44,10 +44,10 @@ var _ = Describe("Test the creation of Backend http settings from Ingress defini
 			Expect(annotations.BackendProtocol(ingress)).To(Equal(protocolEnum))
 
 			cbCtx := &ConfigBuilderContext{
-				IngressList: []*v1beta1.Ingress{ingress},
-				ServiceList: []*v1.Service{service},
-			DefaultAddressPoolID:  to.StringPtr("xx"),
-			DefaultHTTPSettingsID: to.StringPtr("yy"),
+				IngressList:           []*v1beta1.Ingress{ingress},
+				ServiceList:           []*v1.Service{service},
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
 			// Action

--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -13,13 +13,13 @@ import (
 	"time"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"github.com/Azure/go-autorest/autorest/to"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 
@@ -214,9 +214,9 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 	Context("Tests Application Gateway config creation", func() {
 		cbCtx := &ConfigBuilderContext{
-			IngressList:  []*v1beta1.Ingress{ingress},
-			ServiceList:  serviceList,
-			EnvVariables: environment.GetFakeEnv(),
+			IngressList:           []*v1beta1.Ingress{ingress},
+			ServiceList:           serviceList,
+			EnvVariables:          environment.GetFakeEnv(),
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
@@ -455,8 +455,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 				// ingress,
 				ingressNoRules,
 			},
-			ServiceList:  serviceList,
-			EnvVariables: environment.GetFakeEnv(),
+			ServiceList:           serviceList,
+			EnvVariables:          environment.GetFakeEnv(),
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}

--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
+	"github.com/Azure/go-autorest/autorest/to"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 
@@ -217,6 +217,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			IngressList:  []*v1beta1.Ingress{ingress},
 			ServiceList:  serviceList,
 			EnvVariables: environment.GetFakeEnv(),
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		It("Should have created correct App Gateway config JSON blob", func() {
@@ -455,6 +457,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			},
 			ServiceList:  serviceList,
 			EnvVariables: environment.GetFakeEnv(),
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		It("Should have created correct App Gateway config JSON blob", func() {

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -151,6 +151,8 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 		ingress := tests.NewIngressFixture()
 		cbCtx := &ConfigBuilderContext{
 			IngressList: []*v1beta1.Ingress{ingress},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		httpListenersAzureConfigMap := cb.getListenerConfigs(cbCtx)
@@ -175,6 +177,8 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 					tests.NewIngressFixture(),
 				},
 				EnvVariables: envVariables,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
 			listener, port, err := cb.newListener(cbCtx, listenerID80, n.ApplicationGatewayProtocol("Https"))
@@ -197,6 +201,8 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 					tests.NewIngressFixture(),
 				},
 				EnvVariables: envVariables,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 			cbCtx.EnvVariables.UsePrivateIP = "true"
 
@@ -237,6 +243,8 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 					tests.NewIngressFixture(),
 				},
 				EnvVariables: envVariables,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
 			listeners, ports := cb.getListeners(cbCtx)
@@ -262,6 +270,8 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 					tests.NewIngressFixture(),
 				},
 				EnvVariables: envVariablesCopy,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
 			cbCtx.IngressList[0].Annotations[annotations.UsePrivateIPKey] = "true"
@@ -287,6 +297,8 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 					tests.NewIngressFixture(),
 				},
 				EnvVariables: envVariables,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
 			// Add a bunch of Ingress Resources
@@ -323,6 +335,8 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 		cbCtx := &ConfigBuilderContext{
 			IngressList:  ingressList,
 			EnvVariables: envVariables,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		certs := newCertsFixture()

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 		cb := newConfigBuilderFixture(&certs)
 		ingress := tests.NewIngressFixture()
 		cbCtx := &ConfigBuilderContext{
-			IngressList: []*v1beta1.Ingress{ingress},
+			IngressList:           []*v1beta1.Ingress{ingress},
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
@@ -176,9 +176,9 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 					tests.NewIngressFixture(),
 					tests.NewIngressFixture(),
 				},
-				EnvVariables: envVariables,
-			DefaultAddressPoolID:  to.StringPtr("xx"),
-			DefaultHTTPSettingsID: to.StringPtr("yy"),
+				EnvVariables:          envVariables,
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
 			listener, port, err := cb.newListener(cbCtx, listenerID80, n.ApplicationGatewayProtocol("Https"))
@@ -200,9 +200,9 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 					tests.NewIngressFixture(),
 					tests.NewIngressFixture(),
 				},
-				EnvVariables: envVariables,
-			DefaultAddressPoolID:  to.StringPtr("xx"),
-			DefaultHTTPSettingsID: to.StringPtr("yy"),
+				EnvVariables:          envVariables,
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 			cbCtx.EnvVariables.UsePrivateIP = "true"
 
@@ -242,9 +242,9 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 				IngressList: []*v1beta1.Ingress{
 					tests.NewIngressFixture(),
 				},
-				EnvVariables: envVariables,
-			DefaultAddressPoolID:  to.StringPtr("xx"),
-			DefaultHTTPSettingsID: to.StringPtr("yy"),
+				EnvVariables:          envVariables,
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
 			listeners, ports := cb.getListeners(cbCtx)
@@ -269,9 +269,9 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 					tests.NewIngressFixture(),
 					tests.NewIngressFixture(),
 				},
-				EnvVariables: envVariablesCopy,
-			DefaultAddressPoolID:  to.StringPtr("xx"),
-			DefaultHTTPSettingsID: to.StringPtr("yy"),
+				EnvVariables:          envVariablesCopy,
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
 			cbCtx.IngressList[0].Annotations[annotations.UsePrivateIPKey] = "true"
@@ -296,9 +296,9 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 				IngressList: []*v1beta1.Ingress{
 					tests.NewIngressFixture(),
 				},
-				EnvVariables: envVariables,
-			DefaultAddressPoolID:  to.StringPtr("xx"),
-			DefaultHTTPSettingsID: to.StringPtr("yy"),
+				EnvVariables:          envVariables,
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
 			// Add a bunch of Ingress Resources
@@ -333,8 +333,8 @@ var _ = Describe("Process ingress rules and parse frontend listener configs", fu
 		}
 
 		cbCtx := &ConfigBuilderContext{
-			IngressList:  ingressList,
-			EnvVariables: envVariables,
+			IngressList:           ingressList,
+			EnvVariables:          envVariables,
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -40,6 +40,8 @@ var _ = Describe("configure App Gateway health probes", func() {
 		cbCtx := &ConfigBuilderContext{
 			IngressList: ingressList,
 			ServiceList: serviceList,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		// !! Action !!
@@ -122,6 +124,8 @@ var _ = Describe("configure App Gateway health probes", func() {
 		cbCtx := &ConfigBuilderContext{
 			IngressList: ingressList,
 			ServiceList: serviceList,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		// !! Action !!
@@ -143,6 +147,8 @@ var _ = Describe("configure App Gateway health probes", func() {
 		cbCtx := &ConfigBuilderContext{
 			IngressList: ingressList,
 			ServiceList: serviceList,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		// !! Action !!

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -38,8 +38,8 @@ var _ = Describe("configure App Gateway health probes", func() {
 		_ = cb.k8sContext.Caches.Pods.Add(pod)
 
 		cbCtx := &ConfigBuilderContext{
-			IngressList: ingressList,
-			ServiceList: serviceList,
+			IngressList:           ingressList,
+			ServiceList:           serviceList,
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
@@ -122,8 +122,8 @@ var _ = Describe("configure App Gateway health probes", func() {
 		_ = cb.k8sContext.Caches.Pods.Add(pod)
 
 		cbCtx := &ConfigBuilderContext{
-			IngressList: ingressList,
-			ServiceList: serviceList,
+			IngressList:           ingressList,
+			ServiceList:           serviceList,
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
@@ -145,8 +145,8 @@ var _ = Describe("configure App Gateway health probes", func() {
 		_ = cb.k8sContext.Caches.Pods.Add(pod)
 
 		cbCtx := &ConfigBuilderContext{
-			IngressList: ingressList,
-			ServiceList: serviceList,
+			IngressList:           ingressList,
+			ServiceList:           serviceList,
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}

--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -1,11 +1,13 @@
 package appgw
 
 import (
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/extensions/v1beta1"
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
 // appgw_suite_test.go launches these Ginkgo tests
@@ -48,6 +50,8 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 		ingress := tests.NewIngressFixture()
 		cbCtx := &ConfigBuilderContext{
 			IngressList: []*v1beta1.Ingress{ingress},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 		listenersAzureConfigMap := cb.getListenerConfigs(cbCtx)
 
@@ -97,6 +101,8 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 		ingress := tests.NewIngressFixture()
 		cbCtx := &ConfigBuilderContext{
 			IngressList: []*v1beta1.Ingress{ingress},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 		It("should have setup tests with some TLS certs", func() {
 			Ω(len(ingress.Spec.TLS)).Should(BeNumerically(">=", 2))
@@ -122,6 +128,8 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 		ingress.Annotations[annotations.SslRedirectKey] = "one/two/three"
 		cbCtx := &ConfigBuilderContext{
 			IngressList: []*v1beta1.Ingress{ingress},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		// !! Action !!

--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -1,10 +1,10 @@
 package appgw
 
 import (
+	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/extensions/v1beta1"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
@@ -49,7 +49,7 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 		cb := newConfigBuilderFixture(&certs)
 		ingress := tests.NewIngressFixture()
 		cbCtx := &ConfigBuilderContext{
-			IngressList: []*v1beta1.Ingress{ingress},
+			IngressList:           []*v1beta1.Ingress{ingress},
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
@@ -100,7 +100,7 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 		cb := newConfigBuilderFixture(&certs)
 		ingress := tests.NewIngressFixture()
 		cbCtx := &ConfigBuilderContext{
-			IngressList: []*v1beta1.Ingress{ingress},
+			IngressList:           []*v1beta1.Ingress{ingress},
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
@@ -127,7 +127,7 @@ var _ = Describe("Process ingress rules, listeners, and ports", func() {
 		ingress := tests.NewIngressFixture()
 		ingress.Annotations[annotations.SslRedirectKey] = "one/two/three"
 		cbCtx := &ConfigBuilderContext{
-			IngressList: []*v1beta1.Ingress{ingress},
+			IngressList:           []*v1beta1.Ingress{ingress},
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}

--- a/pkg/appgw/public_and_private_ip_test.go
+++ b/pkg/appgw/public_and_private_ip_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
+	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/fake"
@@ -283,6 +284,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 			},
 			ServiceList:  serviceList,
 			EnvVariables: environment.GetFakeEnv(),
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		It("Should have created correct App Gateway config JSON blob", func() {
@@ -311,7 +314,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --    "properties": {
 --        "backendAddressPools": [
 --            {
---                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/defaultaddresspool",    
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/defaultaddresspool",
 --                "name": "defaultaddresspool",
 --                "properties": {
 --                    "backendAddresses": []
@@ -487,7 +490,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace-----service-name---80-80-internal-ingress-resource"
 --                    },
 --                    "httpListener": {
---                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-80-privateip"      
+--                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-80-privateip"
 --                    },
 --                    "ruleType": "Basic"
 --                }

--- a/pkg/appgw/public_and_private_ip_test.go
+++ b/pkg/appgw/public_and_private_ip_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -21,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/fake"
@@ -282,8 +282,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 				ingressPrivateIP,
 				ingressPublicIP,
 			},
-			ServiceList:  serviceList,
-			EnvVariables: environment.GetFakeEnv(),
+			ServiceList:           serviceList,
+			EnvVariables:          environment.GetFakeEnv(),
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}

--- a/pkg/appgw/redirects_test.go
+++ b/pkg/appgw/redirects_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		ingress := tests.NewIngressFixture()
 		ingressList := []*v1beta1.Ingress{ingress}
 		cbCtx := ConfigBuilderContext{
-			IngressList: ingressList,
+			IngressList:           ingressList,
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
@@ -100,7 +100,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		ingress.Spec.TLS = nil
 		ingressList := []*v1beta1.Ingress{ingress}
 		cbCtx := ConfigBuilderContext{
-			IngressList: ingressList,
+			IngressList:           ingressList,
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
@@ -128,7 +128,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		delete(ingress.Annotations, annotations.SslRedirectKey)
 		ingressList := []*v1beta1.Ingress{ingress}
 		cbCtx := ConfigBuilderContext{
-			IngressList: ingressList,
+			IngressList:           ingressList,
 			DefaultAddressPoolID:  to.StringPtr("xx"),
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}

--- a/pkg/appgw/redirects_test.go
+++ b/pkg/appgw/redirects_test.go
@@ -49,6 +49,8 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		ingressList := []*v1beta1.Ingress{ingress}
 		cbCtx := ConfigBuilderContext{
 			IngressList: ingressList,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 		actualRedirects := cb.getRedirectConfigurations(&cbCtx)
 		expectedRedirect := n.ApplicationGatewayRedirectConfiguration{
@@ -99,6 +101,8 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		ingressList := []*v1beta1.Ingress{ingress}
 		cbCtx := ConfigBuilderContext{
 			IngressList: ingressList,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 		actualRedirects := cb.getRedirectConfigurations(&cbCtx)
 
@@ -125,6 +129,8 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		ingressList := []*v1beta1.Ingress{ingress}
 		cbCtx := ConfigBuilderContext{
 			IngressList: ingressList,
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 		actualRedirects := cb.getRedirectConfigurations(&cbCtx)
 

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -171,7 +171,7 @@ func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listen
 				}
 
 				pathMap := c.getPathMap(cbCtx, listenerID, listenerAzConfig, ingress, rule)
-				urlPathMaps[listenerID] = c.mergePathMap(urlPathMaps[listenerID], pathMap)
+				urlPathMaps[listenerID] = c.mergePathMap(urlPathMaps[listenerID], pathMap, cbCtx)
 			}
 		}
 	}
@@ -335,11 +335,11 @@ func (c *appGwConfigBuilder) getPathRules(cbCtx *ConfigBuilderContext, listenerI
 	return &pathRules
 }
 
-func (c *appGwConfigBuilder) mergePathMap(existingPathMap *n.ApplicationGatewayURLPathMap, pathMapToMerge *n.ApplicationGatewayURLPathMap) *n.ApplicationGatewayURLPathMap {
-	if pathMapToMerge.DefaultBackendAddressPool != nil {
+func (c *appGwConfigBuilder) mergePathMap(existingPathMap *n.ApplicationGatewayURLPathMap, pathMapToMerge *n.ApplicationGatewayURLPathMap, cbCtx *ConfigBuilderContext) *n.ApplicationGatewayURLPathMap {
+	if pathMapToMerge.DefaultBackendAddressPool != nil && *pathMapToMerge.DefaultBackendAddressPool.ID != *cbCtx.DefaultAddressPoolID {
 		existingPathMap.DefaultBackendAddressPool = pathMapToMerge.DefaultBackendAddressPool
 	}
-	if pathMapToMerge.DefaultBackendHTTPSettings != nil {
+	if pathMapToMerge.DefaultBackendHTTPSettings != nil && *pathMapToMerge.DefaultBackendHTTPSettings.ID != *cbCtx.DefaultHTTPSettingsID {
 		existingPathMap.DefaultBackendHTTPSettings = pathMapToMerge.DefaultBackendHTTPSettings
 	}
 	if pathMapToMerge.DefaultRedirectConfiguration != nil {

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -46,8 +46,10 @@ var _ = Describe("Test routing rules generations", func() {
 		_ = configBuilder.k8sContext.Caches.Ingress.Add(ingressPathBased2)
 
 		cbCtx := &ConfigBuilderContext{
-			IngressList: []*v1beta1.Ingress{ingressPathBased1, ingressPathBased2},
-			ServiceList: []*v1.Service{service},
+			IngressList:           []*v1beta1.Ingress{ingressPathBased1, ingressPathBased2},
+			ServiceList:           []*v1.Service{service},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		_ = configBuilder.BackendHTTPSettingsCollection(cbCtx)
@@ -122,8 +124,10 @@ var _ = Describe("Test routing rules generations", func() {
 		_ = configBuilder.k8sContext.Caches.Ingress.Add(ingressBasic)
 
 		cbCtx := &ConfigBuilderContext{
-			IngressList: []*v1beta1.Ingress{ingressPathBased, ingressBasic},
-			ServiceList: []*v1.Service{service},
+			IngressList:           []*v1beta1.Ingress{ingressPathBased, ingressBasic},
+			ServiceList:           []*v1.Service{service},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		_ = configBuilder.BackendHTTPSettingsCollection(cbCtx)
@@ -244,8 +248,10 @@ var _ = Describe("Test routing rules generations", func() {
 		_ = configBuilder.k8sContext.Caches.Ingress.Add(ingress)
 
 		cbCtx := &ConfigBuilderContext{
-			IngressList: []*v1beta1.Ingress{ingress},
-			ServiceList: []*v1.Service{service},
+			IngressList:           []*v1beta1.Ingress{ingress},
+			ServiceList:           []*v1.Service{service},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		_ = configBuilder.BackendHTTPSettingsCollection(cbCtx)
@@ -289,8 +295,10 @@ var _ = Describe("Test routing rules generations", func() {
 		_ = configBuilder.k8sContext.Caches.Ingress.Add(ingress)
 
 		cbCtx := &ConfigBuilderContext{
-			IngressList: []*v1beta1.Ingress{ingress},
-			ServiceList: []*v1.Service{service},
+			IngressList:           []*v1beta1.Ingress{ingress},
+			ServiceList:           []*v1.Service{service},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
 		_ = configBuilder.BackendHTTPSettingsCollection(cbCtx)

--- a/pkg/appgw/types_test.go
+++ b/pkg/appgw/types_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/extensions/v1beta1"
+	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
@@ -25,6 +26,8 @@ var _ = Describe("Test ConfigBuilderContext", func() {
 					&ingress1,
 					&ingress2,
 				},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
 			Expect(cbCtx.InIngressList(&ingress1)).To(BeTrue())

--- a/pkg/appgw/types_test.go
+++ b/pkg/appgw/types_test.go
@@ -6,10 +6,10 @@
 package appgw
 
 import (
+	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/extensions/v1beta1"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
@@ -26,8 +26,8 @@ var _ = Describe("Test ConfigBuilderContext", func() {
 					&ingress1,
 					&ingress2,
 				},
-			DefaultAddressPoolID:  to.StringPtr("xx"),
-			DefaultHTTPSettingsID: to.StringPtr("yy"),
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
 			Expect(cbCtx.InIngressList(&ingress1)).To(BeTrue())

--- a/pkg/controller/process_test.go
+++ b/pkg/controller/process_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
+	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
@@ -77,6 +78,8 @@ var _ = Describe("process function tests", func() {
 			IngressList: []*v1beta1.Ingress{
 				ingress,
 			},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 	})
 	AfterEach(func() {

--- a/pkg/controller/process_test.go
+++ b/pkg/controller/process_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -16,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"

--- a/pkg/controller/prune_test.go
+++ b/pkg/controller/prune_test.go
@@ -12,6 +12,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/record"
+	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
@@ -47,6 +48,8 @@ var _ = Describe("prune function tests", func() {
 			ServiceList: []*v1.Service{
 				tests.NewServiceFixture(),
 			},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 		appGw := fixtures.GetAppGateway()
 
@@ -110,6 +113,8 @@ var _ = Describe("prune function tests", func() {
 			ServiceList: []*v1.Service{
 				tests.NewServiceFixture(),
 			},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 		appGw := fixtures.GetAppGateway()
 		It("removes the invalid ingresses", func() {

--- a/pkg/controller/prune_test.go
+++ b/pkg/controller/prune_test.go
@@ -7,12 +7,12 @@ package controller
 
 import (
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/record"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"


### PR DESCRIPTION
This change ensures that once the Default Backend has been set to something that has been derived from a Kubernetes Service it is **not** overwritten with a subsequent Ingress Resourc and set to the default empty backend pool.

This PR fixes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/580

## Before bugfix:

![image](https://user-images.githubusercontent.com/49918230/66246888-c091ac80-e6cc-11e9-826c-c7f1273f22f3.png)



## After bugfix: 

![image](https://user-images.githubusercontent.com/49918230/66246819-29c4f000-e6cc-11e9-815a-76ab93a8256a.png)
