### PR TITLE
helm: script to install w/ Helm but w/o Tiller; default for usePrivateIP

### DIFF
--- a/helm/ingress-azure/Chart.yaml
+++ b/helm/ingress-azure/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.7.1"
+appVersion: "1.0.0"
 description: Use Azure Application Gateway as the ingress for an Azure Kubernetes Service cluster.
 name: ingress-azure
-version: 0.7.1
+version: 1.0.0

--- a/helm/ingress-azure/templates/NOTES.txt
+++ b/helm/ingress-azure/templates/NOTES.txt
@@ -17,6 +17,9 @@ Configuration Details:
     - Subscription ID : {{ .Values.appgw.subscriptionId }}
     - Resource Group  : {{ .Values.appgw.resourceGroup }}
     - Application Gateway Name : {{ .Values.appgw.name }}
+{{- if .Values.appgw.usePrivateIP }}
+    - Using Application Gateway's private IP address
+{{- end }}
  * Kubernetes Ingress Controller:
 {{- if .Values.kubernetes }}
     {{- if .Values.kubernetes.watchNamespace }}

--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -26,6 +26,7 @@ kubernetes:
 #   subscriptionId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 #   resourceGroup: myResourceGroup
 #   name: myApplicationGateway
+#   usePrivateIP: false
 
 ################################################################################
 # Specify the authentication with Azure Resource Manager

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -30,6 +30,7 @@ appgw:
   subscriptionId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   resourceGroup: myResourceGroup
   name: myApplicationGateway
+  usePrivateIP: false
 
 ################################################################################
 # Specify the authentication with Azure Resource Manager

--- a/scripts/install-without-tiller.sh
+++ b/scripts/install-without-tiller.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+AGIC_NAME="ingress-azure"
+AGIC_NAMESPACE="default"
+HELM_CONFIG="./helm-config.yaml"
+
+[[ -f $HELM_CONFIG ]] || { echo "File $HELM_CONFIG does not exist!"; exit 1; }
+
+
+helm template "${AGIC_NAME}" ./helm/ingress-azure \
+     --namespace "${AGIC_NAMESPACE=}" \
+     --values "${HELM_CONFIG}" \
+    | tee /dev/tty | kubectl apply -f -
+
+


### PR DESCRIPTION
This PR adds a script that show how we can install AGIC using Helm 3, but without having Tiller on the cluster.

Also providing defaults for `usePrivateIP`, which is needed for Helm 3.

Fixes:  https://github.com/Azure/application-gateway-kubernetes-ingress/issues/664