### PR TITLE
fix: add not ready address endpoints to Backend pool

### DIFF
--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -162,6 +162,17 @@ func getAddressesForSubset(subset v1.EndpointSubset) *[]n.ApplicationGatewayBack
 		}
 	}
 
+	for _, address := range subset.NotReadyAddresses {
+		// prefer IP address
+		if len(address.IP) != 0 {
+			// address specified by ip
+			ips[address.IP] = nil
+		} else if len(address.Hostname) != 0 {
+			// address specified by hostname
+			fqdns[address.Hostname] = nil
+		}
+	}
+
 	for ip := range ips {
 		addrSet[n.ApplicationGatewayBackendAddress{IPAddress: to.StringPtr(ip)}] = nil
 	}

--- a/pkg/appgw/backendaddresspools_test.go
+++ b/pkg/appgw/backendaddresspools_test.go
@@ -29,6 +29,10 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 			{Hostname: "xyz"},
 			{IP: "2.2.2.2"},
 		},
+		NotReadyAddresses: []v1.EndpointAddress{
+			{Hostname: "pqr"},
+			{IP: "3.3.3.3"},
+		},
 	}
 
 	serviceList := []*v1.Service{
@@ -82,21 +86,23 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		_ = cb.BackendAddressPools(cbCtx)
 		actualPool := cb.newPool("pool-name", subset)
 		It("should contain unique addresses only", func() {
-			Expect(len(*actualPool.BackendAddresses)).To(Equal(4))
+			Expect(len(*actualPool.BackendAddresses)).To(Equal(6))
 		})
 	})
 
 	Context("ensure correct creation of ApplicationGatewayBackendAddress", func() {
 		actual := getAddressesForSubset(subset)
 		It("should contain correct number of ApplicationGatewayBackendAddress", func() {
-			Expect(len(*actual)).To(Equal(4))
+			Expect(len(*actual)).To(Equal(6))
 		})
 		It("should contain correct set of ordered ApplicationGatewayBackendAddress", func() {
 			// The order here is deliberate -- ensure this is properly sorted
 			expected := []n.ApplicationGatewayBackendAddress{
 				{IPAddress: to.StringPtr("1.1.1.1")},
 				{IPAddress: to.StringPtr("2.2.2.2")},
+				{IPAddress: to.StringPtr("3.3.3.3")},
 				{Fqdn: to.StringPtr("abc")},
+				{Fqdn: to.StringPtr("pqr")},
 				{Fqdn: to.StringPtr("xyz")},
 			}
 			Expect(*actual).To(Equal(expected))


### PR DESCRIPTION
Fixes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/606

Endpoints have two set of IP addresses in `Addresses` and `NotReadyAddresses` list. These are updated as the readiness Probe becomes healthy and unhealthy to fully utilize the gateway's probing.