### PR TITLE
fix GH markdown causing rendering bug

### DIFF
--- a/docs/setup/install-new.md
+++ b/docs/setup/install-new.md
@@ -175,7 +175,7 @@ Now that we have App Gateway, AKS, and AGIC installed we can install a sample ap
 via [Azure Cloud Shell](https://shell.azure.com/):
 
  ```yaml
- cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:

--- a/docs/setup/install-new.md
+++ b/docs/setup/install-new.md
@@ -92,17 +92,17 @@ Get credentials for your newly deployed AKS ([read more](https://docs.microsoft.
 
   To install AAD Pod Identity to your cluster:
 
-    - *RBAC enabled* AKS cluster
+   - *RBAC enabled* AKS cluster
 
-    ```bash
-    kubectl create -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment-rbac.yaml
-    ```
+  ```bash
+  kubectl create -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment-rbac.yaml
+  ```
 
-    - *RBAC disabled* AKS cluster
+   - *RBAC disabled* AKS cluster
 
-    ```bash
-    kubectl create -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment.yaml
-    ```
+  ```bash
+  kubectl create -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment.yaml
+  ```
 
 ### Install Helm
 [Helm](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm) is a package manager for
@@ -174,8 +174,9 @@ Kubernetes. We will leverage it to install the `application-gateway-kubernetes-i
 Now that we have App Gateway, AKS, and AGIC installed we can install a sample app
 via [Azure Cloud Shell](https://shell.azure.com/):
 
- ```bash
-cat <<EOF | kubectl apply -f -
+Save the below yaml as `aspnetapp.yaml` and run `kubectl apply -f aspnetapp.yaml`
+
+ ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -220,7 +221,6 @@ spec:
         backend:
           serviceName: aspnetapp
           servicePort: 80
-EOF
 ```
 
 Alternatively you can:

--- a/docs/setup/install-new.md
+++ b/docs/setup/install-new.md
@@ -174,9 +174,8 @@ Kubernetes. We will leverage it to install the `application-gateway-kubernetes-i
 Now that we have App Gateway, AKS, and AGIC installed we can install a sample app
 via [Azure Cloud Shell](https://shell.azure.com/):
 
-Save the below yaml as `aspnetapp.yaml` and run `kubectl apply -f aspnetapp.yaml`
-
  ```yaml
+ cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -221,6 +220,7 @@ spec:
         backend:
           serviceName: aspnetapp
           servicePort: 80
+EOF
 ```
 
 Alternatively you can:


### PR DESCRIPTION
#594

The yaml in bash toward the bottom of this document was being rendered incorrectly on the docs site. I changed the style to be in line with [your websockets page](https://azure.github.io/application-gateway-kubernetes-ingress/how-tos/websockets/) which renders it correctly. 

![image](https://user-images.githubusercontent.com/15880760/66355820-ab1fbb00-e936-11e9-82bf-631c3bd0c903.png)

Also the indentation under [Install AAD Pod Identity](https://azure.github.io/application-gateway-kubernetes-ingress/setup/install-new/#install-aad-pod-identity) had the bulleted list being rendered as a code block. 

![image](https://user-images.githubusercontent.com/15880760/66355904-efab5680-e936-11e9-9ae3-f2be0e83d097.png)

