### PR TITLE
Adding a functional test for Health Probes on pods w/ same labels but different namespaces

### DIFF
--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -52,6 +52,7 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 	serviceName := "hello-world"
 	serviceNameA := "hello-world-a"
 	serviceNameB := "hello-world-b"
+	serviceNameC := "hello-world-c"
 
 	// Frontend and Backend port.
 	servicePort := Port(80)
@@ -163,6 +164,39 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 		},
 	}
 
+	ingressOtherNamespace := &v1beta1.Ingress{
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: "foo.baz",
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								{
+									Path: "/b",
+									Backend: v1beta1.IngressBackend{
+										ServiceName: serviceNameC,
+										ServicePort: intstr.IntOrString{
+											Type:   intstr.Int,
+											IntVal: 80,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotations.IngressClassKey: annotations.ApplicationGatewayIngressClass,
+			},
+			Namespace: tests.OtherNamespace,
+			Name:      tests.Name,
+		},
+	}
+
 	// TODO(draychev): Get this from test fixtures -- tests.NewServiceFixture()
 	service := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -210,6 +244,27 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceNameB,
 			Namespace: tests.Namespace,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name: "servicePort",
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: backendName,
+					},
+					Protocol: v1.ProtocolTCP,
+					Port:     int32(servicePort),
+				},
+			},
+			Selector: map[string]string{"app": "frontend"},
+		},
+	}
+
+	serviceC := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceNameC,
+			Namespace: tests.OtherNamespace,
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
@@ -306,7 +361,32 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 		},
 	}
 
+	endpointsC := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceNameC,
+			Namespace: tests.OtherNamespace,
+		},
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: []v1.EndpointAddress{
+					{IP: "21.21.21.21"},
+					{IP: "21.21.21.22"},
+					{IP: "21.21.21.23"},
+				},
+				Ports: []v1.EndpointPort{
+					{
+						Name:     "servicePort",
+						Port:     int32(servicePort),
+						Protocol: v1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	}
+
 	pod := tests.NewPodFixture(serviceName, tests.Namespace, backendName, int32(backendPort))
+	podB := tests.NewPodFixture(serviceNameB, tests.Namespace, backendName, int32(backendPort))
+	podC := tests.NewPodFixture(serviceNameC, tests.OtherNamespace, backendName, int32(backendPort))
 
 	_ = flag.Lookup("logtostderr").Value.Set("true")
 	_ = flag.Set("v", "3")
@@ -328,15 +408,23 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 		_, _ = k8sClient.CoreV1().Services(tests.Namespace).Create(service)
 		_, _ = k8sClient.CoreV1().Services(tests.Namespace).Create(serviceA)
 		_, _ = k8sClient.CoreV1().Services(tests.Namespace).Create(serviceB)
+		_, _ = k8sClient.CoreV1().Services(tests.OtherNamespace).Create(serviceC)
 		_, _ = k8sClient.CoreV1().Endpoints(tests.Namespace).Create(endpoints)
 		_, _ = k8sClient.CoreV1().Endpoints(tests.Namespace).Create(endpointsA)
 		_, _ = k8sClient.CoreV1().Endpoints(tests.Namespace).Create(endpointsB)
+		_, _ = k8sClient.CoreV1().Endpoints(tests.OtherNamespace).Create(endpointsC)
 		_, _ = k8sClient.CoreV1().Pods(tests.Namespace).Create(pod)
+		_, _ = k8sClient.CoreV1().Pods(tests.Namespace).Create(podB)
+		_, _ = k8sClient.CoreV1().Pods(tests.OtherNamespace).Create(podC)
 		_, _ = k8sClient.CoreV1().Secrets(tests.Namespace).Create(ingressSecret)
 
 		crdClient := fake.NewSimpleClientset()
 		istioCrdClient := istio_fake.NewSimpleClientset()
-		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, []string{tests.Namespace}, 1000*time.Second, metricstore.NewFakeMetricStore())
+		namespaces := []string{
+			tests.Namespace,
+			tests.OtherNamespace,
+		}
+		ctxt = k8scontext.NewContext(k8sClient, crdClient, istioCrdClient, namespaces, 1000*time.Second, metricstore.NewFakeMetricStore())
 
 		secKey := utils.GetResourceKey(ingressSecret.Namespace, ingressSecret.Name)
 		_ = ctxt.CertificateSecretStore.ConvertSecret(secKey, ingressSecret)
@@ -556,6 +644,23 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 				},
 			}
 			check(cbCtx, "waf_annotation.json", stopChannel, ctxt, configBuilder)
+		})
+
+		ginkgo.It("Health Probes: same container labels; different namespaces", func() {
+			cbCtx := &ConfigBuilderContext{
+				IngressList: []*v1beta1.Ingress{
+					ingress,
+					ingressOtherNamespace,
+				},
+				ServiceList: []*v1.Service{
+					serviceA,
+					serviceC,
+				},
+				EnvVariables:          environment.GetFakeEnv(),
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
+			}
+			check(cbCtx, "health_probes_same_labels_different_namespaces.json", stopChannel, ctxt, configBuilder)
 		})
 
 	})

--- a/functional_tests/health_probes_same_labels_different_namespaces.json
+++ b/functional_tests/health_probes_same_labels_different_namespaces.json
@@ -1,0 +1,291 @@
+{
+    "properties": {
+        "backendAddressPools": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/defaultaddresspool",
+                "name": "defaultaddresspool",
+                "properties": {
+                    "backendAddresses": []
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80",
+                "name": "pool---namespace---hello-world-80-bp-80",
+                "properties": {
+                    "backendAddresses": [
+                        {
+                            "ipAddress": "1.1.1.1"
+                        },
+                        {
+                            "ipAddress": "1.1.1.2"
+                        },
+                        {
+                            "ipAddress": "1.1.1.3"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---other-namespace---hello-world-c-80-bp-80",
+                "name": "pool---other-namespace---hello-world-c-80-bp-80",
+                "properties": {
+                    "backendAddresses": [
+                        {
+                            "ipAddress": "21.21.21.21"
+                        },
+                        {
+                            "ipAddress": "21.21.21.22"
+                        },
+                        {
+                            "ipAddress": "21.21.21.23"
+                        }
+                    ]
+                }
+            }
+        ],
+        "backendHttpSettingsCollection": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--",
+                "name": "bp---namespace---hello-world-80-80---name--",
+                "properties": {
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-80---name--"
+                    },
+                    "protocol": "Http"
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---other-namespace---hello-world-c-80-80---name--",
+                "name": "bp---other-namespace---hello-world-c-80-80---name--",
+                "properties": {
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---other-namespace---hello-world-c-80---name--"
+                    },
+                    "protocol": "Http"
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/defaulthttpsetting",
+                "name": "defaulthttpsetting",
+                "properties": {
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http"
+                    },
+                    "protocol": "Http"
+                }
+            }
+        ],
+        "frontendIPConfigurations": [
+            {
+                "id": "--front-end-ip-id-1--",
+                "name": "xx3",
+                "properties": {
+                    "publicIPAddress": {
+                        "id": "xyz"
+                    }
+                }
+            },
+            {
+                "id": "--front-end-ip-id-2--",
+                "name": "yy3",
+                "properties": {
+                    "privateIPAddress": "abc"
+                }
+            }
+        ],
+        "frontendPorts": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-443",
+                "name": "fp-443",
+                "properties": {
+                    "port": 443
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80",
+                "name": "fp-80",
+                "properties": {
+                    "port": 80
+                }
+            }
+        ],
+        "httpListeners": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443",
+                "name": "fl-foo.baz-443",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-443"
+                    },
+                    "hostName": "foo.baz",
+                    "protocol": "Https",
+                    "sslCertificate": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/--namespace-----the-name-of-the-secret--"
+                    }
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-80",
+                "name": "fl-foo.baz-80",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
+                    },
+                    "hostName": "foo.baz",
+                    "protocol": "Http"
+                }
+            }
+        ],
+        "probes": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http",
+                "name": "defaultprobe-Http",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Https",
+                "name": "defaultprobe-Https",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "path": "/",
+                    "protocol": "Https",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-80---name--",
+                "name": "pb---namespace---hello-world-80---name--",
+                "properties": {
+                    "host": "foo.baz",
+                    "interval": 30,
+                    "path": "/",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---other-namespace---hello-world-c-80---name--",
+                "name": "pb---other-namespace---hello-world-c-80---name--",
+                "properties": {
+                    "host": "foo.baz",
+                    "interval": 30,
+                    "path": "/b",
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            }
+        ],
+        "redirectConfigurations": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-foo.baz-443",
+                "name": "sslr-fl-foo.baz-443",
+                "properties": {
+                    "includePath": true,
+                    "includeQueryString": true,
+                    "redirectType": "Permanent",
+                    "targetListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443"
+                    }
+                }
+            }
+        ],
+        "requestRoutingRules": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-foo.baz-443",
+                "name": "rr-foo.baz-443",
+                "properties": {
+                    "backendAddressPool": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80"
+                    },
+                    "backendHttpSettings": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--"
+                    },
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-443"
+                    },
+                    "ruleType": "Basic"
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-foo.baz-80",
+                "name": "rr-foo.baz-80",
+                "properties": {
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-foo.baz-80"
+                    },
+                    "ruleType": "PathBasedRouting",
+                    "urlPathMap": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-foo.baz-80"
+                    }
+                }
+            }
+        ],
+        "sku": {
+            "capacity": 3,
+            "name": "Standard_v2",
+            "tier": "Standard_v2"
+        },
+        "sslCertificates": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/--namespace-----the-name-of-the-secret--",
+                "name": "--namespace-----the-name-of-the-secret--",
+                "properties": {
+                    "data": "xx",
+                    "password": "msazure"
+                }
+            }
+        ],
+        "urlPathMaps": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-foo.baz-80",
+                "name": "url-foo.baz-80",
+                "properties": {
+                    "defaultRedirectConfiguration": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-foo.baz-443"
+                    },
+                    "pathRules": [
+                        {
+                            "name": "pr---other-namespace-----name---0",
+                            "properties": {
+                                "backendAddressPool": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---other-namespace---hello-world-c-80-bp-80"
+                                },
+                                "backendHttpSettings": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---other-namespace---hello-world-c-80-80---name--"
+                                },
+                                "paths": [
+                                    "/b"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "tags": {
+        "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
+        "managed-by-k8s-ingress": "a/b/c"
+    }
+}

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -24,6 +24,7 @@ import (
 // constant values to be used for testing
 const (
 	Namespace               = "--namespace--"
+	OtherNamespace          = "--other-namespace--"
 	Name                    = "--name--"
 	Host                    = "bye.com"
 	OtherHost               = "--some-other-hostname--"
@@ -301,6 +302,7 @@ func NewPodFixture(serviceName string, ingressNamespace string, containerName st
 						},
 					},
 					ReadinessProbe: NewProbeFixture(containerName),
+					LivenessProbe:  NewProbeFixture(containerName),
 				},
 			},
 		},


### PR DESCRIPTION
This functional test covers https://github.com/Azure/application-gateway-kubernetes-ingress/pull/658 and https://github.com/Azure/application-gateway-kubernetes-ingress/pull/616

The test will be breaking until https://github.com/Azure/application-gateway-kubernetes-ingress/pull/658 is merged