### PR TITLE
helm: Fixing ARM template

### DIFF
--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
         {{- if .Values.armAuth }}
         {{- if eq .Values.armAuth.type "servicePrincipal"}}
         - name: AZURE_AUTH_LOCATION
-            value: /etc/Azure/Networking-AppGW/auth/armAuth.json
+          value: /etc/Azure/Networking-AppGW/auth/armAuth.json
         {{- end}}
         {{- end}}
         envFrom:


### PR DESCRIPTION
The incorrect indentation is causing `mapping values are not allowed in this context`

This PR fixes the immediate problem.

With another PR I will introduce tests to ensure this is covered.