### PR TITLE
ingress: Adding annotation waf-policy-for-path; Attach policy to path rule

### DIFF
--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -541,5 +541,22 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 			check(cbCtx, "duplicate_ports.json", stopChannel, ctxt, configBuilder)
 		})
 
+		ginkgo.It("WAF Annotation", func() {
+			annotatedIngress := ingressB
+			annotatedIngress.Annotations[annotations.FirewallPolicy] = "/some/policy/here"
+
+			cbCtx := &ConfigBuilderContext{
+				IngressList: []*v1beta1.Ingress{
+					annotatedIngress,
+				},
+				ServiceList:  serviceList,
+				EnvVariables: environment.GetFakeEnv(),
+				ExistingPortsByNumber: map[Port]n.ApplicationGatewayFrontendPort{
+					Port(80): fixtures.GetDefaultPort(),
+				},
+			}
+			check(cbCtx, "waf_annotation.json", stopChannel, ctxt, configBuilder)
+		})
+
 	})
 })

--- a/functional_tests/waf_annotation.json
+++ b/functional_tests/waf_annotation.json
@@ -1,0 +1,191 @@
+{
+    "properties": {
+        "backendAddressPools": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/defaultaddresspool",
+                "name": "defaultaddresspool",
+                "properties": {
+                    "backendAddresses": []
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80",
+                "name": "pool---namespace---hello-world-b-80-bp-80",
+                "properties": {
+                    "backendAddresses": [
+                        {
+                            "ipAddress": "1.1.1.1"
+                        },
+                        {
+                            "ipAddress": "1.1.1.2"
+                        },
+                        {
+                            "ipAddress": "1.1.1.3"
+                        }
+                    ]
+                }
+            }
+        ],
+        "backendHttpSettingsCollection": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--",
+                "name": "bp---namespace---hello-world-b-80-80---name--",
+                "properties": {
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--"
+                    },
+                    "protocol": "Http"
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/defaulthttpsetting",
+                "name": "defaulthttpsetting",
+                "properties": {
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http"
+                    },
+                    "protocol": "Http"
+                }
+            }
+        ],
+        "frontendIPConfigurations": [
+            {
+                "id": "--front-end-ip-id-1--",
+                "name": "xx3",
+                "properties": {
+                    "publicIPAddress": {
+                        "id": "xyz"
+                    }
+                }
+            },
+            {
+                "id": "--front-end-ip-id-2--",
+                "name": "yy3",
+                "properties": {
+                    "privateIPAddress": "abc"
+                }
+            }
+        ],
+        "frontendPorts": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80",
+                "name": "fp-80",
+                "properties": {
+                    "port": 80
+                }
+            }
+        ],
+        "httpListeners": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-80",
+                "name": "fl-80",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
+                    },
+                    "hostName": "",
+                    "protocol": "Http"
+                }
+            }
+        ],
+        "probes": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http",
+                "name": "defaultprobe-Http",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Https",
+                "name": "defaultprobe-Https",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/",
+                    "protocol": "Https",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--",
+                "name": "pb---namespace---hello-world-b-80---name--",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/B/",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            }
+        ],
+        "redirectConfigurations": null,
+        "requestRoutingRules": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-80",
+                "name": "rr-80",
+                "properties": {
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-80"
+                    },
+                    "ruleType": "PathBasedRouting",
+                    "urlPathMap": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-80"
+                    }
+                }
+            }
+        ],
+        "sku": {
+            "capacity": 3,
+            "name": "Standard_v2",
+            "tier": "Standard_v2"
+        },
+        "sslCertificates": null,
+        "urlPathMaps": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-80",
+                "name": "url-80",
+                "properties": {
+                    "defaultBackendAddressPool": {},
+                    "defaultBackendHttpSettings": {},
+                    "pathRules": [
+                        {
+                            "name": "pr---namespace-----name---0",
+                            "properties": {
+                                "backendAddressPool": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
+                                },
+                                "backendHttpSettings": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--"
+                                },
+                                "firewallPolicy": {
+                                    "id": "/some/policy/here"
+                                },
+                                "paths": [
+                                    "/B/"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "tags": {
+        "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
+        "managed-by-k8s-ingress": "a/b/c"
+    }
+}

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -53,6 +53,11 @@ const (
 	// ApplicationGatewayIngressClass defines the value of the `IngressClassKey` and `IstioGatewayKey`
 	// annotations that will tell the ingress controller whether it should act on this ingress resource or not.
 	ApplicationGatewayIngressClass = "azure/application-gateway"
+
+	// FirewallPolicy is the key part of a key/value Ingress annotation.
+	// The value of this is an ID of a Firewall Policy. The Firewall Policy must be already defined in Azure.
+	// The policy will be attached to all URL paths declared in the annotated Ingress resource.
+	FirewallPolicy = ApplicationGatewayPrefix + "/waf-policy-for-path"
 )
 
 // ProtocolEnum is the type for protocol
@@ -134,6 +139,11 @@ func BackendProtocol(ing *v1beta1.Ingress) (ProtocolEnum, error) {
 	}
 
 	return HTTP, NewInvalidAnnotationContent(BackendProtocolKey, protocol)
+}
+
+// WAFPolicy override path
+func WAFPolicy(ing *v1beta1.Ingress) (string, error) {
+	return parseString(ing, FirewallPolicy)
 }
 
 func parseBool(ing *v1beta1.Ingress, name string) (bool, error) {


### PR DESCRIPTION
In this PR we attach an Azure Firewall Policy to an App Gateway, per path, from an Ingress annotation.

  - recognize the `/waf-policy-for-path` Ingress annotation
  - attach the WAF policy from the key of the annotation to each path rule

### App Gwy config:
(notice the `firewallPolicy` key)

```json
        "urlPathMaps": [
            {
                "id": "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/applicationgatewayd0f0/urlPathMaps/url-www.contoso.com-443",
                "name": "url-www.contoso.com-443",
                "properties": {
                    "defaultBackendAddressPool": {
                        "id": "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/applicationgatewayd0f0/backendAddressPools/defaultaddresspool"
                    },
                    "defaultBackendHttpSettings": {
                        "id": "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/applicationgatewayd0f0/backendHttpSettingsCollection/defaulthttpsetting"
                    },
                    "pathRules": [
                        {
                            "name": "pr-default-websocket-ingress-0",
                            "properties": {
                                "backendAddressPool": {
                                    "id": "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/applicationgatewayd0f0/backendAddressPools/pool-default-websocket-service-80-bp-80"
                                },
                                "backendHttpSettings": {
                                    "id": "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/applicationgatewayd0f0/backendHttpSettingsCollection/bp-default-websocket-service-80-80-websocket-ingress"
                                },
                                "firewallPolicy": {
                                    "id": "/subscriptions/xxx/resourceGroups/MC_ingress-appgw_mycluster_northeurope/providers/Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/globalPolicy"
                                },
                                "paths": [
                                    "/igl/oo"
                                ]
                            }
                        },

```
## Logs:
```
I1030 13:42:44.471288   13620 requestroutingrules.go:311] Attach Firewall Policy /subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/globalPolicy to Path Rule /status/*
```