### PR TITLE
Simplify Updating ingress IP address; Do only if new IP

### DIFF
--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -67,32 +67,32 @@ func NewAzClient(subscriptionID SubscriptionID, resourceGroupName ResourceGroup,
 	}
 
 	if err := az.appGatewaysClient.AddToUserAgent(userAgent); err != nil {
-		glog.Error("Error adding User Agent to App Gateway client: %s", userAgent)
+		glog.Error("Error adding User Agent to App Gateway client: ", userAgent)
 	}
 	az.appGatewaysClient.Authorizer = az.authorizer
 
 	if err := az.publicIPsClient.AddToUserAgent(userAgent); err != nil {
-		glog.Error("Error adding User Agent to Public IP client: %s", userAgent)
+		glog.Error("Error adding User Agent to Public IP client: ", userAgent)
 	}
 	az.publicIPsClient.Authorizer = az.authorizer
 
 	if err := az.virtualNetworksClient.AddToUserAgent(userAgent); err != nil {
-		glog.Error("Error adding User Agent to Virtual Networks client: %s", userAgent)
+		glog.Error("Error adding User Agent to Virtual Networks client: ", userAgent)
 	}
 	az.virtualNetworksClient.Authorizer = az.authorizer
 
 	if err := az.subnetsClient.AddToUserAgent(userAgent); err != nil {
-		glog.Error("Error adding User Agent to Subnets client: %s", userAgent)
+		glog.Error("Error adding User Agent to Subnets client: ", userAgent)
 	}
 	az.subnetsClient.Authorizer = az.authorizer
 
 	if err := az.groupsClient.AddToUserAgent(userAgent); err != nil {
-		glog.Error("Error adding User Agent to Groups client: %s", userAgent)
+		glog.Error("Error adding User Agent to Groups client: ", userAgent)
 	}
 	az.groupsClient.Authorizer = az.authorizer
 
 	if err := az.deploymentsClient.AddToUserAgent(userAgent); err != nil {
-		glog.Error("Error adding User Agent to Deployments client: %s", userAgent)
+		glog.Error("Error adding User Agent to Deployments client: ", userAgent)
 	}
 	az.deploymentsClient.Authorizer = az.authorizer
 

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -41,6 +41,7 @@ type azClient struct {
 	subscriptionID    SubscriptionID
 	resourceGroupName ResourceGroup
 	appGwName         ResourceName
+	memoizedIPs       map[string]n.PublicIPAddress
 
 	ctx context.Context
 }
@@ -55,30 +56,44 @@ func NewAzClient(subscriptionID SubscriptionID, resourceGroupName ResourceGroup,
 		subnetsClient:         n.NewSubnetsClient(string(subscriptionID)),
 		groupsClient:          r.NewGroupsClient(string(subscriptionID)),
 		deploymentsClient:     r.NewDeploymentsClient(string(subscriptionID)),
-		subscriptionID:        subscriptionID,
-		resourceGroupName:     resourceGroupName,
-		appGwName:             appGwName,
+
+		subscriptionID:    subscriptionID,
+		resourceGroupName: resourceGroupName,
+		appGwName:         appGwName,
+		memoizedIPs:       make(map[string]n.PublicIPAddress),
 
 		ctx:        context.Background(),
 		authorizer: authorizer,
 	}
 
-	az.appGatewaysClient.AddToUserAgent(userAgent)
+	if err := az.appGatewaysClient.AddToUserAgent(userAgent); err != nil {
+		glog.Error("Error adding User Agent to App Gateway client: %s", userAgent)
+	}
 	az.appGatewaysClient.Authorizer = az.authorizer
 
-	az.publicIPsClient.AddToUserAgent(userAgent)
+	if err := az.publicIPsClient.AddToUserAgent(userAgent); err != nil {
+		glog.Error("Error adding User Agent to Public IP client: %s", userAgent)
+	}
 	az.publicIPsClient.Authorizer = az.authorizer
-	az.virtualNetworksClient.AddToUserAgent(userAgent)
+
+	if err := az.virtualNetworksClient.AddToUserAgent(userAgent); err != nil {
+		glog.Error("Error adding User Agent to Virtual Networks client: %s", userAgent)
+	}
 	az.virtualNetworksClient.Authorizer = az.authorizer
-	az.subnetsClient.AddToUserAgent(userAgent)
+
+	if err := az.subnetsClient.AddToUserAgent(userAgent); err != nil {
+		glog.Error("Error adding User Agent to Subnets client: %s", userAgent)
+	}
 	az.subnetsClient.Authorizer = az.authorizer
-	az.groupsClient.AddToUserAgent(userAgent)
+
+	if err := az.groupsClient.AddToUserAgent(userAgent); err != nil {
+		glog.Error("Error adding User Agent to Groups client: %s", userAgent)
+	}
 	az.groupsClient.Authorizer = az.authorizer
 
-	az.publicIPsClient.AddToUserAgent(userAgent)
-	az.publicIPsClient.Authorizer = az.authorizer
-
-	az.deploymentsClient.AddToUserAgent(userAgent)
+	if err := az.deploymentsClient.AddToUserAgent(userAgent); err != nil {
+		glog.Error("Error adding User Agent to Deployments client: %s", userAgent)
+	}
 	az.deploymentsClient.Authorizer = az.authorizer
 
 	return az
@@ -100,8 +115,18 @@ func (az *azClient) UpdateGateway(appGwObj *n.ApplicationGateway) (err error) {
 }
 
 func (az *azClient) GetPublicIP(resourceID string) (n.PublicIPAddress, error) {
+	if ip, ok := az.memoizedIPs[resourceID]; ok {
+		return ip, nil
+	}
+
 	_, resourceGroupName, publicIPName := ParseResourceID(resourceID)
-	return az.publicIPsClient.Get(az.ctx, string(resourceGroupName), string(publicIPName), "")
+
+	ip, err := az.publicIPsClient.Get(az.ctx, string(resourceGroupName), string(publicIPName), "")
+	if err != nil {
+		return n.PublicIPAddress{}, err
+	}
+	az.memoizedIPs[resourceID] = ip
+	return ip, nil
 }
 
 // DeployGateway is a method that deploy the appgw and related resources

--- a/pkg/controller/mutate_aks.go
+++ b/pkg/controller/mutate_aks.go
@@ -50,7 +50,7 @@ func (c AppGwIngressController) updateIngressStatus(appGw *n.ApplicationGateway,
 		return
 	}
 
-	glog.V(5).Infof("[mutate_aks] Resolving IP forID %s", *ipConf.ID)
+	glog.V(5).Infof("[mutate_aks] Resolving IP for ID (%s)", *ipConf.ID)
 	if newIP, found := ips[ipResource(*ipConf.ID)]; found {
 		if err := c.k8sContext.UpdateIngressStatus(*ingress, k8scontext.IPAddress(newIP)); err != nil {
 			c.recorder.Event(ingress, v1.EventTypeWarning, events.ReasonUnableToUpdateIngressStatus, err.Error())

--- a/pkg/controller/mutate_aks.go
+++ b/pkg/controller/mutate_aks.go
@@ -28,7 +28,8 @@ func (c AppGwIngressController) MutateAKS() error {
 		return err
 	}
 
-	// update all ingresses with IP address obtained from existing App Gateway configuration
+	// update all relevant ingresses with IP address obtained from existing App Gateway configuration
+	cbCtx.IngressList = c.PruneIngress(appGw, cbCtx)
 	for _, ingress := range cbCtx.IngressList {
 		c.updateIngressStatus(appGw, cbCtx, ingress)
 	}

--- a/pkg/controller/mutate_aks_test.go
+++ b/pkg/controller/mutate_aks_test.go
@@ -42,7 +42,7 @@ var _ = Describe("process function tests", func() {
 		},
 	}
 	publicIP := k8scontext.IPAddress("xxxx")
-	privateIP := k8scontext.IPAddress("xxxx")
+	privateIP := k8scontext.IPAddress("yyyy")
 	var ips map[ipResource]ipAddress
 
 	BeforeEach(func() {
@@ -84,7 +84,7 @@ var _ = Describe("process function tests", func() {
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 
-		ips = make(map[ipResource]ipAddress)
+		ips = map[ipResource]ipAddress{"PublicIP": "xxxx", "PrivateIP": "yyyy"}
 	})
 
 	AfterEach(func() {
@@ -100,17 +100,6 @@ var _ = Describe("process function tests", func() {
 				IP:       string(publicIP),
 			}))
 			Expect(len(updatedIngress.Status.LoadBalancer.Ingress)).To(Equal(1))
-		})
-
-		It("ensure that updateIngressStatus removes ipAddress to ingress not for AGIC", func() {
-			ingress.Annotations[annotations.IngressClassKey] = "otheric"
-			updatedIngress, _ := k8sClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Update(ingress)
-			err := controller.k8sContext.UpdateIngressStatus(*ingress, k8scontext.IPAddress(publicIP))
-			Expect(err).ToNot(HaveOccurred())
-			controller.updateIngressStatus(&appGw, cbCtx, ingress, ips)
-			updatedIngress, _ = k8sClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Get(ingress.Name, metav1.GetOptions{})
-			Expect(annotations.IsApplicationGatewayIngress(updatedIngress)).To(BeFalse())
-			Expect(len(updatedIngress.Status.LoadBalancer.Ingress)).To(Equal(0))
 		})
 
 		It("ensure that updateIngressStatus adds private ipAddress when annotation is present", func() {

--- a/pkg/controller/mutate_aks_test.go
+++ b/pkg/controller/mutate_aks_test.go
@@ -43,6 +43,7 @@ var _ = Describe("process function tests", func() {
 	}
 	publicIP := k8scontext.IPAddress("xxxx")
 	privateIP := k8scontext.IPAddress("xxxx")
+
 	BeforeEach(func() {
 		stopChannel = make(chan struct{})
 
@@ -82,9 +83,11 @@ var _ = Describe("process function tests", func() {
 			DefaultHTTPSettingsID: to.StringPtr("yy"),
 		}
 	})
+
 	AfterEach(func() {
 		close(stopChannel)
 	})
+
 	Context("test updateIngressStatus", func() {
 		It("ensure that updateIngressStatus adds ipAddress to ingress", func() {
 			controller.updateIngressStatus(&appGw, cbCtx, ingress)

--- a/pkg/controller/mutate_app_gateway.go
+++ b/pkg/controller/mutate_app_gateway.go
@@ -51,7 +51,7 @@ func (c AppGwIngressController) getAppGw() (*n.ApplicationGateway, *appgw.Config
 }
 
 // MutateAppGateway applies App Gateway config.
-func (c AppGwIngressController) MutateAppGateway(event events.Event) error {
+func (c AppGwIngressController) MutateAppGateway() error {
 	appGw, cbCtx, err := c.getAppGw()
 	if err != nil {
 		return err

--- a/pkg/controller/mutate_app_gateway.go
+++ b/pkg/controller/mutate_app_gateway.go
@@ -159,7 +159,7 @@ func (c AppGwIngressController) MutateAppGateway() error {
 		if cbCtx.EnvVariables.EnablePanicOnPutError {
 			glogIt = glog.Fatalf
 		}
-		errorLine := fmt.Sprintf("Failed applying App Gwy configuration: %s -- %s", err, string(configJSON))
+		errorLine := fmt.Sprintf("Failed applying App Gwy configuration:\n%s\n\nerror: %s", string(configJSON), err)
 		glogIt(errorLine)
 		if c.agicPod != nil {
 			c.recorder.Event(c.agicPod, v1.EventTypeWarning, events.ReasonFailedApplyingAppGwConfig, errorLine)

--- a/pkg/controller/mutate_app_gateway_test.go
+++ b/pkg/controller/mutate_app_gateway_test.go
@@ -86,7 +86,7 @@ var _ = Describe("process function tests", func() {
 		close(stopChannel)
 	})
 	Context("test updateIngressStatus", func() {
-		It("ensure that updateIngressStatus adds ip to ingress", func() {
+		It("ensure that updateIngressStatus adds ipAddress to ingress", func() {
 			controller.updateIngressStatus(&appGw, cbCtx, ingress)
 			updatedIngress, _ := k8sClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Get(ingress.Name, metav1.GetOptions{})
 			Expect(updatedIngress.Status.LoadBalancer.Ingress).Should(ContainElement(v1.LoadBalancerIngress{
@@ -96,7 +96,7 @@ var _ = Describe("process function tests", func() {
 			Expect(len(updatedIngress.Status.LoadBalancer.Ingress)).To(Equal(1))
 		})
 
-		It("ensure that updateIngressStatus removes ip to ingress not for AGIC", func() {
+		It("ensure that updateIngressStatus removes ipAddress to ingress not for AGIC", func() {
 			ingress.Annotations[annotations.IngressClassKey] = "otheric"
 			updatedIngress, _ := k8sClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Update(ingress)
 			err := controller.k8sContext.UpdateIngressStatus(*ingress, k8scontext.IPAddress(publicIP))
@@ -107,7 +107,7 @@ var _ = Describe("process function tests", func() {
 			Expect(len(updatedIngress.Status.LoadBalancer.Ingress)).To(Equal(0))
 		})
 
-		It("ensure that updateIngressStatus adds private ip when annotation is present", func() {
+		It("ensure that updateIngressStatus adds private ipAddress when annotation is present", func() {
 			ingress.Annotations[annotations.UsePrivateIPKey] = "true"
 			updatedIngress, _ := k8sClient.ExtensionsV1beta1().Ingresses(ingress.Namespace).Update(ingress)
 			Expect(annotations.UsePrivateIP(updatedIngress)).To(BeTrue())

--- a/pkg/controller/prune_test.go
+++ b/pkg/controller/prune_test.go
@@ -53,14 +53,14 @@ var _ = Describe("prune function tests", func() {
 		}
 		appGw := fixtures.GetAppGateway()
 
-		It("removes the ingress using private ip and keeps others", func() {
+		It("removes the ingress using private ipAddress and keeps others", func() {
 			Expect(len(cbCtx.IngressList)).To(Equal(2))
 			prunedIngresses := pruneNoPrivateIP(controller, &appGw, cbCtx, cbCtx.IngressList)
 			Expect(len(prunedIngresses)).To(Equal(1))
 			Expect(prunedIngresses[0].Annotations[annotations.UsePrivateIPKey]).To(Equal(""))
 		})
 
-		It("keeps the ingress using private ip when public ip is present", func() {
+		It("keeps the ingress using private ipAddress when public ipAddress is present", func() {
 			appGw.FrontendIPConfigurations = &[]n.ApplicationGatewayFrontendIPConfiguration{
 				fixtures.GetPublicIPConfiguration(),
 				fixtures.GetPrivateIPConfiguration(),

--- a/pkg/worker/fake.go
+++ b/pkg/worker/fake.go
@@ -12,7 +12,7 @@ import (
 // FakeProcessor is fake event processor type
 type FakeProcessor struct {
 	mutateAppGwy func() error
-	mutateAKS    func([]events.Event) error
+	mutateAKS    func() error
 }
 
 // MutateAppGateway will call the callback provided
@@ -21,8 +21,8 @@ func (fp FakeProcessor) MutateAppGateway() error {
 }
 
 // MutateAKS will call the callback provided
-func (fp FakeProcessor) MutateAKS(events []events.Event) error {
-	return fp.mutateAKS(events)
+func (fp FakeProcessor) MutateAKS() error {
+	return fp.mutateAKS()
 }
 
 // ShouldProcess will return true
@@ -31,7 +31,7 @@ func (fp FakeProcessor) ShouldProcess(event events.Event) (bool, *string) {
 }
 
 // NewFakeProcessor returns a fake processor struct.
-func NewFakeProcessor(mutateAppGwy func() error, mutateAKS func([]events.Event) error) FakeProcessor {
+func NewFakeProcessor(mutateAppGwy func() error, mutateAKS func() error) FakeProcessor {
 	return FakeProcessor{
 		mutateAppGwy: mutateAppGwy,
 		mutateAKS:    mutateAKS,

--- a/pkg/worker/fake.go
+++ b/pkg/worker/fake.go
@@ -11,17 +11,18 @@ import (
 
 // FakeProcessor is fake event processor type
 type FakeProcessor struct {
-	processFunc func(events.Event) error
+	mutateAppGwy func() error
+	mutateAKS    func([]events.Event) error
 }
 
 // MutateAppGateway will call the callback provided
-func (fp FakeProcessor) MutateAppGateway(event events.Event) error {
-	return fp.processFunc(event)
+func (fp FakeProcessor) MutateAppGateway() error {
+	return fp.mutateAppGwy()
 }
 
 // MutateAKS will call the callback provided
-func (fp FakeProcessor) MutateAKS(event events.Event) error {
-	return fp.processFunc(event)
+func (fp FakeProcessor) MutateAKS(events []events.Event) error {
+	return fp.mutateAKS(events)
 }
 
 // ShouldProcess will return true
@@ -30,8 +31,9 @@ func (fp FakeProcessor) ShouldProcess(event events.Event) (bool, *string) {
 }
 
 // NewFakeProcessor returns a fake processor struct.
-func NewFakeProcessor(process func(events.Event) error) FakeProcessor {
+func NewFakeProcessor(mutateAppGwy func() error, mutateAKS func([]events.Event) error) FakeProcessor {
 	return FakeProcessor{
-		processFunc: process,
+		mutateAppGwy: mutateAppGwy,
+		mutateAKS:    mutateAKS,
 	}
 }

--- a/pkg/worker/types.go
+++ b/pkg/worker/types.go
@@ -11,8 +11,8 @@ import (
 
 // EventProcessor provides a mechanism to act on events in the internal queue.
 type EventProcessor interface {
-	MutateAppGateway(events.Event) error
-	MutateAKS(events.Event) error
+	MutateAppGateway() error
+	MutateAKS([]events.Event) error
 	ShouldProcess(events.Event) (bool, *string)
 }
 

--- a/pkg/worker/types.go
+++ b/pkg/worker/types.go
@@ -12,7 +12,7 @@ import (
 // EventProcessor provides a mechanism to act on events in the internal queue.
 type EventProcessor interface {
 	MutateAppGateway() error
-	MutateAKS([]events.Event) error
+	MutateAKS() error
 	ShouldProcess(events.Event) (bool, *string)
 }
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -15,18 +15,15 @@ import (
 
 const sleepOnErrorSeconds = 5
 
-func drainChan(ch chan events.Event, defaultEvent events.Event) (events.Event, []events.Event) {
+func drainChan(ch chan events.Event, defaultEvent events.Event) events.Event {
 	lastEvent := defaultEvent
-	var allEvents []events.Event
 	glog.V(9).Infof("Draining %d events from work channel", len(ch))
 	for {
 		select {
 		case event := <-ch:
-			allEvents = append(allEvents, event)
 			lastEvent = event
 		default:
-			allEvents = append(allEvents, lastEvent)
-			return lastEvent, allEvents
+			return lastEvent
 		}
 	}
 }
@@ -46,9 +43,9 @@ func (w *Worker) Run(work chan events.Event, stopChannel chan struct{}) {
 				continue
 			}
 
-			_, allEvents := drainChan(work, event)
+			_ = drainChan(work, event)
 
-			if err := w.MutateAKS(allEvents); err != nil {
+			if err := w.MutateAKS(); err != nil {
 				glog.Error("Error mutating AKS from k8s event. ", err)
 			}
 

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Worker Test", func() {
 				backChannel <- struct{}{}
 				return nil
 			}
-			mutateAKS := func([]events.Event) error {
+			mutateAKS := func() error {
 				backChannel <- struct{}{}
 				return nil
 			}
@@ -82,9 +82,8 @@ var _ = Describe("Worker Test", func() {
 			}
 			Expect(counter).To(Equal(int64(len(work))))
 			def := events.Event{}
-			lastEvent, allEvents := drainChan(work, def)
+			lastEvent := drainChan(work, def)
 			Expect(len(work)).To(Equal(0))
-			Expect(len(allEvents)).To(Equal(1))
 			Expect(lastEvent).To(Equal(events.Event{}))
 		})
 	})
@@ -96,8 +95,7 @@ var _ = Describe("Worker Test", func() {
 			// Keep the channel empty
 			work := make(chan events.Event, buffSize)
 			def := events.Event{}
-			lastEvent, allEvents := drainChan(work, def)
-			Expect(len(allEvents)).To(Equal(1))
+			lastEvent := drainChan(work, def)
 			Expect(lastEvent).To(Equal(def))
 		})
 	})


### PR DESCRIPTION
In this PR:

 - fleshing out `MutateAKS` -- runs for any kubernetes event
 - added memoization to `GetPublicIP` - so that once an IP resource URI has been resolved to an IP address we don't have to do lookups again.
 - added error handling to the `AddToUserAgent` invocations
 - I deliberately chose to remove the following block:
```go
if !k8scontext.IsIngressApplicationGateway(ingress) || !cbCtx.InIngressList(ingress) {
		if err := c.k8sContext.UpdateIngressStatus(*ingress, ""); err != nil {
```
The concern with the block above is that AGIC will be wiping the IP address of Ingress resources that it should not (no longer) be concerned with.  So if I have an Nginx ingress it seems that AGIC here will mutate that as well.  The downsides is that with the block of code removed we may leave previously mutated Ingress with a stale IP (should the AGIC annotation be removed, we will not update it any more).  I believe this is the safest bet.

Logging changes:
```
I1023 16:01:25.347788   18295 mutate_aks.go:86] [mutate_aks] Found IPs: map[/subscriptions/xxx/resourceGroups/derayche-rg-A/providers/Microsoft.Network/applicationGateways/applicationgatewayxxxx/frontendIPConfigurations/appGatewayFrontendIP:333.333.333.333 /subscriptions/xxx/resourceGroups/derayche-rg-A/providers/Microsoft.Network/applicationGateways/applicationgatewayxxxx/frontendIPConfigurations/derayche-ip:10.1.1.1]
I1023 16:01:25.347832   18295 mutate_aks.go:58] [mutate_aks] IP 333.333.333.333 already set on Ingress default/websocket-ingress

```