### PR TITLE
More functional tests covering two Ingress resources

### DIFF
--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -139,7 +139,7 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 								{
 									Path: "/.well-known/acme-challenge/blahBlahBBLLAAHH",
 									Backend: v1beta1.IngressBackend{
-										ServiceName: serviceName,
+										ServiceName: serviceNameB,
 										ServicePort: intstr.IntOrString{
 											Type:   intstr.Int,
 											IntVal: 80,

--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -11,13 +11,13 @@ import (
 	"time"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"github.com/Azure/go-autorest/autorest/to"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 
@@ -513,8 +513,10 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 					ingress,
 					ingressFooBazNoTLS,
 				},
-				ServiceList:  serviceList,
-				EnvVariables: environment.GetFakeEnv(),
+				ServiceList:           serviceList,
+				EnvVariables:          environment.GetFakeEnv(),
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 			check(cbCtx, "two_ingresses_same_domain_tls_notls.json", stopChannel, ctxt, configBuilder)
 		})

--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -337,8 +337,8 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{tests.Namespace}, 1000*time.Second)
 
 		secKey := utils.GetResourceKey(ingressSecret.Namespace, ingressSecret.Name)
-		err := ctxt.CertificateSecretStore.ConvertSecret(secKey, ingressSecret)
-		pfx := ctxt.CertificateSecretStore.GetPfxCertificate(secKey)
+		_ = ctxt.CertificateSecretStore.ConvertSecret(secKey, ingressSecret)
+		_ = ctxt.CertificateSecretStore.GetPfxCertificate(secKey)
 
 		appGwy := &n.ApplicationGateway{
 			ApplicationGatewayPropertiesFormat: NewAppGwyConfigFixture(),

--- a/functional_tests/helpers.go
+++ b/functional_tests/helpers.go
@@ -27,7 +27,7 @@ func check(cbCtx *appgw.ConfigBuilderContext, expectedFilename string, stopChan 
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	if appGW.SslCertificates != nil {
-		for idx, _ := range *appGW.SslCertificates {
+		for idx := range *appGW.SslCertificates {
 			if (*appGW.SslCertificates)[idx].Data != nil {
 				*(*appGW.SslCertificates)[idx].Data = "xx"
 			}

--- a/functional_tests/helpers.go
+++ b/functional_tests/helpers.go
@@ -26,6 +26,14 @@ func check(cbCtx *appgw.ConfigBuilderContext, expectedFilename string, stopChan 
 	appGW, err := configBuilder.Build(cbCtx)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
+	if appGW.SslCertificates != nil {
+		for idx, _ := range *appGW.SslCertificates {
+			if (*appGW.SslCertificates)[idx].Data != nil {
+				*(*appGW.SslCertificates)[idx].Data = "xx"
+			}
+		}
+	}
+
 	jsonBlob, err := appGW.MarshalJSON()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 

--- a/functional_tests/one_ingress_slash_nothing.json
+++ b/functional_tests/one_ingress_slash_nothing.json
@@ -10,8 +10,8 @@
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-b-80-bp-80",
-                "name": "pool-test-ingress-controller-hello-world-b-80-bp-80",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80",
+                "name": "pool---namespace---hello-world-b-80-bp-80",
                 "properties": {
                     "backendAddresses": [
                         {
@@ -30,12 +30,12 @@
         "backendHttpSettingsCollection": [
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-b-80-80---name--",
-                "name": "bp-test-ingress-controller-hello-world-b-80-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--",
+                "name": "bp---namespace---hello-world-b-80-80---name--",
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -127,8 +127,8 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--",
-                "name": "pb-test-ingress-controller-hello-world-b-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--",
+                "name": "pb---namespace---hello-world-b-80---name--",
                 "properties": {
                     "host": "localhost",
                     "interval": 30,
@@ -147,10 +147,10 @@
                 "name": "rr-80",
                 "properties": {
                     "backendAddressPool": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-b-80-bp-80"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
                     },
                     "backendHttpSettings": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-b-80-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--"
                     },
                     "httpListener": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-80"

--- a/functional_tests/one_ingress_slash_slashnothing.json
+++ b/functional_tests/one_ingress_slash_slashnothing.json
@@ -10,8 +10,8 @@
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-a-80-bp-80",
-                "name": "pool-test-ingress-controller-hello-world-a-80-bp-80",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-a-80-bp-80",
+                "name": "pool---namespace---hello-world-a-80-bp-80",
                 "properties": {
                     "backendAddresses": [
                         {
@@ -28,8 +28,8 @@
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-b-80-bp-80",
-                "name": "pool-test-ingress-controller-hello-world-b-80-bp-80",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80",
+                "name": "pool---namespace---hello-world-b-80-bp-80",
                 "properties": {
                     "backendAddresses": [
                         {
@@ -48,24 +48,24 @@
         "backendHttpSettingsCollection": [
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-a-80-80---name--",
-                "name": "bp-test-ingress-controller-hello-world-a-80-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-a-80-80---name--",
+                "name": "bp---namespace---hello-world-a-80-80---name--",
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-a-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-a-80---name--"
                     },
                     "protocol": "Http"
                 }
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-b-80-80---name--",
-                "name": "bp-test-ingress-controller-hello-world-b-80-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--",
+                "name": "bp---namespace---hello-world-b-80-80---name--",
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -157,8 +157,8 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-a-80---name--",
-                "name": "pb-test-ingress-controller-hello-world-a-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-a-80---name--",
+                "name": "pb---namespace---hello-world-a-80---name--",
                 "properties": {
                     "host": "localhost",
                     "interval": 30,
@@ -169,8 +169,8 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--",
-                "name": "pb-test-ingress-controller-hello-world-b-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--",
+                "name": "pb---namespace---hello-world-b-80---name--",
                 "properties": {
                     "host": "localhost",
                     "interval": 30,
@@ -211,21 +211,21 @@
                 "name": "url-80",
                 "properties": {
                     "defaultBackendAddressPool": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-b-80-bp-80"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
                     },
                     "defaultBackendHttpSettings": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-b-80-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--"
                     },
                     "pathRules": [
                         {
                             "etag": "*",
-                            "name": "pr-test-ingress-controller---name---0",
+                            "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-a-80-bp-80"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-a-80-bp-80"
                                 },
                                 "backendHttpSettings": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-a-80-80---name--"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-a-80-80---name--"
                                 },
                                 "paths": [
                                     "/A/"

--- a/functional_tests/one_ingress_slash_slashnothing.json
+++ b/functional_tests/one_ingress_slash_slashnothing.json
@@ -53,7 +53,7 @@
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-a-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -65,7 +65,7 @@
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -152,6 +152,30 @@
                     "interval": 30,
                     "path": "/",
                     "protocol": "Https",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-a-80---name--",
+                "name": "pb-test-ingress-controller-hello-world-a-80---name--",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/A/",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--",
+                "name": "pb-test-ingress-controller-hello-world-b-80---name--",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/",
+                    "protocol": "Http",
                     "timeout": 30,
                     "unhealthyThreshold": 3
                 }

--- a/functional_tests/run.sh
+++ b/functional_tests/run.sh
@@ -2,4 +2,4 @@
 
 set -auexo pipefail
 
-go test -v $(go list ./... | grep 'application-gateway') | tee output.json; echo $?
+go test -v $(go list ./... | grep 'application-gateway'); echo $?

--- a/functional_tests/three_ingresses.json
+++ b/functional_tests/three_ingresses.json
@@ -10,8 +10,8 @@
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-80-bp-80",
-                "name": "pool-test-ingress-controller-hello-world-80-bp-80",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80",
+                "name": "pool---namespace---hello-world-80-bp-80",
                 "properties": {
                     "backendAddresses": [
                         {
@@ -28,8 +28,8 @@
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-a-80-bp-80",
-                "name": "pool-test-ingress-controller-hello-world-a-80-bp-80",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-a-80-bp-80",
+                "name": "pool---namespace---hello-world-a-80-bp-80",
                 "properties": {
                     "backendAddresses": [
                         {
@@ -46,8 +46,8 @@
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-b-80-bp-80",
-                "name": "pool-test-ingress-controller-hello-world-b-80-bp-80",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80",
+                "name": "pool---namespace---hello-world-b-80-bp-80",
                 "properties": {
                     "backendAddresses": [
                         {
@@ -66,36 +66,36 @@
         "backendHttpSettingsCollection": [
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-80-80---name--",
-                "name": "bp-test-ingress-controller-hello-world-80-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--",
+                "name": "bp---namespace---hello-world-80-80---name--",
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-80---name--"
                     },
                     "protocol": "Http"
                 }
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-a-80-80---name--",
-                "name": "bp-test-ingress-controller-hello-world-a-80-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-a-80-80---name--",
+                "name": "bp---namespace---hello-world-a-80-80---name--",
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-a-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-a-80---name--"
                     },
                     "protocol": "Http"
                 }
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-b-80-80---name--",
-                "name": "bp-test-ingress-controller-hello-world-b-80-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--",
+                "name": "bp---namespace---hello-world-b-80-80---name--",
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -137,6 +137,14 @@
         "frontendPorts": [
             {
                 "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-443",
+                "name": "fp-443",
+                "properties": {
+                    "port": 443
+                }
+            },
+            {
+                "etag": "*",
                 "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80",
                 "name": "fp-80",
                 "properties": {
@@ -158,6 +166,24 @@
                     },
                     "hostName": "",
                     "protocol": "Http"
+                }
+            },
+            {
+                "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443",
+                "name": "fl-foo.baz-443",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-443"
+                    },
+                    "hostName": "foo.baz",
+                    "protocol": "Https",
+                    "sslCertificate": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/--namespace-----the-name-of-the-secret--"
+                    }
                 }
             },
             {
@@ -202,8 +228,8 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-80---name--",
-                "name": "pb-test-ingress-controller-hello-world-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-80---name--",
+                "name": "pb---namespace---hello-world-80---name--",
                 "properties": {
                     "host": "foo.baz",
                     "interval": 30,
@@ -214,8 +240,8 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-a-80---name--",
-                "name": "pb-test-ingress-controller-hello-world-a-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-a-80---name--",
+                "name": "pb---namespace---hello-world-a-80---name--",
                 "properties": {
                     "host": "localhost",
                     "interval": 30,
@@ -226,8 +252,8 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--",
-                "name": "pb-test-ingress-controller-hello-world-b-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--",
+                "name": "pb---namespace---hello-world-b-80---name--",
                 "properties": {
                     "host": "localhost",
                     "interval": 30,
@@ -238,7 +264,21 @@
                 }
             }
         ],
-        "redirectConfigurations": null,
+        "redirectConfigurations": [
+            {
+                "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-foo.baz-443",
+                "name": "sslr-fl-foo.baz-443",
+                "properties": {
+                    "includePath": true,
+                    "includeQueryString": true,
+                    "redirectType": "Permanent",
+                    "targetListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443"
+                    }
+                }
+            }
+        ],
         "requestRoutingRules": [
             {
                 "etag": "*",
@@ -256,17 +296,31 @@
             },
             {
                 "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-foo.baz-443",
+                "name": "rr-foo.baz-443",
+                "properties": {
+                    "backendAddressPool": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80"
+                    },
+                    "backendHttpSettings": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--"
+                    },
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443"
+                    },
+                    "ruleType": "Basic"
+                }
+            },
+            {
+                "etag": "*",
                 "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-foo.baz-80",
                 "name": "rr-foo.baz-80",
                 "properties": {
-                    "backendAddressPool": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-80-bp-80"
-                    },
-                    "backendHttpSettings": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-80-80---name--"
-                    },
                     "httpListener": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-80"
+                    },
+                    "redirectConfiguration": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-foo.baz-443"
                     },
                     "ruleType": "Basic"
                 }
@@ -277,7 +331,17 @@
             "name": "Standard_v2",
             "tier": "Standard_v2"
         },
-        "sslCertificates": null,
+        "sslCertificates": [
+            {
+                "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/--namespace-----the-name-of-the-secret--",
+                "name": "--namespace-----the-name-of-the-secret--",
+                "properties": {
+                    "data": "xx",
+                    "password": "msazure"
+                }
+            }
+        ],
         "urlPathMaps": [
             {
                 "etag": "*",
@@ -293,13 +357,13 @@
                     "pathRules": [
                         {
                             "etag": "*",
-                            "name": "pr-test-ingress-controller---name---0",
+                            "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-a-80-bp-80"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-a-80-bp-80"
                                 },
                                 "backendHttpSettings": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-a-80-80---name--"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-a-80-80---name--"
                                 },
                                 "paths": [
                                     "/A/"
@@ -308,13 +372,13 @@
                         },
                         {
                             "etag": "*",
-                            "name": "pr-test-ingress-controller---name---0",
+                            "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-b-80-bp-80"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
                                 },
                                 "backendHttpSettings": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-b-80-80---name--"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--"
                                 },
                                 "paths": [
                                     "/B/"

--- a/functional_tests/three_ingresses.json
+++ b/functional_tests/three_ingresses.json
@@ -83,7 +83,7 @@
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-a-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -95,7 +95,7 @@
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -208,6 +208,30 @@
                     "host": "foo.baz",
                     "interval": 30,
                     "path": "/",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-a-80---name--",
+                "name": "pb-test-ingress-controller-hello-world-a-80---name--",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/A/",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--",
+                "name": "pb-test-ingress-controller-hello-world-b-80---name--",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/B/",
                     "protocol": "Http",
                     "timeout": 30,
                     "unhealthyThreshold": 3

--- a/functional_tests/two_ingresses_same_domain_tls_notls.json
+++ b/functional_tests/two_ingresses_same_domain_tls_notls.json
@@ -10,8 +10,8 @@
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-80-bp-80",
-                "name": "pool-test-ingress-controller-hello-world-80-bp-80",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80",
+                "name": "pool---namespace---hello-world-80-bp-80",
                 "properties": {
                     "backendAddresses": [
                         {
@@ -30,12 +30,12 @@
         "backendHttpSettingsCollection": [
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-80-80---name--",
-                "name": "bp-test-ingress-controller-hello-world-80-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--",
+                "name": "bp---namespace---hello-world-80-80---name--",
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -77,6 +77,14 @@
         "frontendPorts": [
             {
                 "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-443",
+                "name": "fp-443",
+                "properties": {
+                    "port": 443
+                }
+            },
+            {
+                "etag": "*",
                 "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80",
                 "name": "fp-80",
                 "properties": {
@@ -85,6 +93,24 @@
             }
         ],
         "httpListeners": [
+            {
+                "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443",
+                "name": "fl-foo.baz-443",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-443"
+                    },
+                    "hostName": "foo.baz",
+                    "protocol": "Https",
+                    "sslCertificate": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/--namespace-----the-name-of-the-secret--"
+                    }
+                }
+            },
             {
                 "etag": "*",
                 "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-80",
@@ -127,8 +153,8 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-80---name--",
-                "name": "pb-test-ingress-controller-hello-world-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-80---name--",
+                "name": "pb---namespace---hello-world-80---name--",
                 "properties": {
                     "host": "foo.baz",
                     "interval": 30,
@@ -139,8 +165,39 @@
                 }
             }
         ],
-        "redirectConfigurations": null,
+        "redirectConfigurations": [
+            {
+                "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-foo.baz-443",
+                "name": "sslr-fl-foo.baz-443",
+                "properties": {
+                    "includePath": true,
+                    "includeQueryString": true,
+                    "redirectType": "Permanent",
+                    "targetListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443"
+                    }
+                }
+            }
+        ],
         "requestRoutingRules": [
+            {
+                "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-foo.baz-443",
+                "name": "rr-foo.baz-443",
+                "properties": {
+                    "backendAddressPool": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80"
+                    },
+                    "backendHttpSettings": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--"
+                    },
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443"
+                    },
+                    "ruleType": "Basic"
+                }
+            },
             {
                 "etag": "*",
                 "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-foo.baz-80",
@@ -161,29 +218,36 @@
             "name": "Standard_v2",
             "tier": "Standard_v2"
         },
-        "sslCertificates": null,
+        "sslCertificates": [
+            {
+                "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/--namespace-----the-name-of-the-secret--",
+                "name": "--namespace-----the-name-of-the-secret--",
+                "properties": {
+                    "data": "xx",
+                    "password": "msazure"
+                }
+            }
+        ],
         "urlPathMaps": [
             {
                 "etag": "*",
                 "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-foo.baz-80",
                 "name": "url-foo.baz-80",
                 "properties": {
-                    "defaultBackendAddressPool": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-80-bp-80"
-                    },
-                    "defaultBackendHttpSettings": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-80-80---name--"
+                    "defaultRedirectConfiguration": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-foo.baz-443"
                     },
                     "pathRules": [
                         {
                             "etag": "*",
-                            "name": "pr-test-ingress-controller---name---0",
+                            "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-80-bp-80"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80"
                                 },
                                 "backendHttpSettings": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-80-80---name--"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--"
                                 },
                                 "paths": [
                                     "/.well-known/acme-challenge/blahBlahBBLLAAHH"

--- a/functional_tests/two_ingresses_same_domain_tls_notls.json
+++ b/functional_tests/two_ingresses_same_domain_tls_notls.json
@@ -10,8 +10,8 @@
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-b-80-bp-80",
-                "name": "pool-test-ingress-controller-hello-world-b-80-bp-80",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-80-bp-80",
+                "name": "pool-test-ingress-controller-hello-world-80-bp-80",
                 "properties": {
                     "backendAddresses": [
                         {
@@ -30,12 +30,12 @@
         "backendHttpSettingsCollection": [
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-b-80-80---name--",
-                "name": "bp-test-ingress-controller-hello-world-b-80-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-80-80---name--",
+                "name": "bp-test-ingress-controller-hello-world-80-80---name--",
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -87,8 +87,8 @@
         "httpListeners": [
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-80",
-                "name": "fl-80",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-80",
+                "name": "fl-foo.baz-80",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -96,7 +96,7 @@
                     "frontendPort": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
                     },
-                    "hostName": "",
+                    "hostName": "foo.baz",
                     "protocol": "Http"
                 }
             }
@@ -127,12 +127,12 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--",
-                "name": "pb-test-ingress-controller-hello-world-b-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-80---name--",
+                "name": "pb-test-ingress-controller-hello-world-80---name--",
                 "properties": {
-                    "host": "localhost",
+                    "host": "foo.baz",
                     "interval": 30,
-                    "path": "/",
+                    "path": "/.well-known/acme-challenge/blahBlahBBLLAAHH",
                     "protocol": "Http",
                     "timeout": 30,
                     "unhealthyThreshold": 3
@@ -143,19 +143,16 @@
         "requestRoutingRules": [
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-80",
-                "name": "rr-80",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-foo.baz-80",
+                "name": "rr-foo.baz-80",
                 "properties": {
-                    "backendAddressPool": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-b-80-bp-80"
-                    },
-                    "backendHttpSettings": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-b-80-80---name--"
-                    },
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-80"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-80"
                     },
-                    "ruleType": "Basic"
+                    "ruleType": "PathBasedRouting",
+                    "urlPathMap": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-foo.baz-80"
+                    }
                 }
             }
         ],
@@ -165,7 +162,38 @@
             "tier": "Standard_v2"
         },
         "sslCertificates": null,
-        "urlPathMaps": null
+        "urlPathMaps": [
+            {
+                "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-foo.baz-80",
+                "name": "url-foo.baz-80",
+                "properties": {
+                    "defaultBackendAddressPool": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-80-bp-80"
+                    },
+                    "defaultBackendHttpSettings": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-80-80---name--"
+                    },
+                    "pathRules": [
+                        {
+                            "etag": "*",
+                            "name": "pr-test-ingress-controller---name---0",
+                            "properties": {
+                                "backendAddressPool": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-80-bp-80"
+                                },
+                                "backendHttpSettings": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-80-80---name--"
+                                },
+                                "paths": [
+                                    "/.well-known/acme-challenge/blahBlahBBLLAAHH"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",

--- a/functional_tests/two_ingresses_same_domain_tls_notls.json
+++ b/functional_tests/two_ingresses_same_domain_tls_notls.json
@@ -25,6 +25,24 @@
                         }
                     ]
                 }
+            },
+            {
+                "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80",
+                "name": "pool---namespace---hello-world-b-80-bp-80",
+                "properties": {
+                    "backendAddresses": [
+                        {
+                            "ipAddress": "1.1.1.1"
+                        },
+                        {
+                            "ipAddress": "1.1.1.2"
+                        },
+                        {
+                            "ipAddress": "1.1.1.3"
+                        }
+                    ]
+                }
             }
         ],
         "backendHttpSettingsCollection": [
@@ -36,6 +54,18 @@
                     "port": 80,
                     "probe": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-80---name--"
+                    },
+                    "protocol": "Http"
+                }
+            },
+            {
+                "etag": "*",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--",
+                "name": "bp---namespace---hello-world-b-80-80---name--",
+                "properties": {
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -158,6 +188,18 @@
                 "properties": {
                     "host": "foo.baz",
                     "interval": 30,
+                    "path": "/",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--",
+                "name": "pb---namespace---hello-world-b-80---name--",
+                "properties": {
+                    "host": "foo.baz",
+                    "interval": 30,
                     "path": "/.well-known/acme-challenge/blahBlahBBLLAAHH",
                     "protocol": "Http",
                     "timeout": 30,
@@ -244,10 +286,10 @@
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
                                 },
                                 "backendHttpSettings": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--"
                                 },
                                 "paths": [
                                     "/.well-known/acme-challenge/blahBlahBBLLAAHH"

--- a/functional_tests/two_ingresses_slash_slashsomething.json
+++ b/functional_tests/two_ingresses_slash_slashsomething.json
@@ -10,8 +10,8 @@
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-a-80-bp-80",
-                "name": "pool-test-ingress-controller-hello-world-a-80-bp-80",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-a-80-bp-80",
+                "name": "pool---namespace---hello-world-a-80-bp-80",
                 "properties": {
                     "backendAddresses": [
                         {
@@ -28,8 +28,8 @@
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-b-80-bp-80",
-                "name": "pool-test-ingress-controller-hello-world-b-80-bp-80",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80",
+                "name": "pool---namespace---hello-world-b-80-bp-80",
                 "properties": {
                     "backendAddresses": [
                         {
@@ -48,24 +48,24 @@
         "backendHttpSettingsCollection": [
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-a-80-80---name--",
-                "name": "bp-test-ingress-controller-hello-world-a-80-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-a-80-80---name--",
+                "name": "bp---namespace---hello-world-a-80-80---name--",
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-a-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-a-80---name--"
                     },
                     "protocol": "Http"
                 }
             },
             {
                 "etag": "*",
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-b-80-80---name--",
-                "name": "bp-test-ingress-controller-hello-world-b-80-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--",
+                "name": "bp---namespace---hello-world-b-80-80---name--",
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -157,8 +157,8 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-a-80---name--",
-                "name": "pb-test-ingress-controller-hello-world-a-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-a-80---name--",
+                "name": "pb---namespace---hello-world-a-80---name--",
                 "properties": {
                     "host": "localhost",
                     "interval": 30,
@@ -169,8 +169,8 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--",
-                "name": "pb-test-ingress-controller-hello-world-b-80---name--",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--",
+                "name": "pb---namespace---hello-world-b-80---name--",
                 "properties": {
                     "host": "localhost",
                     "interval": 30,
@@ -211,21 +211,21 @@
                 "name": "url-80",
                 "properties": {
                     "defaultBackendAddressPool": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-b-80-bp-80"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
                     },
                     "defaultBackendHttpSettings": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-b-80-80---name--"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--"
                     },
                     "pathRules": [
                         {
                             "etag": "*",
-                            "name": "pr-test-ingress-controller---name---0",
+                            "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-a-80-bp-80"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-a-80-bp-80"
                                 },
                                 "backendHttpSettings": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-a-80-80---name--"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-a-80-80---name--"
                                 },
                                 "paths": [
                                     "/A/"

--- a/functional_tests/two_ingresses_slash_slashsomething.json
+++ b/functional_tests/two_ingresses_slash_slashsomething.json
@@ -53,7 +53,7 @@
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-a-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -65,7 +65,7 @@
                 "properties": {
                     "port": 80,
                     "probe": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--"
                     },
                     "protocol": "Http"
                 }
@@ -152,6 +152,30 @@
                     "interval": 30,
                     "path": "/",
                     "protocol": "Https",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-a-80---name--",
+                "name": "pb-test-ingress-controller-hello-world-a-80---name--",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/A/",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb-test-ingress-controller-hello-world-b-80---name--",
+                "name": "pb-test-ingress-controller-hello-world-b-80---name--",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/",
+                    "protocol": "Http",
                     "timeout": 30,
                     "unhealthyThreshold": 3
                 }


### PR DESCRIPTION
These are the (semantically incompatible) tests for https://github.com/Azure/application-gateway-kubernetes-ingress/pull/591

These tests cover https://github.com/Azure/application-gateway-kubernetes-ingress/issues/571

I corrected the warming up of the secrets cache (and added proper secrets), which enabled TLS for these tests, hence the larger than expected changes.

The new addition to the test suite is `functional_tests/two_ingresses_same_domain_tls_notls.json`  and the https://github.com/Azure/application-gateway-kubernetes-ingress/compare/draychev/fix-sslredirect?expand=1#diff-f184c6b27beefd59b48cbee1236306efR502