### PR TITLE
Attach a FirewallPolicy to the listener w/ a feature flag

### DIFF
--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -39,9 +39,9 @@ data:
   {{- else }}
 
   {{- if .Values.appgw.subnetPrefix }}
-  APPGW_SUBNET_PREFIX: {{ .Values.appgw.subnetPrefix | quote }} 
+  APPGW_SUBNET_PREFIX: {{ .Values.appgw.subnetPrefix | quote }}
   {{- end }}
-  
+
   {{- if .Values.appgw.subnetName }}
   APPGW_SUBNET_NAME: {{ .Values.appgw.subnetName | quote }}
   {{- else }}
@@ -54,6 +54,10 @@ data:
 
 {{- if .Values.appgw.shared }}
   APPGW_ENABLE_SHARED_APPGW: {{ .Values.appgw.shared | quote }}
+{{- end }}
+
+{{- if .Values.appgw.waf_listener }}
+  ATTACH_WAF_POLICY_TO_LISTENER: {{ .Values.appgw.waf_listener | quote }}
 {{- end }}
 
 {{- if .Values.kubernetes.watchNamespace }}

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- end }}
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ .Values.kubernetes.httpServicePort }}
+        prometheus.io/port: {{ .Values.kubernetes.httpServicePort | quote}}
     spec:
       serviceAccountName: {{ template "application-gateway-kubernetes-ingress.serviceaccountname" . }}
       containers:

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -72,6 +72,7 @@ type listenerAzConfig struct {
 	Protocol                     n.ApplicationGatewayProtocol
 	Secret                       secretIdentifier
 	SslRedirectConfigurationName string
+	FirewallPolicy               string
 }
 
 // formatPropName ensures that the string generated is not longer than 80 characters.

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -75,6 +75,9 @@ const (
 
 	// UseManagedIdentityForPodVarName is an environment variable name.
 	UseManagedIdentityForPodVarName = "USE_MANAGED_IDENTITY_FOR_POD"
+
+	// AttachWAFPolicyToListenerVarName is an environment variable name.
+	AttachWAFPolicyToListenerVarName = "ATTACH_WAF_POLICY_TO_LISTENER"
 )
 
 // EnvVariables is a struct storing values for environment variables.
@@ -100,6 +103,7 @@ type EnvVariables struct {
 	EnableDeployAppGateway     bool
 	UseManagedIdentityForPod   bool
 	HTTPServicePort            string
+	AttachWAFPolicyToListener  bool
 }
 
 var portNumberValidator = regexp.MustCompile(`^[0-9]{4,5}$`)
@@ -129,6 +133,7 @@ func GetEnv() EnvVariables {
 		EnableDeployAppGateway:     GetEnvironmentVariable(EnableDeployAppGatewayVarName, "false", boolValidator) == "true",
 		UseManagedIdentityForPod:   GetEnvironmentVariable(UseManagedIdentityForPodVarName, "false", boolValidator) == "true",
 		HTTPServicePort:            GetEnvironmentVariable(HTTPServicePortVarName, "8123", portNumberValidator),
+		AttachWAFPolicyToListener:  GetEnvironmentVariable(AttachWAFPolicyToListenerVarName, "false", boolValidator) == "true",
 	}
 
 	return env


### PR DESCRIPTION
This PR stacked on top of https://github.com/Azure/application-gateway-kubernetes-ingress/pull/644 -- adds FirewallPolicy to the Listener, when there are no rules.

  - adding `ATTACH_WAF_POLICY_TO_LISTENER` variable to enable attaching WAF policy to listener
  - adding `FirewallPolicy` to the `listenerAzConfig` struct
  - when `AttachWAFPolicyToListener` is enabled - attach policy to respective listener
  - for default listener - find an Ingress with a WAF annotation and attach it to the only listener