### PR TITLE
istio: Carve out istio port generation to simplify frontend_listeners.go

### DIFF
--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -28,27 +28,7 @@ func (c *appGwConfigBuilder) getListeners(cbCtx *ConfigBuilderContext) (*[]n.App
 	var ports []n.ApplicationGatewayFrontendPort
 
 	if cbCtx.EnvVariables.EnableIstioIntegration {
-		for listenerID, config := range c.getListenerConfigsFromIstio(cbCtx.IstioGateways, cbCtx.IstioVirtualServices) {
-			listener, port, err := c.newListener(cbCtx, listenerID, config.Protocol)
-			if err != nil {
-				glog.Errorf("Failed creating listener %+v: %s", listenerID, err)
-				continue
-			}
-			if listenerName, exists := publIPPorts[*port.Name]; exists && listenerID.UsePrivateIP {
-				glog.Errorf("Can't assign port %s to Private IP Listener %s; already assigned to Public IP Listener %s", *port.Name, *listener.Name, listenerName)
-				continue
-			}
-
-			if !listenerID.UsePrivateIP {
-				publIPPorts[*port.Name] = *listener.Name
-			}
-
-			listeners = append(listeners, *listener)
-			if _, exists := portSet[*port.Name]; !exists {
-				portSet[*port.Name] = nil
-				ports = append(ports, *port)
-			}
-		}
+		listeners, ports, portSet, publIPPorts = c.getIstioListenersPorts(cbCtx)
 	}
 
 	for listenerID, config := range c.getListenerConfigs(cbCtx) {

--- a/pkg/appgw/frontend_listeners_istio.go
+++ b/pkg/appgw/frontend_listeners_istio.go
@@ -1,0 +1,43 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package appgw
+
+import (
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
+	"github.com/golang/glog"
+)
+
+func (c *appGwConfigBuilder) getIstioListenersPorts(cbCtx *ConfigBuilderContext) ([]n.ApplicationGatewayHTTPListener, []n.ApplicationGatewayFrontendPort, map[string]interface{}, map[string]string) {
+	publIPPorts := make(map[string]string)
+	portSet := make(map[string]interface{})
+	var listeners []n.ApplicationGatewayHTTPListener
+	var ports []n.ApplicationGatewayFrontendPort
+
+	if cbCtx.EnvVariables.EnableIstioIntegration {
+		for listenerID, config := range c.getListenerConfigsFromIstio(cbCtx.IstioGateways, cbCtx.IstioVirtualServices) {
+			listener, port, err := c.newListener(cbCtx, listenerID, config.Protocol)
+			if err != nil {
+				glog.Errorf("Failed creating listener %+v: %s", listenerID, err)
+				continue
+			}
+			if listenerName, exists := publIPPorts[*port.Name]; exists && listenerID.UsePrivateIP {
+				glog.Errorf("Can't assign port %s to Private IP Listener %s; already assigned to Public IP Listener %s", *port.Name, *listener.Name, listenerName)
+				continue
+			}
+
+			if !listenerID.UsePrivateIP {
+				publIPPorts[*port.Name] = *listener.Name
+			}
+
+			listeners = append(listeners, *listener)
+			if _, exists := portSet[*port.Name]; !exists {
+				portSet[*port.Name] = nil
+				ports = append(ports, *port)
+			}
+		}
+	}
+	return listeners, ports, portSet, publIPPorts
+}

--- a/pkg/brownfield/ports.go
+++ b/pkg/brownfield/ports.go
@@ -27,7 +27,7 @@ func (er ExistingResources) GetBlacklistedPorts() ([]n.ApplicationGatewayFronten
 	for _, port := range er.Ports {
 		portJSON, _ := port.MarshalJSON()
 		// Is the port associated with a blacklisted listener?
-		if _, exists := blacklistedPortSet[portName(*port.Name)]; exists {
+		if _, isBlacklisted := blacklistedPortSet[portName(*port.Name)]; isBlacklisted {
 			glog.V(5).Infof("[brownfield] Port %s is blacklisted: %s", portName(*port.Name), portJSON)
 			blacklistedPorts = append(blacklistedPorts, port)
 			continue


### PR DESCRIPTION
This PR moves code from `pkg/appgw/frontend_listeners.go` into (new) `pkg/appgw/frontend_listeners_istio.go` to simplify the code in frontend_listeners.

There are no functional code changes in this PR.