### PR TITLE
probes: start http server for liveness early on

### DIFF
--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -38,14 +38,14 @@ spec:
             port: {{ .Values.kubernetes.httpServicePort }}
           initialDelaySeconds: 5
           periodSeconds: 10
-          failureThreshold: 180
+          failureThreshold: 60
         livenessProbe:
           httpGet:
             path: /health/alive
             port: {{ .Values.kubernetes.httpServicePort }}
           initialDelaySeconds: 15
           periodSeconds: 20
-          failureThreshold: 90
+          failureThreshold: 30
         env:
         - name: AZURE_CONTEXT_LOCATION
           value: /etc/appgw/azure.json

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -38,12 +38,14 @@ spec:
             port: {{ .Values.kubernetes.httpServicePort }}
           initialDelaySeconds: 5
           periodSeconds: 10
+          failureThreshold: 180
         livenessProbe:
           httpGet:
             path: /health/alive
             port: {{ .Values.kubernetes.httpServicePort }}
           initialDelaySeconds: 15
           periodSeconds: 20
+          failureThreshold: 90
         env:
         - name: AZURE_CONTEXT_LOCATION
           value: /etc/appgw/azure.json

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -38,14 +38,12 @@ spec:
             port: {{ .Values.kubernetes.httpServicePort }}
           initialDelaySeconds: 5
           periodSeconds: 10
-          failureThreshold: 60
         livenessProbe:
           httpGet:
             path: /health/alive
             port: {{ .Values.kubernetes.httpServicePort }}
           initialDelaySeconds: 15
           periodSeconds: 20
-          failureThreshold: 30
         env:
         - name: AZURE_CONTEXT_LOCATION
           value: /etc/appgw/azure.json

--- a/pkg/azure/fake.go
+++ b/pkg/azure/fake.go
@@ -5,7 +5,11 @@
 
 package azure
 
-import n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+import (
+	"github.com/Azure/go-autorest/autorest"
+
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+)
 
 // GetGatewayFunc is a function type
 type GetGatewayFunc func() (n.ApplicationGateway, error)
@@ -30,6 +34,10 @@ type FakeAzClient struct {
 // NewFakeAzClient returns a fake Azure Client
 func NewFakeAzClient() *FakeAzClient {
 	return &FakeAzClient{}
+}
+
+// SetAuthorizer is an empty function
+func (az *FakeAzClient) SetAuthorizer(authorizer autorest.Authorizer) {
 }
 
 // GetGateway runs GetGatewayFunc and return a gateway


### PR DESCRIPTION
[UPDATE]: As issue here is with waiting for AAD pod identity to provide a token and then becoming live. This causes AGIC to get terminated when token process takes longer.
To avoid this, We have decided to start the http server before the token process. This will make the pod `live` from k8s perspective. Readiness probe will still rely on cache sync channel to close to indicate that controller is ready.

[OLD] We know that AAD Pod Identity in its current form may take 10 to 15 minutes to start. 
Issue https://github.com/Azure/application-gateway-kubernetes-ingress/issues/668 is a manifestation of this delay.
Our Readiness and Liveness probes are aggressive - defaulted to `failureThreshold` of 3.
That makes readiness crash after 30 seconds and liveness after 60 seconds.

This PR increases wait time to 30 minutes.