### PR TITLE
fix: use subnet name in subnet lookup

### DIFF
--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -137,8 +137,13 @@ func (az *azClient) DeployGatewayWithVnet(resourceGroupName ResourceGroup, vnetN
 	}
 
 	glog.Infof("Checking the Vnet %s for a subnet with prefix %s", vnetName, subnetPrefix)
-	subnet, err := az.findSubnet(vnet, subnetPrefix)
+	subnet, err := az.findSubnet(vnet, subnetName, subnetPrefix)
 	if err != nil {
+		if subnetPrefix == "" {
+			glog.Infof("Unable to find a subnet with subnetName %s. Please provide subnetPrefix in order to allow AGIC to create a subnet in Vnet %s", subnetName, vnetName)
+			return
+		}
+
 		glog.Infof("Unable to find a subnet. Creating a subnet %s with prefix %s in Vnet %s", subnetName, subnetPrefix, vnetName)
 		subnet, err = az.createSubnet(vnet, subnetName, subnetPrefix)
 		if err != nil {
@@ -185,13 +190,13 @@ func (az *azClient) getVnet(resourceGroupName ResourceGroup, vnetName ResourceNa
 	return az.virtualNetworksClient.Get(az.ctx, string(resourceGroupName), string(vnetName), "")
 }
 
-func (az *azClient) findSubnet(vnet n.VirtualNetwork, subnetPrefix string) (subnet n.Subnet, err error) {
+func (az *azClient) findSubnet(vnet n.VirtualNetwork, subnetName ResourceName, subnetPrefix string) (subnet n.Subnet, err error) {
 	for _, subnet := range *vnet.Subnets {
-		if *subnet.AddressPrefix == subnetPrefix {
+		if string(subnetName) == *subnet.Name && (subnetPrefix == "" || subnetPrefix == *subnet.AddressPrefix) {
 			return subnet, nil
 		}
 	}
-	err = errors.New("Unable to find subnet")
+	err = errors.New("Unable to find subnet with matching subnetName and subnetPrefix")
 	return
 }
 


### PR DESCRIPTION
This PR modifies the subnet look up.
Earlier, we were looking for existing subnet by matching address prefix provided in `subnetPrefix` parameter. We were not matching the `subnetName` parameter.