### PR TITLE
Fix typo

### DIFF
--- a/docs/how-tos/dns.md
+++ b/docs/how-tos/dns.md
@@ -1,6 +1,6 @@
 # Automate DNS updates
 
-When a hostname is specified in the Kubrenetes Ingress resource's rules, it can be used to automaticall create DNS records for the given domain and App Gateway's IP address.
+When a hostname is specified in the Kubernetes Ingress resource's rules, it can be used to automaticall create DNS records for the given domain and App Gateway's IP address.
 To achieve this the [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) Kubernetes app is required. ExternalDNS in installable via a [Helm chart](https://github.com/kubernetes-incubator/external-dns). The [following document](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/azure.md) provides a tutorial on setting up ExternalDNS with an Azure DNS.
 
 Below is a sample Ingress resource, annotated with


### PR DESCRIPTION
This change fixes Kub**er**netes being misspelled as Kub**re**netes in the [Automate DNS updates](https://azure.github.io/application-gateway-kubernetes-ingress/how-tos/dns/) documentation.