### PR TITLE
metrics: add more metrics for Prometheus metric server

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -84,9 +84,10 @@ func main() {
 	istioCrdClient := istio.NewForConfigOrDie(apiConfig)
 	recorder := getEventRecorder(kubeClient)
 	namespaces := getNamespacesToWatch(env.WatchNamespace)
-	k8sContext := k8scontext.NewContext(kubeClient, crdClient, istioCrdClient, namespaces, *resyncPeriod)
-	agicPod := k8sContext.GetAGICPod(env)
 	metricStore := metricstore.NewMetricStore(env)
+	metricStore.Start()
+	k8sContext := k8scontext.NewContext(kubeClient, crdClient, istioCrdClient, namespaces, *resyncPeriod, metricStore)
+	agicPod := k8sContext.GetAGICPod(env)
 
 	// get the details from Azure Context
 	azContext, err := azure.NewAzContext(env.AzContextLocation)

--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 
 	. "github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
@@ -334,7 +335,7 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 
 		crdClient := fake.NewSimpleClientset()
 		istioCrdClient := istio_fake.NewSimpleClientset()
-		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{tests.Namespace}, 1000*time.Second)
+		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{tests.Namespace}, 1000*time.Second, metricstore.NewFakeMetricStore())
 
 		secKey := utils.GetResourceKey(ingressSecret.Namespace, ingressSecret.Name)
 		_ = ctxt.CertificateSecretStore.ConvertSecret(secKey, ingressSecret)

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -29,6 +29,7 @@ import (
 	istio_fake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned/fake"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
@@ -438,7 +439,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 		// Create a `k8scontext` to start listiening to ingress resources.
 
-		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second)
+		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second, metricstore.NewFakeMetricStore())
 		Expect(ctxt).ShouldNot(BeNil(), "Unable to create `k8scontext`")
 
 		// Initialize the `ConfigBuilder`

--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -28,6 +28,7 @@ import (
 	istio_fake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned/fake"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 )
@@ -199,7 +200,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 		crdClient := fake.NewSimpleClientset()
 		istioCrdClient := istio_fake.NewSimpleClientset()
-		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second)
+		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second, metricstore.NewFakeMetricStore())
 
 		appGwy := &n.ApplicationGateway{
 			ApplicationGatewayPropertiesFormat: NewAppGwyConfigFixture(),

--- a/pkg/appgw/public_and_private_ip_test.go
+++ b/pkg/appgw/public_and_private_ip_test.go
@@ -28,6 +28,7 @@ import (
 	istio_fake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned/fake"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
@@ -224,7 +225,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 	crdClient := fake.NewSimpleClientset()
 	istioCrdClient := istio_fake.NewSimpleClientset()
-	ctxt := k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second)
+	ctxt := k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second, metricstore.NewFakeMetricStore())
 
 	secret := tests.NewSecretTestFixture()
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -61,8 +61,6 @@ func NewAppGwIngressController(azClient azure.AzClient, appGwIdentifier appgw.Id
 // Start function runs the k8scontext and continues to listen to the
 // event channel and enqueue events before stopChannel is closed
 func (c *AppGwIngressController) Start(envVariables environment.EnvVariables) error {
-	c.metricStore.Start()
-
 	// Starts k8scontext which contains all the informers
 	// This will start individual go routines for informers
 	if err := c.k8sContext.Run(c.stopChannel, false, envVariables); err != nil {

--- a/pkg/controller/process_test.go
+++ b/pkg/controller/process_test.go
@@ -24,6 +24,7 @@ import (
 	istio_fake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned/fake"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
 )
@@ -53,7 +54,7 @@ var _ = Describe("process function tests", func() {
 		ingress = tests.NewIngressFixture()
 
 		// Create a `k8scontext` to start listening to ingress resources.
-		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{tests.Namespace}, 1000*time.Second)
+		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{tests.Namespace}, 1000*time.Second, metricstore.NewFakeMetricStore())
 
 		_, err := k8sClient.CoreV1().Namespaces().Create(ns)
 		Expect(err).Should(BeNil(), "Unable to create the namespace %s: %v", tests.Name, err)

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -30,6 +30,7 @@ import (
 	istio_externalversions "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/informers/externalversions"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
@@ -38,7 +39,7 @@ const providerPrefix = "azure://"
 const workBuffer = 1024
 
 // NewContext creates a context based on a Kubernetes client instance.
-func NewContext(kubeClient kubernetes.Interface, crdClient versioned.Interface, istioCrdClient istio_versioned.Interface, namespaces []string, resyncPeriod time.Duration) *Context {
+func NewContext(kubeClient kubernetes.Interface, crdClient versioned.Interface, istioCrdClient istio_versioned.Interface, namespaces []string, resyncPeriod time.Duration, metricStore metricstore.MetricStore) *Context {
 	var options []informers.SharedInformerOption
 	var crdOptions []externalversions.SharedInformerOption
 	for _, namespace := range namespaces {
@@ -84,6 +85,8 @@ func NewContext(kubeClient kubernetes.Interface, crdClient versioned.Interface, 
 		CertificateSecretStore: NewSecretStore(),
 		Work:                   make(chan events.Event, workBuffer),
 		CacheSynced:            make(chan interface{}),
+
+		metricStore: metricStore,
 	}
 
 	h := handlers{context}

--- a/pkg/k8scontext/handlers.go
+++ b/pkg/k8scontext/handlers.go
@@ -16,6 +16,7 @@ func (h handlers) addFunc(obj interface{}) {
 		Type:  events.Create,
 		Value: obj,
 	}
+	h.context.metricStore.IncK8sAPIEventCounter()
 }
 
 func (h handlers) updateFunc(oldObj, newObj interface{}) {
@@ -26,6 +27,7 @@ func (h handlers) updateFunc(oldObj, newObj interface{}) {
 		Type:  events.Update,
 		Value: newObj,
 	}
+	h.context.metricStore.IncK8sAPIEventCounter()
 }
 
 func (h handlers) deleteFunc(obj interface{}) {
@@ -33,4 +35,5 @@ func (h handlers) deleteFunc(obj interface{}) {
 		Type:  events.Delete,
 		Value: obj,
 	}
+	h.context.metricStore.IncK8sAPIEventCounter()
 }

--- a/pkg/k8scontext/ingress_handlers.go
+++ b/pkg/k8scontext/ingress_handlers.go
@@ -43,6 +43,7 @@ func (h handlers) ingressAdd(obj interface{}) {
 		Type:  events.Create,
 		Value: obj,
 	}
+	h.context.metricStore.IncK8sAPIEventCounter()
 }
 
 func (h handlers) ingressDelete(obj interface{}) {
@@ -68,6 +69,7 @@ func (h handlers) ingressDelete(obj interface{}) {
 		Type:  events.Delete,
 		Value: obj,
 	}
+	h.context.metricStore.IncK8sAPIEventCounter()
 }
 
 func (h handlers) ingressUpdate(oldObj, newObj interface{}) {
@@ -105,4 +107,5 @@ func (h handlers) ingressUpdate(oldObj, newObj interface{}) {
 		Type:  events.Update,
 		Value: newObj,
 	}
+	h.context.metricStore.IncK8sAPIEventCounter()
 }

--- a/pkg/k8scontext/ingress_handlers_test.go
+++ b/pkg/k8scontext/ingress_handlers_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/fake"
 	istioFake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned/fake"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
 )
 
@@ -21,7 +22,7 @@ var _ = ginkgo.Describe("K8scontext Ingress Cache Handlers", func() {
 
 	ginkgo.Context("Test ingress handlers", func() {
 		h := handlers{
-			context: NewContext(k8sClient, fake.NewSimpleClientset(), istioFake.NewSimpleClientset(), []string{"ns"}, 1000*time.Second),
+			context: NewContext(k8sClient, fake.NewSimpleClientset(), istioFake.NewSimpleClientset(), []string{"ns"}, 1000*time.Second, metricstore.NewFakeMetricStore()),
 		}
 
 		ginkgo.It("add, delete, update ingress from cache", func() {

--- a/pkg/k8scontext/k8scontext_test.go
+++ b/pkg/k8scontext/k8scontext_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/fake"
 	istioFake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned/fake"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 )
 
@@ -91,7 +92,7 @@ var _ = ginkgo.Describe("K8scontext", func() {
 		Expect(err).ToNot(HaveOccurred(), "Unabled to create ingress resource due to: %v", err)
 
 		// Create a `k8scontext` to start listening to ingress resources.
-		ctxt = NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second)
+		ctxt = NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second, metricstore.NewFakeMetricStore())
 
 		Expect(ctxt).ShouldNot(BeNil(), "Unable to create `k8scontext`")
 	})

--- a/pkg/k8scontext/secrets_handlers.go
+++ b/pkg/k8scontext/secrets_handlers.go
@@ -26,6 +26,7 @@ func (h handlers) secretAdd(obj interface{}) {
 				Type:  events.Create,
 				Value: obj,
 			}
+			h.context.metricStore.IncK8sAPIEventCounter()
 		}
 	}
 }
@@ -43,6 +44,7 @@ func (h handlers) secretUpdate(oldObj, newObj interface{}) {
 				Type:  events.Update,
 				Value: newObj,
 			}
+			h.context.metricStore.IncK8sAPIEventCounter()
 		}
 	}
 }
@@ -68,5 +70,6 @@ func (h handlers) secretDelete(obj interface{}) {
 			Type:  events.Delete,
 			Value: obj,
 		}
+		h.context.metricStore.IncK8sAPIEventCounter()
 	}
 }

--- a/pkg/k8scontext/secrets_handlers_test.go
+++ b/pkg/k8scontext/secrets_handlers_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/fake"
 	istioFake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned/fake"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 )
 
 var _ = ginkgo.Describe("K8scontext Secrets Cache Handlers", func() {
@@ -21,7 +23,7 @@ var _ = ginkgo.Describe("K8scontext Secrets Cache Handlers", func() {
 
 	ginkgo.Context("Test secrets handlers", func() {
 		h := handlers{
-			context: NewContext(k8sClient, fake.NewSimpleClientset(), istioFake.NewSimpleClientset(), []string{"ns"}, 1000*time.Second),
+			context: NewContext(k8sClient, fake.NewSimpleClientset(), istioFake.NewSimpleClientset(), []string{"ns"}, 1000*time.Second, metricstore.NewFakeMetricStore()),
 		}
 
 		ginkgo.It("add, delete, update secrets from cache", func() {

--- a/pkg/k8scontext/types.go
+++ b/pkg/k8scontext/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned"
 	istio_versioned "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/istio_crd_client/clientset/versioned"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/metricstore"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
@@ -54,6 +55,8 @@ type Context struct {
 	Work chan events.Event
 
 	CacheSynced chan interface{}
+
+	metricStore metricstore.MetricStore
 }
 
 // IPAddress is type for IP address string

--- a/pkg/metricstore/fake.go
+++ b/pkg/metricstore/fake.go
@@ -34,3 +34,11 @@ func (ms *fakeMetricStore) Handler() http.Handler {
 }
 
 func (ms *fakeMetricStore) SetUpdateLatencySec(dur time.Duration) {}
+
+func (ms *fakeMetricStore) IncArmAPIUpdateCallFailureCounter() {}
+
+func (ms *fakeMetricStore) IncArmAPIUpdateCallSuccessCounter() {}
+
+func (ms *fakeMetricStore) IncArmAPICallCounter() {}
+
+func (ms *fakeMetricStore) IncK8sAPIEventCounter() {}

--- a/pkg/metricstore/metricstore.go
+++ b/pkg/metricstore/metricstore.go
@@ -27,12 +27,20 @@ type MetricStore interface {
 	Stop()
 	Handler() http.Handler
 	SetUpdateLatencySec(time.Duration)
+	IncArmAPIUpdateCallFailureCounter()
+	IncArmAPIUpdateCallSuccessCounter()
+	IncArmAPICallCounter()
+	IncK8sAPIEventCounter()
 }
 
 // AGICMetricStore is store
 type AGICMetricStore struct {
-	constLabels   prometheus.Labels
-	updateLatency prometheus.Gauge
+	constLabels                    prometheus.Labels
+	updateLatency                  prometheus.Gauge
+	k8sAPIEventCounter             prometheus.Counter
+	armAPICallCounter              prometheus.Counter
+	armAPIUpdateCallFailureCounter prometheus.Counter
+	armAPIUpdateCallSuccessCounter prometheus.Counter
 
 	registry *prometheus.Registry
 }
@@ -73,6 +81,28 @@ func (ms *AGICMetricStore) Stop() {
 // SetUpdateLatencySec updates latency
 func (ms *AGICMetricStore) SetUpdateLatencySec(duration time.Duration) {
 	ms.updateLatency.Set(duration.Seconds())
+}
+
+// IncArmAPIUpdateCallFailureCounter increases the counter for failure on ARM
+func (ms *AGICMetricStore) IncArmAPIUpdateCallFailureCounter() {
+	ms.armAPIUpdateCallFailureCounter.Inc()
+	ms.armAPICallCounter.Inc()
+}
+
+// IncArmAPIUpdateCallSuccessCounter increases the counter for success on ARM
+func (ms *AGICMetricStore) IncArmAPIUpdateCallSuccessCounter() {
+	ms.armAPIUpdateCallSuccessCounter.Inc()
+	ms.armAPICallCounter.Inc()
+}
+
+// IncArmAPICallCounter increases the counter for success on ARM
+func (ms *AGICMetricStore) IncArmAPICallCounter() {
+	ms.armAPICallCounter.Inc()
+}
+
+// IncK8sAPIEventCounter increases the counter after recieving a k8s Event
+func (ms *AGICMetricStore) IncK8sAPIEventCounter() {
+	ms.k8sAPIEventCounter.Inc()
 }
 
 // Handler return the registry

--- a/pkg/metricstore/metricstore.go
+++ b/pkg/metricstore/metricstore.go
@@ -60,9 +60,33 @@ func NewMetricStore(envVariable environment.EnvVariables) MetricStore {
 		constLabels: constLabels,
 		updateLatency: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace:   PrometheusNamespace,
+			ConstLabels: constLabels,
 			Name:        "update_latency_seconds",
 			Help:        "The time spent in updating Application Gateway",
+		}),
+		k8sAPIEventCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   PrometheusNamespace,
 			ConstLabels: constLabels,
+			Name:        "k8s_api_event_counter",
+			Help:        "This counter represents the number of events received from k8s API Server",
+		}),
+		armAPICallCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   PrometheusNamespace,
+			ConstLabels: constLabels,
+			Name:        "arm_api_call_counter",
+			Help:        "This counter represents the number of API calls to ARM",
+		}),
+		armAPIUpdateCallFailureCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   PrometheusNamespace,
+			ConstLabels: constLabels,
+			Name:        "arm_api_update_call_failure_counter",
+			Help:        "This counter represents the number of update API calls that failed to update Application Gateway",
+		}),
+		armAPIUpdateCallSuccessCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   PrometheusNamespace,
+			ConstLabels: constLabels,
+			Name:        "arm_api_update_call_success_counter",
+			Help:        "This counter represents the number of update API calls that successfully updated Application Gateway",
 		}),
 		registry: prometheus.NewRegistry(),
 	}
@@ -83,6 +107,11 @@ func (ms *AGICMetricStore) SetUpdateLatencySec(duration time.Duration) {
 	ms.updateLatency.Set(duration.Seconds())
 }
 
+// IncK8sAPIEventCounter increases the counter after recieving a k8s Event
+func (ms *AGICMetricStore) IncK8sAPIEventCounter() {
+	ms.k8sAPIEventCounter.Inc()
+}
+
 // IncArmAPIUpdateCallFailureCounter increases the counter for failure on ARM
 func (ms *AGICMetricStore) IncArmAPIUpdateCallFailureCounter() {
 	ms.armAPIUpdateCallFailureCounter.Inc()
@@ -98,11 +127,6 @@ func (ms *AGICMetricStore) IncArmAPIUpdateCallSuccessCounter() {
 // IncArmAPICallCounter increases the counter for success on ARM
 func (ms *AGICMetricStore) IncArmAPICallCounter() {
 	ms.armAPICallCounter.Inc()
-}
-
-// IncK8sAPIEventCounter increases the counter after recieving a k8s Event
-func (ms *AGICMetricStore) IncK8sAPIEventCounter() {
-	ms.k8sAPIEventCounter.Inc()
 }
 
 // Handler return the registry


### PR DESCRIPTION
This PR adds more metrics to metric server
1. `k8s_api_event_counter`
1. `arm_api_call_counter`
1. `arm_api_update_call_failure_counter`
1. `arm_api_update_call_success_counter`