### PR TITLE
Break on old App Gateway SKUs

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
@@ -58,6 +59,11 @@ var (
 	versionInfo    = flags.Bool("version", false, "Print version")
 	verbosity      = flags.Int(verbosityFlag, 1, "Set logging verbosity level")
 )
+
+var allowedSkus = map[n.ApplicationGatewayTier]interface{}{
+	n.ApplicationGatewayTierStandardV2: nil,
+	n.ApplicationGatewayTierWAFV2: nil,
+}
 
 func main() {
 	// Log output is buffered... Calling Flush before exiting guarantees all log output is written.
@@ -179,6 +185,16 @@ func main() {
 	appGw, _ := azClient.GetGateway()
 	if err := appgw.FatalValidateOnExistingConfig(recorder, appGw.ApplicationGatewayPropertiesFormat, env); err != nil {
 		glog.Fatal("Got a fatal validation error on existing Application Gateway config. Please update Application Gateway or the controller's helm config. Error:", err)
+	}
+
+	if _, exists := allowedSkus[appGw.Sku.Tier]; !exists {
+		errorLine := fmt.Sprintf("App Gateway SKU Tier %s is not supported by AGIC version %s", appGw.Sku.Tier, appgw.GetVersion())
+		if agicPod != nil {
+			recorder.Event(agicPod, v1.EventTypeWarning, events.UnsupportedAppGatewaySKUTier, errorLine)
+		}
+		// Slow down the cycling of the AGIC pod.
+		time.Sleep(5 * time.Second)
+		glog.Fatal(errorLine)
 	}
 
 	appGwIngressController := controller.NewAppGwIngressController(azClient, appGwIdentifier, k8sContext, recorder, metricStore, agicPod)

--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -62,7 +62,7 @@ var (
 
 var allowedSkus = map[n.ApplicationGatewayTier]interface{}{
 	n.ApplicationGatewayTierStandardV2: nil,
-	n.ApplicationGatewayTierWAFV2: nil,
+	n.ApplicationGatewayTierWAFV2:      nil,
 }
 
 func main() {
@@ -188,7 +188,7 @@ func main() {
 	}
 
 	if _, exists := allowedSkus[appGw.Sku.Tier]; !exists {
-		errorLine := fmt.Sprintf("App Gateway SKU Tier %s is not supported by AGIC version %s", appGw.Sku.Tier, appgw.GetVersion())
+		errorLine := fmt.Sprintf("App Gateway SKU Tier %s is not supported by AGIC version %s; (v0.10.0 supports App Gwy v1)", appGw.Sku.Tier, appgw.GetVersion())
 		if agicPod != nil {
 			recorder.Event(agicPod, v1.EventTypeWarning, events.UnsupportedAppGatewaySKUTier, errorLine)
 		}

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -213,6 +213,7 @@ func (c *appGwConfigBuilder) addTags() {
 	c.appGw.Tags[tags.LastUpdatedByK8sIngress] = to.StringPtr(c.clock.Now().String())
 }
 
+// GetVersion returns a string representing the version of AGIC.
 func GetVersion() string {
 	return fmt.Sprintf("%s/%s/%s", version.Version, version.GitCommit, version.BuildDate)
 }

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -204,11 +204,15 @@ func (c *appGwConfigBuilder) addTags() {
 		c.appGw.Tags = make(map[string]*string)
 	}
 	// Identify the App Gateway as being exclusively managed by a Kubernetes Ingress.
-	c.appGw.Tags[tags.ManagedByK8sIngress] = to.StringPtr(fmt.Sprintf("%s/%s/%s", version.Version, version.GitCommit, version.BuildDate))
+	c.appGw.Tags[tags.ManagedByK8sIngress] = to.StringPtr(GetVersion())
 	if aksResourceID, err := azure.ConvertToClusterResourceGroup(c.k8sContext.GetInfrastructureResourceGroupID()); err == nil {
 		c.appGw.Tags[tags.IngressForAKSClusterID] = to.StringPtr(aksResourceID)
 	} else {
 		glog.V(5).Infof("Error while parsing cluster resource ID for tagging: %s", err)
 	}
 	c.appGw.Tags[tags.LastUpdatedByK8sIngress] = to.StringPtr(c.clock.Now().String())
+}
+
+func GetVersion() string {
+	return fmt.Sprintf("%s/%s/%s", version.Version, version.GitCommit, version.BuildDate)
 }

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -56,4 +56,7 @@ const (
 
 	// ReasonARMAuthFailure is a reason for an event to be emitted.
 	ReasonARMAuthFailure = "ARMAuthFailure"
+
+	// UnsupportedAppGatewaySKUTier is a reason for an event to be emitted.
+	UnsupportedAppGatewaySKUTier = "UnsupportedAppGatewaySKUTier"
 )


### PR DESCRIPTION
With this PR we discontinue support of v1 of App Gateway.

The proposed commit will print the following whet App Gateway is of the supported set of SKU Tiers:

```
F1030 14:26:42.482820   17255 main.go:197] App Gateway SKU Tier Standard is not supported by AGIC version 0.11.0/2f8cb7f5/2019-10-30-14:26T-0700
```

The addition of `time.Sleep` for 5 seconds is deliberate - to slow down the cycling of the AGIC pod.