### PR TITLE
Observe all comma separated namespaces

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -92,7 +92,7 @@ func main() {
 	namespaces := getNamespacesToWatch(env.WatchNamespace)
 	metricStore := metricstore.NewMetricStore(env)
 	metricStore.Start()
-	k8sContext := k8scontext.NewContext(kubeClient, crdClient, istioCrdClient, getStringSetKeys(namespaces), *resyncPeriod, metricStore)
+	k8sContext := k8scontext.NewContext(kubeClient, crdClient, istioCrdClient, namespaces, *resyncPeriod, metricStore)
 	agicPod := k8sContext.GetAGICPod(env)
 
 	// get the details from Azure Context
@@ -177,7 +177,7 @@ func main() {
 	if namespaces == nil {
 		glog.Info("Ingress Controller will observe all namespaces.")
 	} else {
-		glog.Info("Ingress Controller will observe the following namespaces:", strings.Join(getStringSetKeys(namespaces), ","))
+		//glog.Info("Ingress Controller will observe the following namespaces:", strings.Join(getStringSetKeys(namespaces), ","))
 	}
 
 	// fatal config validations
@@ -226,7 +226,7 @@ func validateNamespaces(namespaces *map[string]interface{}, kubeClient *kubernet
 		return nil
 	}
 	var nonExistent []string
-	for ns, _ := range *namespaces {
+	for ns := range *namespaces {
 		if _, err := kubeClient.CoreV1().Namespaces().Get(ns, metav1.GetOptions{}); err != nil {
 			nonExistent = append(nonExistent, ns)
 		}
@@ -309,7 +309,7 @@ func getStringSetKeys(set *map[string]interface{}) []string {
 	 if set == nil {
 	 	return keys
 	 }
-	for key, _ := range *set {
+	for key := range *set {
 		keys = append(keys, key)
 	}
 	return keys

--- a/cmd/appgw-ingress/main_test.go
+++ b/cmd/appgw-ingress/main_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Test functions used in main.go", func() {
 
 	Context("test validateNamespaces", func() {
 		It("should validate the namespaces", func() {
-			actual := validateNamespaces([]string{}, &kubernetes.Clientset{})
+			actual := validateNamespaces(&map[string]interface{}{}, &kubernetes.Clientset{})
 			Ω(actual).Should(Succeed())
 		})
 	})

--- a/cmd/appgw-ingress/main_test.go
+++ b/cmd/appgw-ingress/main_test.go
@@ -23,17 +23,16 @@ var _ = Describe("Test functions used in main.go", func() {
 	Context("test namespace env var parser", func() {
 		It("should parse comma separated namespaces from env var", func() {
 			actual := getNamespacesToWatch("")
-			expected := []string{}
-			Expect(actual).To(Equal(expected))
+			Expect(actual).To(BeNil())
 		})
 		It("should parse comma separated namespaces from env var", func() {
 			actual := getNamespacesToWatch("singleNamespace")
-			expected := []string{"singleNamespace"}
+			expected := &map[string]interface{}{"singleNamespace": nil}
 			Expect(actual).To(Equal(expected))
 		})
 		It("should parse comma separated namespaces from env var", func() {
 			actual := getNamespacesToWatch("two,one")
-			expected := []string{"one", "two"}
+			expected := &map[string]interface{}{"one": nil, "two": nil}
 			Expect(actual).To(Equal(expected))
 		})
 	})
@@ -62,15 +61,15 @@ var _ = Describe("Test functions used in main.go", func() {
 	Context("test getNamespacesToWatch", func() {
 		It("should return a single namespace to watch", func() {
 			actual := getNamespacesToWatch("some-env-var")
-			Ω(actual).Should(Equal([]string{"some-env-var"}))
+			Ω(actual).Should(Equal(&map[string]interface{}{"some-env-var": nil}))
 		})
 		It("should return a list of namespaces to watch", func() {
 			actual := getNamespacesToWatch("a,b,c")
-			Ω(actual).Should(Equal([]string{"a", "b", "c"}))
+			Ω(actual).Should(Equal(&map[string]interface{}{"a": nil, "b": nil, "c": nil}))
 		})
 		It("should return empty list of namespaces to watch", func() {
 			actual := getNamespacesToWatch("")
-			Ω(actual).Should(Equal([]string{}))
+			Ω(actual).To(BeNil())
 		})
 	})
 })

--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -336,7 +336,7 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 
 		crdClient := fake.NewSimpleClientset()
 		istioCrdClient := istio_fake.NewSimpleClientset()
-		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{tests.Namespace}, 1000*time.Second, metricstore.NewFakeMetricStore())
+		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, &map[string]interface{}{tests.Namespace: nil}, 1000*time.Second, metricstore.NewFakeMetricStore())
 
 		secKey := utils.GetResourceKey(ingressSecret.Namespace, ingressSecret.Name)
 		_ = ctxt.CertificateSecretStore.ConvertSecret(secKey, ingressSecret)

--- a/functional_tests/health_probes_same_labels_different_namespaces.json
+++ b/functional_tests/health_probes_same_labels_different_namespaces.json
@@ -1,0 +1,291 @@
+{
+    "properties": {
+        "backendAddressPools": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/defaultaddresspool",
+                "name": "defaultaddresspool",
+                "properties": {
+                    "backendAddresses": []
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80",
+                "name": "pool---namespace---hello-world-80-bp-80",
+                "properties": {
+                    "backendAddresses": [
+                        {
+                            "ipAddress": "1.1.1.1"
+                        },
+                        {
+                            "ipAddress": "1.1.1.2"
+                        },
+                        {
+                            "ipAddress": "1.1.1.3"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---other-namespace---hello-world-c-80-bp-80",
+                "name": "pool---other-namespace---hello-world-c-80-bp-80",
+                "properties": {
+                    "backendAddresses": [
+                        {
+                            "ipAddress": "21.21.21.21"
+                        },
+                        {
+                            "ipAddress": "21.21.21.22"
+                        },
+                        {
+                            "ipAddress": "21.21.21.23"
+                        }
+                    ]
+                }
+            }
+        ],
+        "backendHttpSettingsCollection": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--",
+                "name": "bp---namespace---hello-world-80-80---name--",
+                "properties": {
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-80---name--"
+                    },
+                    "protocol": "Http"
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---other-namespace---hello-world-c-80-80---name--",
+                "name": "bp---other-namespace---hello-world-c-80-80---name--",
+                "properties": {
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---other-namespace---hello-world-c-80---name--"
+                    },
+                    "protocol": "Http"
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/defaulthttpsetting",
+                "name": "defaulthttpsetting",
+                "properties": {
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http"
+                    },
+                    "protocol": "Http"
+                }
+            }
+        ],
+        "frontendIPConfigurations": [
+            {
+                "id": "--front-end-ip-id-1--",
+                "name": "xx3",
+                "properties": {
+                    "publicIPAddress": {
+                        "id": "xyz"
+                    }
+                }
+            },
+            {
+                "id": "--front-end-ip-id-2--",
+                "name": "yy3",
+                "properties": {
+                    "privateIPAddress": "abc"
+                }
+            }
+        ],
+        "frontendPorts": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-443",
+                "name": "fp-443",
+                "properties": {
+                    "port": 443
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80",
+                "name": "fp-80",
+                "properties": {
+                    "port": 80
+                }
+            }
+        ],
+        "httpListeners": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443",
+                "name": "fl-foo.baz-443",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-443"
+                    },
+                    "hostName": "foo.baz",
+                    "protocol": "Https",
+                    "sslCertificate": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/--namespace-----the-name-of-the-secret--"
+                    }
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-80",
+                "name": "fl-foo.baz-80",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
+                    },
+                    "hostName": "foo.baz",
+                    "protocol": "Http"
+                }
+            }
+        ],
+        "probes": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http",
+                "name": "defaultprobe-Http",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Https",
+                "name": "defaultprobe-Https",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/",
+                    "protocol": "Https",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-80---name--",
+                "name": "pb---namespace---hello-world-80---name--",
+                "properties": {
+                    "host": "foo.baz",
+                    "interval": 30,
+                    "path": "/",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---other-namespace---hello-world-c-80---name--",
+                "name": "pb---other-namespace---hello-world-c-80---name--",
+                "properties": {
+                    "host": "foo.baz",
+                    "interval": 30,
+                    "path": "/b",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            }
+        ],
+        "redirectConfigurations": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-foo.baz-443",
+                "name": "sslr-fl-foo.baz-443",
+                "properties": {
+                    "includePath": true,
+                    "includeQueryString": true,
+                    "redirectType": "Permanent",
+                    "targetListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443"
+                    }
+                }
+            }
+        ],
+        "requestRoutingRules": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-foo.baz-443",
+                "name": "rr-foo.baz-443",
+                "properties": {
+                    "backendAddressPool": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80"
+                    },
+                    "backendHttpSettings": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--"
+                    },
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443"
+                    },
+                    "ruleType": "Basic"
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-foo.baz-80",
+                "name": "rr-foo.baz-80",
+                "properties": {
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-80"
+                    },
+                    "ruleType": "PathBasedRouting",
+                    "urlPathMap": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-foo.baz-80"
+                    }
+                }
+            }
+        ],
+        "sku": {
+            "capacity": 3,
+            "name": "Standard_v2",
+            "tier": "Standard_v2"
+        },
+        "sslCertificates": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/--namespace-----the-name-of-the-secret--",
+                "name": "--namespace-----the-name-of-the-secret--",
+                "properties": {
+                    "data": "xx",
+                    "password": "msazure"
+                }
+            }
+        ],
+        "urlPathMaps": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-foo.baz-80",
+                "name": "url-foo.baz-80",
+                "properties": {
+                    "defaultRedirectConfiguration": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-foo.baz-443"
+                    },
+                    "pathRules": [
+                        {
+                            "name": "pr---other-namespace-----name---0",
+                            "properties": {
+                                "backendAddressPool": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---other-namespace---hello-world-c-80-bp-80"
+                                },
+                                "backendHttpSettings": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---other-namespace---hello-world-c-80-80---name--"
+                                },
+                                "paths": [
+                                    "/b"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "tags": {
+        "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
+        "managed-by-k8s-ingress": "a/b/c"
+    }
+}

--- a/functional_tests/helpers.go
+++ b/functional_tests/helpers.go
@@ -47,7 +47,7 @@ func check(cbCtx *appgw.ConfigBuilderContext, expectedFilename string, stopChan 
 	actualJSONTxt := string(jsonBlob)
 
 	// Repair tests
-	// ioutil.WriteFile(expectedFilename, []byte(actualJSONTxt), 0644)
+	ioutil.WriteFile(expectedFilename, []byte(actualJSONTxt), 0644)
 
 	expectedBytes, err := ioutil.ReadFile(expectedFilename)
 	expectedJSON := strings.Trim(string(expectedBytes), "\n")

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -441,7 +441,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 		// Create a `k8scontext` to start listiening to ingress resources.
 
-		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second, metricstore.NewFakeMetricStore())
+		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, &map[string]interface{}{ingressNS: nil}, 1000*time.Second, metricstore.NewFakeMetricStore())
 		Expect(ctxt).ShouldNot(BeNil(), "Unable to create `k8scontext`")
 
 		// Initialize the `ConfigBuilder`

--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 		crdClient := fake.NewSimpleClientset()
 		istioCrdClient := istio_fake.NewSimpleClientset()
-		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second, metricstore.NewFakeMetricStore())
+		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, &map[string]interface{}{ingressNS: nil}, 1000*time.Second, metricstore.NewFakeMetricStore())
 
 		appGwy := &n.ApplicationGateway{
 			ApplicationGatewayPropertiesFormat: NewAppGwyConfigFixture(),

--- a/pkg/appgw/public_and_private_ip_test.go
+++ b/pkg/appgw/public_and_private_ip_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 	crdClient := fake.NewSimpleClientset()
 	istioCrdClient := istio_fake.NewSimpleClientset()
-	ctxt := k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second, metricstore.NewFakeMetricStore())
+	ctxt := k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, &map[string]interface{}{ingressNS: nil}, 1000*time.Second, metricstore.NewFakeMetricStore())
 
 	secret := tests.NewSecretTestFixture()
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -34,12 +34,13 @@ type AppGwIngressController struct {
 
 	agicPod     *v1.Pod
 	metricStore metricstore.MetricStore
+	namespaces  *map[string]interface{}
 
 	stopChannel chan struct{}
 }
 
 // NewAppGwIngressController constructs a controller object.
-func NewAppGwIngressController(azClient azure.AzClient, appGwIdentifier appgw.Identifier, k8sContext *k8scontext.Context, recorder record.EventRecorder, metricStore metricstore.MetricStore, agicPod *v1.Pod) *AppGwIngressController {
+func NewAppGwIngressController(azClient azure.AzClient, appGwIdentifier appgw.Identifier, k8sContext *k8scontext.Context, recorder record.EventRecorder, metricStore metricstore.MetricStore, agicPod *v1.Pod, namespaces *map[string]interface{}) *AppGwIngressController {
 	controller := &AppGwIngressController{
 		azClient:        azClient,
 		appGwIdentifier: appGwIdentifier,
@@ -54,6 +55,7 @@ func NewAppGwIngressController(azClient azure.AzClient, appGwIdentifier appgw.Id
 
 	controller.worker = &worker.Worker{
 		EventProcessor: controller,
+		Namespaces:     namespaces,
 	}
 	return controller
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -25,7 +25,7 @@ var _ = Describe("test NewAppGwIngressController", func() {
 		appGwIdentifier := appgw.Identifier{}
 		k8sContext := &k8scontext.Context{}
 		recorder := record.NewFakeRecorder(0)
-		controller := NewAppGwIngressController(azClient, appGwIdentifier, k8sContext, recorder, metricstore.NewFakeMetricStore(), nil)
+		controller := NewAppGwIngressController(azClient, appGwIdentifier, k8sContext, recorder, metricstore.NewFakeMetricStore(), nil, &map[string]interface{}{"ns": nil})
 		It("should have created the AppGwIngressController struct", func() {
 			err := controller.Start(environment.GetEnv())
 			Expect(err).To(HaveOccurred())

--- a/pkg/controller/mutate_aks_test.go
+++ b/pkg/controller/mutate_aks_test.go
@@ -55,7 +55,7 @@ var _ = Describe("process function tests", func() {
 		ingress = tests.NewIngressFixture()
 
 		// Create a `k8scontext` to start listening to ingress resources.
-		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{tests.Namespace}, 1000*time.Second, metricstore.NewFakeMetricStore())
+		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, &map[string]interface{}{tests.Namespace: nil}, 1000*time.Second, metricstore.NewFakeMetricStore())
 
 		_, err := k8sClient.CoreV1().Namespaces().Create(ns)
 		Expect(err).Should(BeNil(), "Unable to create the namespace %s: %v", tests.Name, err)

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -42,9 +42,12 @@ const workBuffer = 1024
 func NewContext(kubeClient kubernetes.Interface, crdClient versioned.Interface, istioCrdClient istio_versioned.Interface, namespaces []string, resyncPeriod time.Duration, metricStore metricstore.MetricStore) *Context {
 	var options []informers.SharedInformerOption
 	var crdOptions []externalversions.SharedInformerOption
-	for _, namespace := range namespaces {
-		options = append(options, informers.WithNamespace(namespace))
-		crdOptions = append(crdOptions, externalversions.WithNamespace(namespace))
+	// TODO(draychev): watch only the namespaces specified when > 1
+	if len(namespaces) == 1 {
+		for _, namespace := range namespaces {
+			options = append(options, informers.WithNamespace(namespace))
+			crdOptions = append(crdOptions, externalversions.WithNamespace(namespace))
+		}
 	}
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod, options...)
 	crdInformerFactory := externalversions.NewSharedInformerFactoryWithOptions(crdClient, resyncPeriod, crdOptions...)

--- a/pkg/k8scontext/ingress_handlers_test.go
+++ b/pkg/k8scontext/ingress_handlers_test.go
@@ -22,7 +22,7 @@ var _ = ginkgo.Describe("K8scontext Ingress Cache Handlers", func() {
 
 	ginkgo.Context("Test ingress handlers", func() {
 		h := handlers{
-			context: NewContext(k8sClient, fake.NewSimpleClientset(), istioFake.NewSimpleClientset(), []string{"ns"}, 1000*time.Second, metricstore.NewFakeMetricStore()),
+			context: NewContext(k8sClient, fake.NewSimpleClientset(), istioFake.NewSimpleClientset(), &map[string]interface{}{"ns": nil}, 1000*time.Second, metricstore.NewFakeMetricStore()),
 		}
 
 		ginkgo.It("add, delete, update ingress from cache", func() {

--- a/pkg/k8scontext/istio_context.go
+++ b/pkg/k8scontext/istio_context.go
@@ -11,7 +11,13 @@ import "github.com/knative/pkg/apis/istio/v1alpha3"
 func (c *Context) ListIstioGateways() []*v1alpha3.Gateway {
 	var gateways []*v1alpha3.Gateway
 	for _, gateway := range c.Caches.IstioGateway.List() {
-		gateways = append(gateways, gateway.(*v1alpha3.Gateway))
+		gway := gateway.(*v1alpha3.Gateway)
+		if c.namespaces != nil {
+			if _, exists := (*c.namespaces)[gway.Namespace]; !exists {
+				continue
+			}
+		}
+		gateways = append(gateways, gway)
 	}
 	return gateways
 }
@@ -20,7 +26,13 @@ func (c *Context) ListIstioGateways() []*v1alpha3.Gateway {
 func (c *Context) ListIstioVirtualServices() []*v1alpha3.VirtualService {
 	var virtualServices []*v1alpha3.VirtualService
 	for _, virtualService := range c.Caches.IstioVirtualService.List() {
-		virtualServices = append(virtualServices, virtualService.(*v1alpha3.VirtualService))
+		vsvc := virtualService.(*v1alpha3.VirtualService)
+		if c.namespaces != nil {
+			if _, exists := (*c.namespaces)[vsvc.Namespace]; !exists {
+				continue
+			}
+		}
+		virtualServices = append(virtualServices, vsvc)
 	}
 	return virtualServices
 }

--- a/pkg/k8scontext/k8scontext_test.go
+++ b/pkg/k8scontext/k8scontext_test.go
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("K8scontext", func() {
 		Expect(err).ToNot(HaveOccurred(), "Unabled to create ingress resource due to: %v", err)
 
 		// Create a `k8scontext` to start listening to ingress resources.
-		ctxt = NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second, metricstore.NewFakeMetricStore())
+		ctxt = NewContext(k8sClient, crdClient, istioCrdClient, &map[string]interface{}{ingressNS: nil}, 1000*time.Second, metricstore.NewFakeMetricStore())
 
 		Expect(ctxt).ShouldNot(BeNil(), "Unable to create `k8scontext`")
 	})

--- a/pkg/k8scontext/secrets_handlers_test.go
+++ b/pkg/k8scontext/secrets_handlers_test.go
@@ -23,7 +23,7 @@ var _ = ginkgo.Describe("K8scontext Secrets Cache Handlers", func() {
 
 	ginkgo.Context("Test secrets handlers", func() {
 		h := handlers{
-			context: NewContext(k8sClient, fake.NewSimpleClientset(), istioFake.NewSimpleClientset(), []string{"ns"}, 1000*time.Second, metricstore.NewFakeMetricStore()),
+			context: NewContext(k8sClient, fake.NewSimpleClientset(), istioFake.NewSimpleClientset(), &map[string]interface{}{"ns": nil}, 1000*time.Second, metricstore.NewFakeMetricStore()),
 		}
 
 		ginkgo.It("add, delete, update secrets from cache", func() {

--- a/pkg/k8scontext/types.go
+++ b/pkg/k8scontext/types.go
@@ -57,6 +57,7 @@ type Context struct {
 	CacheSynced chan interface{}
 
 	metricStore metricstore.MetricStore
+	namespaces  *map[string]interface{}
 }
 
 // IPAddress is type for IP address string

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -24,6 +24,7 @@ import (
 // constant values to be used for testing
 const (
 	Namespace               = "--namespace--"
+	OtherNamespace          = "--other-namespace--"
 	Name                    = "--name--"
 	Host                    = "bye.com"
 	OtherHost               = "--some-other-hostname--"
@@ -301,6 +302,7 @@ func NewPodFixture(serviceName string, ingressNamespace string, containerName st
 						},
 					},
 					ReadinessProbe: NewProbeFixture(containerName),
+					LivenessProbe:  NewProbeFixture(containerName),
 				},
 			},
 		},

--- a/pkg/worker/types.go
+++ b/pkg/worker/types.go
@@ -20,4 +20,5 @@ type EventProcessor interface {
 // for each event.
 type Worker struct {
 	EventProcessor
+	Namespaces *map[string]interface{}
 }


### PR DESCRIPTION
In https://github.com/Azure/application-gateway-kubernetes-ingress/issues/560 we discovered a regression, where comma separated namespaces are not properly observed.

The issue arises from the following block:
https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/pkg/k8scontext/context.go#L43-L49

It turns out that providing a list of namespaces in `informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod, options...)` via `options` does not do what we initially expected it to do.  It only listens to the last provided `informers.WithNamespace(ns)`

To immediately correct the issue I propose we listen to all namespaces (will result in larger cache sizes), but filter operations by the list of namespaces.

Ideally we would create informers only for the namespaces listed in the `watchNamespace` key. This should be done, but requires larger code changes. I propose we do this as step to following the fix here.