### PR TITLE
Set Backend and HTTP Settings to nil when Redirect is configured

### DIFF
--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -92,6 +92,9 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 			if rule.RedirectConfiguration == nil {
 				rule.BackendAddressPool = urlPathMap.DefaultBackendAddressPool
 				rule.BackendHTTPSettings = urlPathMap.DefaultBackendHTTPSettings
+			} else {
+				rule.BackendAddressPool = nil
+				rule.BackendHTTPSettings = nil
 			}
 		} else {
 			// Path-based Rule


### PR DESCRIPTION
This PR fixes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/571