### PR TITLE
deploy: deploy subnet when subnet prefix is given

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -93,6 +93,8 @@ func main() {
 	azContext, err := azure.NewAzContext(env.AzContextLocation)
 	if err != nil {
 		glog.Info("Unable to load Azure Context file:", env.AzContextLocation)
+	} else if azContext.VNetResourceGroup == "" {
+		azContext.VNetResourceGroup = azContext.ResourceGroup
 	}
 
 	// adjust env variable

--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -96,8 +96,11 @@ func main() {
 	}
 
 	// adjust env variable
-	if env.AppGwName == "" {
-		env.AppGwName = env.ReleaseName
+	if env.AppGwResourceID != "" {
+		subscriptionID, resourceGroupName, applicationGatewayName := azure.ParseResourceID(env.AppGwResourceID)
+		env.SubscriptionID = string(subscriptionID)
+		env.ResourceGroupName = string(resourceGroupName)
+		env.AppGwName = string(applicationGatewayName)
 	}
 	if azContext != nil && env.SubscriptionID == "" {
 		env.SubscriptionID = string(azContext.SubscriptionID)

--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -99,12 +99,14 @@ func main() {
 	if env.AppGwName == "" {
 		env.AppGwName = env.ReleaseName
 	}
-
 	if azContext != nil && env.SubscriptionID == "" {
 		env.SubscriptionID = string(azContext.SubscriptionID)
 	}
 	if azContext != nil && env.ResourceGroupName == "" {
 		env.ResourceGroupName = string(azContext.ResourceGroup)
+	}
+	if env.AppGwSubnetName == "" {
+		env.AppGwSubnetName = env.AppGwName + "-subnet"
 	}
 
 	if err := environment.ValidateEnv(env); err != nil {
@@ -127,11 +129,8 @@ func main() {
 		if err == azure.ErrAppGatewayNotFound && env.EnableDeployAppGateway {
 			if env.AppGwSubnetID != "" {
 				err = azClient.DeployGatewayWithSubnet(env.AppGwSubnetID)
-			} else if env.AppGwVnetID != "" {
-				_, vnetResourceGroup, vnetName := azure.ParseResourceID(env.AppGwVnetID)
-				err = azClient.DeployGatewayWithVnet(vnetResourceGroup, vnetName, env.AppGwSubnetPrefix)
 			} else if azContext != nil {
-				err = azClient.DeployGatewayWithVnet(azure.ResourceGroup(azContext.VNetResourceGroup), azure.ResourceName(azContext.VNetName), env.AppGwSubnetPrefix)
+				err = azClient.DeployGatewayWithVnet(azure.ResourceGroup(azContext.VNetResourceGroup), azure.ResourceName(azContext.VNetName), azure.ResourceName(env.AppGwSubnetName), env.AppGwSubnetPrefix)
 			}
 
 			if err != nil {

--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -1,13 +1,21 @@
 {{- if required "A valid appgw entry is required!" .Values.appgw }}
 {{- end }}
 
-{{- if required "please provide a value for appgw.name in the helm config." .Values.appgw.name }}
-{{- end}}}
+{{- if not .Values.appgw.applicationGatewayID }}
+  {{- if not .Values.appgw.name }}
+    {{- if required "Please either provide appgw.applicationGatewayID or appgw.name" .Values.appgw.applicationGatewayID }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 
-{{- if .Values.appgw.create }}
-  {{- if required "Please provide appgw.subnetName or appgw.subnetId of an existing subnet. If you want AGIC to optionally create a new subnet, then also provide appgw.subnetPrefix." .Values.appgw.name }}
-  {{- end}}}
-{{- end -}}}}}
+{{- if .Values.appgw.name }}
+  {{- if not .Values.appgw.subnetPrefix }}
+  {{- if not .Values.appgw.subnetID }}
+    {{- if required "Please provide appgw.subnetPrefix or appgw.subnetID of an existing subnet" .Values.appgw.subnetPrefix }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}
 
 apiVersion: v1
 kind: ConfigMap
@@ -19,33 +27,41 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 data:
-  APPGW_SUBSCRIPTION_ID: {{ .Values.appgw.subscriptionId }}
-  APPGW_RESOURCE_GROUP:  {{ .Values.appgw.resourceGroup }}
-  APPGW_NAME:            {{ .Values.appgw.name }}
-  APPGW_SUBNETPREFIX:    {{ .Values.appgw.subnetPrefix }}
-  APPGW_SUBNETID:        {{ .Values.appgw.subnetId }}
-  APPGW_SUBNETNAME:      {{ .Values.appgw.subnetName }}
-  RELEASE_NAME:          {{ .Release.Name }}
-  APPGW_VERBOSITY_LEVEL: "{{ .Values.verbosityLevel }}"
-{{- if .Values.kubernetes }}
+  APPGW_VERBOSITY_LEVEL: {{ .Values.verbosityLevel | quote }}
+  HTTP_SERVICE_PORT:     {{ .Values.kubernetes.httpServicePort | quote }}
+  USE_PRIVATE_IP:        {{ .Values.appgw.usePrivateIP | quote }}
+
+{{- if .Values.appgw.applicationGatewayID }}
+  APPGW_RESOURCE_ID: {{ .Values.appgw.applicationGatewayID | quote }}
+{{- else }}
+  APPGW_SUBSCRIPTION_ID: {{ .Values.appgw.subscriptionId | quote }}
+  APPGW_RESOURCE_GROUP:  {{ .Values.appgw.resourceGroup | quote }}
+  APPGW_NAME:            {{ .Values.appgw.name | quote }}
+  APPGW_ENABLE_DEPLOY:   "true"
+
+  {{- if .Values.appgw.subnetID }}
+  APPGW_SUBNET_ID: {{ .Values.appgw.subnetID | quote }}
+  {{- else }}
+  {{- if .Values.appgw.subnetName }}
+  APPGW_SUBNET_NAME: {{ .Values.appgw.subnetName | quote }}
+  {{- else }}
+  APPGW_SUBNET_NAME: "{{ .Values.appgw.name }}-subnet"
+  {{- end }}
+  APPGW_SUBNET_PREFIX: {{ .Values.appgw.subnetPrefix | quote }} 
+  {{- end }}
+
+{{- end }}
+
+{{- if .Values.appgw.shared }}
+  APPGW_ENABLE_SHARED_APPGW: {{ .Values.appgw.shared | quote }}
+{{- end }}
+
 {{- if .Values.kubernetes.watchNamespace }}
   KUBERNETES_WATCHNAMESPACE: "{{ .Values.kubernetes.watchNamespace }}"
 {{- end }}
-{{- if .Values.kubernetes.httpServicePort }}
-  HTTP_SERVICE_PORT: "{{ .Values.kubernetes.httpServicePort }}"
-{{- end }}
-{{- end }}
-  USE_PRIVATE_IP: "{{ .Values.appgw.usePrivateIP }}"
-{{- if .Values.appgw }}
-{{- if .Values.appgw.shared }}
-  APPGW_ENABLE_SHARED_APPGW: "{{ .Values.appgw.shared }}"
-{{- end }}
-{{- end }}
+
 {{- if .Values.armAuth -}}
 {{- if eq .Values.armAuth.type "aadPodIdentity"}}
   USE_MANAGED_IDENTITY_FOR_POD: "true"
 {{- end }}
-{{- end }}
-{{- if .Values.appgw.create }}
-  APPGW_ENABLE_DEPLOY_APPGATEWAY: "{{ .Values.appgw.create }}"
 {{- end }}

--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -1,6 +1,14 @@
 {{- if required "A valid appgw entry is required!" .Values.appgw }}
 {{- end }}
 
+{{- if required "please provide a value for appgw.name in the helm config." .Values.appgw.name }}
+{{- end}}}
+
+{{- if .Values.appgw.create }}
+  {{- if required "Please provide appgw.subnetName or appgw.subnetId of an existing subnet. If you want AGIC to optionally create a new subnet, then also provide appgw.subnetPrefix." .Values.appgw.name }}
+  {{- end}}}
+{{- end -}}}}}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,9 +22,9 @@ data:
   APPGW_SUBSCRIPTION_ID: {{ .Values.appgw.subscriptionId }}
   APPGW_RESOURCE_GROUP:  {{ .Values.appgw.resourceGroup }}
   APPGW_NAME:            {{ .Values.appgw.name }}
-  APPGW_SUBNETID:        {{ .Values.appgw.subnetId }}
-  APPGW_VNETID:          {{ .Values.appgw.vnetId }}
   APPGW_SUBNETPREFIX:    {{ .Values.appgw.subnetPrefix }}
+  APPGW_SUBNETID:        {{ .Values.appgw.subnetId }}
+  APPGW_SUBNETNAME:      {{ .Values.appgw.subnetName }}
   RELEASE_NAME:          {{ .Release.Name }}
   APPGW_VERBOSITY_LEVEL: "{{ .Values.verbosityLevel }}"
 {{- if .Values.kubernetes }}

--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -15,6 +15,8 @@ data:
   APPGW_RESOURCE_GROUP:  {{ .Values.appgw.resourceGroup }}
   APPGW_NAME:            {{ .Values.appgw.name }}
   APPGW_SUBNETID:        {{ .Values.appgw.subnetId }}
+  APPGW_VNETID:          {{ .Values.appgw.vnetId }}
+  APPGW_SUBNETPREFIX:    {{ .Values.appgw.subnetPrefix }}
   RELEASE_NAME:          {{ .Release.Name }}
   APPGW_VERBOSITY_LEVEL: "{{ .Values.verbosityLevel }}"
 {{- if .Values.kubernetes }}

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -8,6 +8,7 @@ package azure
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	r "github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
@@ -22,17 +23,20 @@ import (
 type AzClient interface {
 	GetGateway() (n.ApplicationGateway, error)
 	UpdateGateway(*n.ApplicationGateway) error
-	DeployGateway(string) error
+	DeployGatewayWithVnet(ResourceGroup, ResourceName, string) error
+	DeployGatewayWithSubnet(string) error
 
 	GetPublicIP(string) (n.PublicIPAddress, error)
 }
 
 type azClient struct {
-	appGatewaysClient n.ApplicationGatewaysClient
-	publicIPsClient   n.PublicIPAddressesClient
-	groupsClient      r.GroupsClient
-	deploymentsClient r.DeploymentsClient
-	authorizer        autorest.Authorizer
+	appGatewaysClient     n.ApplicationGatewaysClient
+	publicIPsClient       n.PublicIPAddressesClient
+	virtualNetworksClient n.VirtualNetworksClient
+	subnetsClient         n.SubnetsClient
+	groupsClient          r.GroupsClient
+	deploymentsClient     r.DeploymentsClient
+	authorizer            autorest.Authorizer
 
 	subscriptionID    SubscriptionID
 	resourceGroupName ResourceGroup
@@ -45,13 +49,15 @@ type azClient struct {
 func NewAzClient(subscriptionID SubscriptionID, resourceGroupName ResourceGroup, appGwName ResourceName, authorizer autorest.Authorizer) AzClient {
 	userAgent := fmt.Sprintf("ingress-appgw/%s", version.Version)
 	az := &azClient{
-		appGatewaysClient: n.NewApplicationGatewaysClient(string(subscriptionID)),
-		publicIPsClient:   n.NewPublicIPAddressesClient(string(subscriptionID)),
-		groupsClient:      r.NewGroupsClient(string(subscriptionID)),
-		deploymentsClient: r.NewDeploymentsClient(string(subscriptionID)),
-		subscriptionID:    subscriptionID,
-		resourceGroupName: resourceGroupName,
-		appGwName:         appGwName,
+		appGatewaysClient:     n.NewApplicationGatewaysClient(string(subscriptionID)),
+		publicIPsClient:       n.NewPublicIPAddressesClient(string(subscriptionID)),
+		virtualNetworksClient: n.NewVirtualNetworksClient(string(subscriptionID)),
+		subnetsClient:         n.NewSubnetsClient(string(subscriptionID)),
+		groupsClient:          r.NewGroupsClient(string(subscriptionID)),
+		deploymentsClient:     r.NewDeploymentsClient(string(subscriptionID)),
+		subscriptionID:        subscriptionID,
+		resourceGroupName:     resourceGroupName,
+		appGwName:             appGwName,
 
 		ctx:        context.Background(),
 		authorizer: authorizer,
@@ -62,7 +68,10 @@ func NewAzClient(subscriptionID SubscriptionID, resourceGroupName ResourceGroup,
 
 	az.publicIPsClient.AddToUserAgent(userAgent)
 	az.publicIPsClient.Authorizer = az.authorizer
-
+	az.virtualNetworksClient.AddToUserAgent(userAgent)
+	az.virtualNetworksClient.Authorizer = az.authorizer
+	az.subnetsClient.AddToUserAgent(userAgent)
+	az.subnetsClient.Authorizer = az.authorizer
 	az.groupsClient.AddToUserAgent(userAgent)
 	az.groupsClient.Authorizer = az.authorizer
 
@@ -96,8 +105,32 @@ func (az *azClient) GetPublicIP(resourceID string) (n.PublicIPAddress, error) {
 }
 
 // DeployGateway is a method that deploy the appgw and related resources
-func (az *azClient) DeployGateway(subnetID string) (err error) {
+func (az *azClient) DeployGatewayWithVnet(resourceGroupName ResourceGroup, vnetName ResourceName, subnetPrefix string) (err error) {
+	vnet, err := az.getVnet(resourceGroupName, vnetName)
+	if err != nil {
+		return
+	}
+
+	glog.Infof("Checking the Vnet %s for a subnet with prefix %s", vnetName, subnetPrefix)
+	subnet, err := az.findSubnet(vnet, subnetPrefix)
+	if err != nil {
+		subnetName := string(az.appGwName) + "-subnet"
+		glog.Infof("Unable to find a subnet. Creating a subnet %s with prefix %s in Vnet %s", subnetName, subnetPrefix, vnetName)
+		subnet, err = az.createSubnet(vnet, subnetName, subnetPrefix)
+		if err != nil {
+			return
+		}
+	}
+
+	err = az.DeployGatewayWithSubnet(*subnet.ID)
+	return
+}
+
+// DeployGateway is a method that deploy the appgw and related resources
+func (az *azClient) DeployGatewayWithSubnet(subnetID string) (err error) {
 	glog.Infof("Deploying Gateway")
+
+	// Check if group exists
 	group, err := az.getGroup()
 	if err != nil {
 		return
@@ -122,6 +155,41 @@ func (az *azClient) DeployGateway(subnetID string) (err error) {
 // Create a resource group for the deployment.
 func (az *azClient) getGroup() (r.Group, error) {
 	return az.groupsClient.Get(az.ctx, string(az.resourceGroupName))
+}
+
+func (az *azClient) getVnet(resourceGroupName ResourceGroup, vnetName ResourceName) (n.VirtualNetwork, error) {
+	return az.virtualNetworksClient.Get(az.ctx, string(resourceGroupName), string(vnetName), "")
+}
+
+func (az *azClient) findSubnet(vnet n.VirtualNetwork, subnetPrefix string) (subnet n.Subnet, err error) {
+	for _, subnet := range *vnet.Subnets {
+		if *subnet.AddressPrefix == subnetPrefix {
+			return subnet, nil
+		}
+	}
+	err = errors.New("Unable to find subnet")
+	return
+}
+
+func (az *azClient) createSubnet(vnet n.VirtualNetwork, subnetName string, subnetPrefix string) (subnet n.Subnet, err error) {
+	_, resourceGroup, vnetName := ParseResourceID(*vnet.ID)
+	subnet = n.Subnet{
+		SubnetPropertiesFormat: &n.SubnetPropertiesFormat{
+			AddressPrefix: &subnetPrefix,
+		},
+	}
+	subnetFuture, err := az.subnetsClient.CreateOrUpdate(az.ctx, string(resourceGroup), string(vnetName), subnetName, subnet)
+	if err != nil {
+		return
+	}
+
+	// Wait until deployment finshes and save the error message
+	err = subnetFuture.WaitForCompletionRef(az.ctx, az.subnetsClient.BaseClient.Client)
+	if err != nil {
+		return
+	}
+
+	return az.subnetsClient.Get(az.ctx, string(resourceGroup), string(vnetName), subnetName, "")
 }
 
 // Create the deployment

--- a/pkg/azure/fake.go
+++ b/pkg/azure/fake.go
@@ -48,10 +48,18 @@ func (az *FakeAzClient) UpdateGateway(appGwObj *n.ApplicationGateway) (err error
 	return nil
 }
 
-// DeployGateway runs DeployGatewayFunc
-func (az *FakeAzClient) DeployGateway(subnetID string) (err error) {
+// DeployGatewayWithSubnet runs DeployGatewayFunc
+func (az *FakeAzClient) DeployGatewayWithSubnet(subnetID string) (err error) {
 	if az.DeployGatewayFunc != nil {
 		return az.DeployGatewayFunc(subnetID)
+	}
+	return nil
+}
+
+// DeployGatewayWithVnet runs DeployGatewayFunc
+func (az *FakeAzClient) DeployGatewayWithVnet(resourceGroupName ResourceGroup, vnetName ResourceName, subnetPrefix string) (err error) {
+	if az.DeployGatewayFunc != nil {
+		return az.DeployGatewayFunc(subnetPrefix)
 	}
 	return nil
 }

--- a/pkg/azure/fake.go
+++ b/pkg/azure/fake.go
@@ -57,7 +57,7 @@ func (az *FakeAzClient) DeployGatewayWithSubnet(subnetID string) (err error) {
 }
 
 // DeployGatewayWithVnet runs DeployGatewayFunc
-func (az *FakeAzClient) DeployGatewayWithVnet(resourceGroupName ResourceGroup, vnetName ResourceName, subnetPrefix string) (err error) {
+func (az *FakeAzClient) DeployGatewayWithVnet(resourceGroupName ResourceGroup, vnetName ResourceName, subnetName ResourceName, subnetPrefix string) (err error) {
 	if az.DeployGatewayFunc != nil {
 		return az.DeployGatewayFunc(subnetPrefix)
 	}

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -26,14 +26,14 @@ const (
 	// AppGwNameVarName is the name of the APPGW_NAME
 	AppGwNameVarName = "APPGW_NAME"
 
+	// AppGwSubnetPrefixVarName is the name of the APPGW_SUBNETPREFIX
+	AppGwSubnetPrefixVarName = "APPGW_SUBNETPREFIX"
+
 	// AppGwSubnetIDVarName is the name of the APPGW_SUBNETID
 	AppGwSubnetIDVarName = "APPGW_SUBNETID"
 
-	// AppGwVnetIDVarName is the name of the APPGW_VNETID
-	AppGwVnetIDVarName = "APPGW_VNETID"
-
-	// AppGwSubnetPrefixVarName is the name of the APPGW_SUBNETPREFIX
-	AppGwSubnetPrefixVarName = "APPGW_SUBNETPREFIX"
+	// AppGwSubnetNameVarName is the name of the APPGW_SUBNETNAME
+	AppGwSubnetNameVarName = "APPGW_SUBNETNAME"
 
 	// ReleaseNameVarName is the name of the RELEASE_NAME
 	ReleaseNameVarName = "RELEASE_NAME"
@@ -84,9 +84,9 @@ type EnvVariables struct {
 	SubscriptionID             string
 	ResourceGroupName          string
 	AppGwName                  string
-	AppGwSubnetID              string
-	AppGwVnetID                string
 	AppGwSubnetPrefix          string
+	AppGwSubnetID              string
+	AppGwSubnetName            string
 	ReleaseName                string
 	AuthLocation               string
 	WatchNamespace             string
@@ -113,9 +113,9 @@ func GetEnv() EnvVariables {
 		SubscriptionID:             os.Getenv(SubscriptionIDVarName),
 		ResourceGroupName:          os.Getenv(ResourceGroupNameVarName),
 		AppGwName:                  os.Getenv(AppGwNameVarName),
-		AppGwSubnetID:              os.Getenv(AppGwSubnetIDVarName),
-		AppGwVnetID:                os.Getenv(AppGwVnetIDVarName),
 		AppGwSubnetPrefix:          os.Getenv(AppGwSubnetPrefixVarName),
+		AppGwSubnetID:              os.Getenv(AppGwSubnetIDVarName),
+		AppGwSubnetName:            os.Getenv(AppGwSubnetNameVarName),
 		ReleaseName:                os.Getenv(ReleaseNameVarName),
 		AuthLocation:               os.Getenv(AuthLocationVarName),
 		WatchNamespace:             os.Getenv(WatchNamespaceVarName),
@@ -137,11 +137,12 @@ func GetEnv() EnvVariables {
 
 // ValidateEnv validates environment variables.
 func ValidateEnv(env EnvVariables) error {
-	if env.EnableDeployAppGateway && len(env.AppGwSubnetID) == 0 && len(env.AppGwSubnetPrefix) == 0 {
+	if len(env.AppGwName) == 0 {
+		return errors.New("Missing required Environment variables: Provide atleast provide APPGW_NAME. You can also provided APPGW_SUBSCRIPTION_ID and APPGW_RESOURCE_GROUP (ENVT001)")
+	}
+	if env.EnableDeployAppGateway && len(env.AppGwSubnetID) == 0 && len(env.AppGwSubnetPrefix) == 0 && len(env.AppGwSubnetName) == 0 {
 		// when create is true, then either we should have env.AppGwSubnetID or env.AppGwSubnetPrefix
-		return errors.New("Missing required Environment variables: Please provide APPGW_SUBNETID or APPGW_SUBNETPREFIX used to create the App Gateway (ENVT001)")
-	} else if len(env.SubscriptionID) == 0 || len(env.ResourceGroupName) == 0 || len(env.AppGwName) == 0 {
-		return errors.New("Missing required Environment variables: Provide APPGW_SUBSCRIPTION_ID, APPGW_RESOURCE_GROUP and APPGW_NAME (ENVT002)")
+		return errors.New("Missing required Environment variables: Please provide APPGW_SUBNETNAME or APPGW_SUBNETID of an existing subnet. If you want AGIC to optionally create a new subnet, then also provide APPGW_SUBNETPREFIX (ENVT002)")
 	}
 
 	if env.WatchNamespace == "" {

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -26,17 +26,17 @@ const (
 	// AppGwNameVarName is the name of the APPGW_NAME
 	AppGwNameVarName = "APPGW_NAME"
 
-	// AppGwSubnetPrefixVarName is the name of the APPGW_SUBNETPREFIX
-	AppGwSubnetPrefixVarName = "APPGW_SUBNETPREFIX"
+	// AppGwSubnetNameVarName is the name of the APPGW_SUBNET_NAME
+	AppGwSubnetNameVarName = "APPGW_SUBNET_NAME"
 
-	// AppGwSubnetIDVarName is the name of the APPGW_SUBNETID
-	AppGwSubnetIDVarName = "APPGW_SUBNETID"
+	// AppGwSubnetPrefixVarName is the name of the APPGW_SUBNET_PREFIX
+	AppGwSubnetPrefixVarName = "APPGW_SUBNET_PREFIX"
 
-	// AppGwSubnetNameVarName is the name of the APPGW_SUBNETNAME
-	AppGwSubnetNameVarName = "APPGW_SUBNETNAME"
+	// AppGwResourceIDVarName is the name of the APPGW_RESOURCE_ID
+	AppGwResourceIDVarName = "APPGW_RESOURCE_ID"
 
-	// ReleaseNameVarName is the name of the RELEASE_NAME
-	ReleaseNameVarName = "RELEASE_NAME"
+	// AppGwSubnetIDVarName is the name of the APPGW_SUBNET_ID
+	AppGwSubnetIDVarName = "APPGW_SUBNET_ID"
 
 	// AuthLocationVarName is the name of the AZURE_AUTH_LOCATION
 	AuthLocationVarName = "AZURE_AUTH_LOCATION"
@@ -63,7 +63,7 @@ const (
 	EnablePanicOnPutErrorVarName = "APPGW_ENABLE_PANIC_ON_PUT_ERROR"
 
 	// EnableDeployAppGatewayVarName is a feature flag.
-	EnableDeployAppGatewayVarName = "APPGW_ENABLE_DEPLOY_APPGATEWAY"
+	EnableDeployAppGatewayVarName = "APPGW_ENABLE_DEPLOY"
 
 	// HTTPServicePortVarName is an environment variable name.
 	HTTPServicePortVarName = "HTTP_SERVICE_PORT"
@@ -84,10 +84,10 @@ type EnvVariables struct {
 	SubscriptionID             string
 	ResourceGroupName          string
 	AppGwName                  string
-	AppGwSubnetPrefix          string
-	AppGwSubnetID              string
 	AppGwSubnetName            string
-	ReleaseName                string
+	AppGwSubnetPrefix          string
+	AppGwResourceID            string
+	AppGwSubnetID              string
 	AuthLocation               string
 	WatchNamespace             string
 	UsePrivateIP               string
@@ -113,10 +113,10 @@ func GetEnv() EnvVariables {
 		SubscriptionID:             os.Getenv(SubscriptionIDVarName),
 		ResourceGroupName:          os.Getenv(ResourceGroupNameVarName),
 		AppGwName:                  os.Getenv(AppGwNameVarName),
-		AppGwSubnetPrefix:          os.Getenv(AppGwSubnetPrefixVarName),
-		AppGwSubnetID:              os.Getenv(AppGwSubnetIDVarName),
 		AppGwSubnetName:            os.Getenv(AppGwSubnetNameVarName),
-		ReleaseName:                os.Getenv(ReleaseNameVarName),
+		AppGwSubnetPrefix:          os.Getenv(AppGwSubnetPrefixVarName),
+		AppGwResourceID:            os.Getenv(AppGwResourceIDVarName),
+		AppGwSubnetID:              os.Getenv(AppGwSubnetIDVarName),
 		AuthLocation:               os.Getenv(AuthLocationVarName),
 		WatchNamespace:             os.Getenv(WatchNamespaceVarName),
 		UsePrivateIP:               os.Getenv(UsePrivateIPVarName),
@@ -140,7 +140,7 @@ func ValidateEnv(env EnvVariables) error {
 	if len(env.AppGwName) == 0 {
 		return errors.New("Missing required Environment variables: Provide atleast provide APPGW_NAME. You can also provided APPGW_SUBSCRIPTION_ID and APPGW_RESOURCE_GROUP (ENVT001)")
 	}
-	if env.EnableDeployAppGateway && len(env.AppGwSubnetID) == 0 && len(env.AppGwSubnetPrefix) == 0 && len(env.AppGwSubnetName) == 0 {
+	if env.EnableDeployAppGateway && (len(env.AppGwResourceID) == 0 && len(env.AppGwSubnetPrefix) == 0 && len(env.AppGwSubnetName) == 0) {
 		// when create is true, then either we should have env.AppGwSubnetID or env.AppGwSubnetPrefix
 		return errors.New("Missing required Environment variables: Please provide APPGW_SUBNETNAME or APPGW_SUBNETID of an existing subnet. If you want AGIC to optionally create a new subnet, then also provide APPGW_SUBNETPREFIX (ENVT002)")
 	}

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -29,6 +29,12 @@ const (
 	// AppGwSubnetIDVarName is the name of the APPGW_SUBNETID
 	AppGwSubnetIDVarName = "APPGW_SUBNETID"
 
+	// AppGwVnetIDVarName is the name of the APPGW_VNETID
+	AppGwVnetIDVarName = "APPGW_VNETID"
+
+	// AppGwSubnetPrefixVarName is the name of the APPGW_SUBNETPREFIX
+	AppGwSubnetPrefixVarName = "APPGW_SUBNETPREFIX"
+
 	// ReleaseNameVarName is the name of the RELEASE_NAME
 	ReleaseNameVarName = "RELEASE_NAME"
 
@@ -79,6 +85,8 @@ type EnvVariables struct {
 	ResourceGroupName          string
 	AppGwName                  string
 	AppGwSubnetID              string
+	AppGwVnetID                string
+	AppGwSubnetPrefix          string
 	ReleaseName                string
 	AuthLocation               string
 	WatchNamespace             string
@@ -106,6 +114,8 @@ func GetEnv() EnvVariables {
 		ResourceGroupName:          os.Getenv(ResourceGroupNameVarName),
 		AppGwName:                  os.Getenv(AppGwNameVarName),
 		AppGwSubnetID:              os.Getenv(AppGwSubnetIDVarName),
+		AppGwVnetID:                os.Getenv(AppGwVnetIDVarName),
+		AppGwSubnetPrefix:          os.Getenv(AppGwSubnetPrefixVarName),
 		ReleaseName:                os.Getenv(ReleaseNameVarName),
 		AuthLocation:               os.Getenv(AuthLocationVarName),
 		WatchNamespace:             os.Getenv(WatchNamespaceVarName),
@@ -127,8 +137,9 @@ func GetEnv() EnvVariables {
 
 // ValidateEnv validates environment variables.
 func ValidateEnv(env EnvVariables) error {
-	if env.EnableDeployAppGateway && len(env.AppGwSubnetID) == 0 {
-		return errors.New("Missing required Environment variables: Provide APPGW_SUBNETID (ENVT001)")
+	if env.EnableDeployAppGateway && len(env.AppGwSubnetID) == 0 && len(env.AppGwSubnetPrefix) == 0 {
+		// when create is true, then either we should have env.AppGwSubnetID or env.AppGwSubnetPrefix
+		return errors.New("Missing required Environment variables: Please provide APPGW_SUBNETID or APPGW_SUBNETPREFIX used to create the App Gateway (ENVT001)")
 	} else if len(env.SubscriptionID) == 0 || len(env.ResourceGroupName) == 0 || len(env.AppGwName) == 0 {
 		return errors.New("Missing required Environment variables: Provide APPGW_SUBSCRIPTION_ID, APPGW_RESOURCE_GROUP and APPGW_NAME (ENVT002)")
 	}


### PR DESCRIPTION
This PR adds new parameters to the helm config.
1. `applicationGatewayID`
1. `subnetPrefix`
1. `subnetName`

Add new validations:
1. Either `applicationGatewayID` or `name` should be given.
1. When `applicationGatewayID`, it is bring your own appgw case.
1. When appgw's `name` is used, then we assume that it is a create case. We ask for either `subnetID` or `subnetPrefix`.