### PR TITLE
brownfield: Merge Ports

### DIFF
--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -91,6 +91,13 @@ func (c *appGwConfigBuilder) getListeners(cbCtx *ConfigBuilderContext) (*[]n.App
 		listeners = brownfield.MergeListeners(existingBlacklisted, listeners)
 	}
 
+	if cbCtx.EnvVariables.EnableBrownfieldDeployment {
+		er := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, nil)
+		existingBlacklisted, existingNonBlacklisted := er.GetBlacklistedPorts()
+		brownfield.LogPorts(existingBlacklisted, existingNonBlacklisted, ports)
+		ports = brownfield.MergePorts(existingBlacklisted, ports)
+	}
+
 	sort.Sort(sorter.ByListenerName(listeners))
 	sort.Sort(sorter.ByFrontendPortName(ports))
 

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -121,6 +121,9 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 
 func (c *appGwConfigBuilder) noRulesIngress(cbCtx *ConfigBuilderContext, ingress *v1beta1.Ingress, urlPathMaps *map[listenerIdentifier]*n.ApplicationGatewayURLPathMap) {
 	// There are no Rules. We are dealing with some very rudimentary Ingress definition.
+	if ingress.Spec.Backend == nil {
+		return
+	}
 	backendID := generateBackendID(ingress, nil, nil, ingress.Spec.Backend)
 	_, _, serviceBackendPairMap, err := c.getBackendsAndSettingsMap(cbCtx)
 	if err != nil {


### PR DESCRIPTION
It is time to use `GetBlacklistedPorts()`, `LogPorts()`, and `MergePorts()` to properly preserve Frontend Ports covered by a `AzureIngressProhibitedTarget` CRD

Part 2: https://github.com/Azure/application-gateway-kubernetes-ingress/pull/578/files