### PR TITLE
Remove Tags field before caching config

### DIFF
--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -19,8 +19,10 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
+// Keys that act as cache-busters should be removed from the JSON stored in cache.
 var keysToDeleteForCache = []string{
 	"etag",
+	"tags", // In the Tags of App Gwy we store the timestamp of the most recent update.
 }
 
 func (c *AppGwIngressController) updateCache(appGw *n.ApplicationGateway) {


### PR DESCRIPTION
With the addition of the `last-updated-by-k8s-ingress` tag via https://github.com/Azure/application-gateway-kubernetes-ingress/pull/561 we introduced a subtle (or not so) cache buster.

To ensure that we could cache, and correctly identify JSON configs that have not changed since last ARM PUT, we remove the UserTags field - much like we do with etags.

Cache buster in question:
https://github.com/Azure/application-gateway-kubernetes-ingress/blob/0.10.0/pkg/appgw/configbuilder.go#L213

Tested:
```
I1030 17:20:04.354645   23852 mutate_app_gateway.go:150] cache: Config has NOT changed! No need to connect to ARM.
```