### PR TITLE
prometheus: add prom annot for deployment and register newly metrics

### DIFF
--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         aadpodidbinding: {{ template "application-gateway-kubernetes-ingress.fullname" . }}
         {{- end }}
         {{- end }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.kubernetes.httpServicePort }}
     spec:
       serviceAccountName: {{ template "application-gateway-kubernetes-ingress.serviceaccountname" . }}
       containers:

--- a/pkg/metricstore/metricstore.go
+++ b/pkg/metricstore/metricstore.go
@@ -95,11 +95,19 @@ func NewMetricStore(envVariable environment.EnvVariables) MetricStore {
 // Start store
 func (ms *AGICMetricStore) Start() {
 	ms.registry.MustRegister(ms.updateLatency)
+	ms.registry.MustRegister(ms.k8sAPIEventCounter)
+	ms.registry.MustRegister(ms.armAPIUpdateCallSuccessCounter)
+	ms.registry.MustRegister(ms.armAPIUpdateCallFailureCounter)
+	ms.registry.MustRegister(ms.armAPICallCounter)
 }
 
 // Stop store
 func (ms *AGICMetricStore) Stop() {
 	ms.registry.Unregister(ms.updateLatency)
+	ms.registry.Unregister(ms.k8sAPIEventCounter)
+	ms.registry.Unregister(ms.armAPIUpdateCallSuccessCounter)
+	ms.registry.Unregister(ms.armAPIUpdateCallFailureCounter)
+	ms.registry.Unregister(ms.armAPICallCounter)
 }
 
 // SetUpdateLatencySec updates latency


### PR DESCRIPTION
This PR adds annotations to the AGIC pod deployments. This will be used by prometheus to discover metrics from AGIC. Also, adding registering the new metrics.