### PR TITLE
Add extra hostnames only for the first listener

### DIFF
--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/record"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/azure"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/azure/tags"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
@@ -183,7 +182,7 @@ func generateBackendID(ingress *v1beta1.Ingress, rule *v1beta1.IngressRule, path
 	}
 }
 
-func generateListenerID(ingress *v1beta1.Ingress, rule *v1beta1.IngressRule, protocol n.ApplicationGatewayProtocol, overridePort *Port, usePrivateIP bool) listenerIdentifier {
+func generateListenerID(rule *v1beta1.IngressRule, protocol n.ApplicationGatewayProtocol, overridePort *Port, usePrivateIP bool, additionalHostnames []string) listenerIdentifier {
 	frontendPort := Port(80)
 	if protocol == n.HTTPS {
 		frontendPort = Port(443)
@@ -201,14 +200,7 @@ func generateListenerID(ingress *v1beta1.Ingress, rule *v1beta1.IngressRule, pro
 	if rule != nil && rule.Host != "" {
 		hostnames = append(hostnames, rule.Host)
 	}
-
-	if extendedHostNames, err := annotations.GetHostNameExtensions(ingress); err == nil {
-		if extendedHostNames != nil {
-			hostnames = append(hostnames, extendedHostNames...)
-		}
-	}
-
-	listenerID.setHostNames(hostnames)
+	listenerID.setHostNames(append(hostnames, additionalHostnames...))
 	return listenerID
 }
 

--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -52,7 +52,7 @@ var _ = Describe("MutateAppGateway ingress rules, listeners, and ports", func() 
 		ingress.Spec.TLS = nil
 
 		// !! Action !!
-		listenerConfigs := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables)
+		listenerConfigs := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables, nil)
 
 		// Verify front end listeners
 		It("should have correct count of frontend listeners", func() {
@@ -115,7 +115,7 @@ var _ = Describe("MutateAppGateway ingress rules, listeners, and ports", func() 
 		}
 
 		// !! Action !!
-		frontendListeners := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables)
+		frontendListeners := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables, nil)
 
 		httpListenersAzureConfigMap := cb.getListenerConfigs(cbCtx)
 

--- a/pkg/appgw/redirects_test.go
+++ b/pkg/appgw/redirects_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 			ID:   to.StringPtr(cb.appGwIdentifier.redirectConfigurationID("sslr-" + listenerID2Name)),
 		}
 
-		actualListeners := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables)
+		actualListeners := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables, nil)
 
 		It("test was setup correctly", func() {
 			Expect(ingress.Spec.TLS).ToNot(BeNil())
@@ -102,7 +102,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		actualRedirects := cb.getRedirectConfigurations(&cbCtx)
 
 		// Run this to link the listeners and the redirect config
-		actualListeners := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables)
+		actualListeners := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables, nil)
 
 		It("test was setup correctly", func() {
 			Expect(ingress.Spec.TLS).To(BeNil())
@@ -130,7 +130,7 @@ var _ = Describe("Test SSL Redirect Annotations", func() {
 		actualRedirects := cb.getRedirectConfigurations(&cbCtx)
 
 		// Run this to link the listeners and the redirect config
-		actualListeners := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables)
+		actualListeners := cb.getListenersFromIngress(ingress, cbCtx.EnvVariables, nil)
 
 		It("test was setup correctly", func() {
 			Expect(ingress.Spec.TLS).ToNot(BeNil())

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -163,8 +163,13 @@ func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listen
 				continue
 			}
 
-			_, azListenerConfig := c.processIngressRule(rule, ingress, cbCtx.EnvVariables)
-			for listenerID, listenerAzConfig := range azListenerConfig {
+			var additionalHostnames []string
+			if extendedHostNames, err := annotations.GetHostNameExtensions(ingress); err == nil && extendedHostNames != nil && ruleIdx == 0 {
+				additionalHostnames = extendedHostNames
+			}
+
+			_, azListenerConfigs := c.processIngressRule(rule, ingress, cbCtx.EnvVariables, additionalHostnames)
+			for listenerID, listenerAzConfig := range azListenerConfigs {
 				if _, exists := urlPathMaps[listenerID]; !exists {
 					urlPathMaps[listenerID] = &n.ApplicationGatewayURLPathMap{
 						Etag: to.StringPtr("*"),

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Test routing rules generations", func() {
 		_ = configBuilder.Listeners(cbCtx)
 		// !! Action !! -- will mutate pathMap struct
 		pathMaps := configBuilder.getPathMaps(cbCtx)
-		sharedListenerID := generateListenerID(ingressPathBased1, rule, n.HTTPS, nil, false)
+		sharedListenerID := generateListenerID(rule, n.HTTPS, nil, false, []string{})
 		generatedPathMap := pathMaps[sharedListenerID]
 		It("has default backend pool", func() {
 			Expect(generatedPathMap.DefaultBackendAddressPool).To(Not(BeNil()))
@@ -141,7 +141,7 @@ var _ = Describe("Test routing rules generations", func() {
 		_ = configBuilder.Listeners(cbCtx)
 		// !! Action !! -- will mutate pathMap struct
 		pathMaps := configBuilder.getPathMaps(cbCtx)
-		sharedListenerID := generateListenerID(ingressPathBased, rule, n.HTTPS, nil, false)
+		sharedListenerID := generateListenerID(rule, n.HTTPS, nil, false, []string{})
 		generatedPathMap := pathMaps[sharedListenerID]
 		backendIDBasic := generateBackendID(ingressBasic, &ruleBasic, pathBasic, backendBasic)
 		It("has default backend pool coming from basic ingress", func() {
@@ -208,7 +208,7 @@ var _ = Describe("Test routing rules generations", func() {
 		_ = configBuilder.Listeners(cbCtx)
 		// !! Action !! -- will mutate pathMap struct
 		pathMap := configBuilder.getPathMaps(cbCtx)
-		listenerID := generateListenerID(ingress, rule, n.HTTP, nil, false)
+		listenerID := generateListenerID(rule, n.HTTP, nil, false, []string{})
 		It("has no default backend pool", func() {
 			Expect(pathMap[listenerID].DefaultBackendAddressPool).To(BeNil())
 		})
@@ -261,7 +261,7 @@ var _ = Describe("Test routing rules generations", func() {
 		pathMap := configBuilder.getPathMaps(cbCtx)
 
 		rule := &ingress.Spec.Rules[0]
-		listenerID := generateListenerID(ingress, rule, n.HTTP, nil, false)
+		listenerID := generateListenerID(rule, n.HTTP, nil, false, []string{})
 		It("has no default backend pool", func() {
 			Expect(pathMap[listenerID].DefaultBackendAddressPool).To(BeNil())
 		})


### PR DESCRIPTION
There seems to be a case where we end up adding the same domain name to multiple listeners and that results in an ARM error.

The error is:
```
error: network.ApplicationGatewaysClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="ApplicationGatewayHttpListenersUsingSameFrontendPort" Message="Two Http Listeners of Application Gateway /subscriptions/xx/resourceGroups/xx/providers/Microsoft.Network/applicationGateways/xx are using the same Frontend Port /subscriptions/xx/resourceGroups/xx/providers/Microsoft.Network/applicationGateways/xx/frontendPorts/fp-443." Details=[]
```
 
This error is a bit misleading since it mentions the same port being used by 2 listeners. This is actually allowed.  On the other hand two or more listeners can not share the same hostname.

In this case we end up with a config which may look like this:
```
-- App Gwy config --            { 
-- App Gwy config --                "id": "/subscriptions/xxx/resourceGroups/derayche-rg-A/providers/Microsoft.Network/applicationGateways/xxx/httpListeners/fl-662b79a8bda68b8522c2c5e37af22a20"
,
-- App Gwy config --                "name": "fl-662b79a8bda68b8522c2c5e37af22a20",
-- App Gwy config --                "properties": {
-- App Gwy config --                    "frontendIPConfiguration": {
-- App Gwy config --                        "id": "/subscriptions/xxx/resourceGroups/derayche-rg-A/providers/Microsoft.Network/applicationGateways/xxx/frontendIPConfigurations/appGatewayFronten
dIP"
-- App Gwy config --                    },
-- App Gwy config --                    "frontendPort": {
-- App Gwy config --                        "id": "/subscriptions/d664a618-e0fd-447e-a2cf-e0ca50ef6456/resourceGroups/derayche-rg-A/providers/Microsoft.Network/applicationGateways/applicationgatewayd0f0/frontendPorts/fp-443"
-- App Gwy config --                    },
-- App Gwy config --                    "hostnames": [
-- App Gwy config --                        "contoso.com",
-- App Gwy config --                        "appa-??-*.mis.li"
-- App Gwy config --                    ],
-- App Gwy config --                    "protocol": "Https",
-- App Gwy config --                    "sslCertificate": {
-- App Gwy config --                        "id": "/subscriptions/xxx/resourceGroups/derayche-rg-A/providers/Microsoft.Network/applicationGateways/xxx/sslCertificates/broken-brownfield-testsecr
et-tls"
-- App Gwy config --                    }
-- App Gwy config --                }
-- App Gwy config --            },
-- App Gwy config --            {
-- App Gwy config --                "id": "/subscriptions/xxx/resourceGroups/derayche-rg-A/providers/Microsoft.Network/applicationGateways/applicationgatewayd0f0/httpListeners/fl-837dd560ab59aee3a637acbfa27798d0"
,
-- App Gwy config --                "name": "fl-837dd560ab59aee3a637acbfa27798d0",
-- App Gwy config --                "properties": {
-- App Gwy config --                    "frontendIPConfiguration": {
-- App Gwy config --                        "id": "/subscriptions/xxx/resourceGroups/derayche-rg-A/providers/Microsoft.Network/applicationGateways/applicationgatewayd0f0/frontendIPConfigurations/appGatewayFronten
dIP"
-- App Gwy config --                    },
-- App Gwy config --                    "frontendPort": {
-- App Gwy config --                        "id": "/subscriptions/xxx/resourceGroups/derayche-rg-A/providers/Microsoft.Network/applicationGateways/xxx/frontendPorts/fp-443"
-- App Gwy config --                    },
-- App Gwy config --                    "hostnames": [
-- App Gwy config --                        "stage.contoso.com",
-- App Gwy config --                        "appa-??-*.mis.li"
-- App Gwy config --                    ],
-- App Gwy config --                    "protocol": "Https",
-- App Gwy config --                    "sslCertificate": {
-- App Gwy config --                        "id": "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Network/applicationGateways/applicationgatewayd0f0/sslCertificates/broken-brownfield-testsecr
et-tls"
-- App Gwy config --                    }
-- App Gwy config --                }
-- App Gwy config --            },
```

The issue there is the `"appa-??-*.mis.li` hostname being referenced twice, once for each listener, and not the port number.

To address the problem I decided to add the hostnames to the first listener only.