### PR TITLE
kubenet: associate route table to appgw subnet

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -183,6 +183,16 @@ func main() {
 		}
 	}
 
+	// add route table to application gateway subnet
+	if azContext != nil && azContext.RouteTableName != "" {
+		err = azClient.ApplyRouteTable(azure.ResourceGroup(azContext.VNetResourceGroup), azure.ResourceName(azContext.VNetName), azure.ResourceName(env.AppGwSubnetName), azure.ResourceName(azContext.RouteTableName))
+		if err != nil {
+			glog.Errorf("Unable to associate Application Gateway subnet %s with route table %s due to error: ",
+				env.AppGwSubnetName, azContext.RouteTableName,
+				err)
+		}
+	}
+
 	// namespace validations
 	if err := validateNamespaces(namespaces, kubeClient); err != nil {
 		glog.Fatal(err) // side-effect: will panic on non-existent namespace

--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -222,7 +222,7 @@ func main() {
 
 		err = azClient.ApplyRouteTable(subnetID, routeTableID)
 		if err != nil {
-			glog.Warningf("Unable to associate Application Gateway subnet '%s' with route table '%s' due to error: [%+v]",
+			glog.V(5).Infof("Unable to associate Application Gateway subnet '%s' with route table '%s' due to error (this is relevant for AKS clusters using 'Kubenet' network plugin): [%+v]",
 				subnetID,
 				routeTableID,
 				err)

--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -187,9 +187,9 @@ func main() {
 	if azContext != nil && azContext.RouteTableName != "" {
 		err = azClient.ApplyRouteTable(azure.ResourceGroup(azContext.VNetResourceGroup), azure.ResourceName(azContext.VNetName), azure.ResourceName(env.AppGwSubnetName), azure.ResourceName(azContext.RouteTableName))
 		if err != nil {
-			glog.Errorf("Unable to associate Application Gateway subnet %s with route table %s due to error: ",
+			glog.Warningf("Unable to associate Application Gateway subnet %s with route table %s due to error: %s",
 				env.AppGwSubnetName, azContext.RouteTableName,
-				err)
+				err.Error())
 		}
 	}
 

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -32,7 +32,7 @@ func ParseResourceID(ID string) (SubscriptionID, ResourceGroup, ResourceName) {
 	return SubscriptionID(split[2]), ResourceGroup(split[4]), ResourceName(split[8])
 }
 
-// ParseSubResourceID gets subscriptionId, resource group, vnet name, sub resource name from resourceID
+// ParseSubResourceID gets subscriptionId, resource group, resource name, sub resource name from resourceID
 func ParseSubResourceID(ID string) (SubscriptionID, ResourceGroup, ResourceName, ResourceName) {
 	split := strings.Split(ID, "/")
 	if len(split) < 11 {

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -32,6 +32,27 @@ func ParseResourceID(ID string) (SubscriptionID, ResourceGroup, ResourceName) {
 	return SubscriptionID(split[2]), ResourceGroup(split[4]), ResourceName(split[8])
 }
 
+// ParseSubResourceID gets subscriptionId, resource group, vnet name, sub resource name from resourceID
+func ParseSubResourceID(ID string) (SubscriptionID, ResourceGroup, ResourceName, ResourceName) {
+	split := strings.Split(ID, "/")
+	if len(split) < 9 {
+		glog.Errorf("resourceID %s is invalid. There should be atleast 9 segments in resourceID", ID)
+		return "", "", "", ""
+	}
+
+	return SubscriptionID(split[2]), ResourceGroup(split[4]), ResourceName(split[8]), ResourceName(split[10])
+}
+
+// ResourceID generates a resource id
+func ResourceID(subscriptionID SubscriptionID, resourceGroup ResourceGroup, provider string, resourceKind string, resourcePath string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/%s/%s/%s", subscriptionID, resourceGroup, provider, resourceKind, resourcePath)
+}
+
+// RouteTableID generates a route table resource id
+func RouteTableID(subscriptionID SubscriptionID, resourceGroup ResourceGroup, routeTableName ResourceName) string {
+	return ResourceID(subscriptionID, resourceGroup, "Microsoft.Network", "routeTables", string(routeTableName))
+}
+
 // ConvertToClusterResourceGroup converts infra resource group to aks cluster ID
 func ConvertToClusterResourceGroup(subscriptionID SubscriptionID, resourceGroup ResourceGroup, err error) (string, error) {
 	if err != nil {

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -35,7 +35,7 @@ func ParseResourceID(ID string) (SubscriptionID, ResourceGroup, ResourceName) {
 // ParseSubResourceID gets subscriptionId, resource group, vnet name, sub resource name from resourceID
 func ParseSubResourceID(ID string) (SubscriptionID, ResourceGroup, ResourceName, ResourceName) {
 	split := strings.Split(ID, "/")
-	if len(split) < 9 {
+	if len(split) < 11 {
 		glog.Errorf("resourceID %s is invalid. There should be atleast 9 segments in resourceID", ID)
 		return "", "", "", ""
 	}

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -114,5 +114,32 @@ var _ = Describe("Azure", func() {
 				Ω(context.Region).To(Equal("l"))
 			})
 		})
+
+		Context("test RouteTableID func", func(){
+			It("generate correct route table ID", func(){
+				expectedRouteTable := "/subscriptions/subID/resourceGroups/resGp/providers/Microsoft.Network/routeTables/rt"
+				Expect(RouteTableID(SubscriptionID("subID"), ResourceGroup("resGp"), ResourceName("rt"))).To(Equal(expectedRouteTable))
+			})
+		})
+
+		Context("test ParseSubResourceID func", func(){
+			It("parses sub resource ID correctly", func(){
+				subResourceID := "/subscriptions/subID/resourceGroups/resGp/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/cert"
+				subID, resourceGp, resource, subResource := ParseSubResourceID(subResourceID)
+				Expect(subID).To(Equal(SubscriptionID("subID")))
+				Expect(resourceGp).To(Equal(ResourceGroup("resGp")))
+				Expect(resource).To(Equal(ResourceName("appgw")))
+				Expect(subResource).To(Equal(ResourceName("cert")))
+			})
+
+			It("should give error if segements are less", func(){
+				subResourceID := "/subscriptions/subID/resourceGroups/resGp/providers/Microsoft.Network/applicationGateways/appgw"
+				subID, resourceGp, resource, subResource := ParseSubResourceID(subResourceID)
+				Expect(subID).To(Equal(SubscriptionID("")))
+				Expect(resourceGp).To(Equal(ResourceGroup("")))
+				Expect(resource).To(Equal(ResourceName("")))
+				Expect(subResource).To(Equal(ResourceName("")))
+			})
+		})
 	})
 })

--- a/pkg/azure/context.go
+++ b/pkg/azure/context.go
@@ -13,17 +13,18 @@ import (
 
 // AzContext represents the Azure context file
 type AzContext struct {
-	Cloud                  string `json:"cloud"`
-	TenantID               string `json:"tenantId"`
-	SubscriptionID         string `json:"subscriptionId"`
-	ClientID               string `json:"aadClientId"`
-	ClientSecret           string `json:"aadClientSecret"`
-	ResourceGroup          string `json:"resourceGroup"`
-	Region                 string `json:"location"`
-	VNetName               string `json:"vnetName"`
-	VNetResourceGroup      string `json:"vnetResourceGroup"`
-	RouteTableName         string `json:"routeTableName"`
-	UserAssignedIdentityID string `json:"userAssignedIdentityID"`
+	Cloud                   string `json:"cloud"`
+	TenantID                string `json:"tenantId"`
+	SubscriptionID          string `json:"subscriptionId"`
+	ClientID                string `json:"aadClientId"`
+	ClientSecret            string `json:"aadClientSecret"`
+	ResourceGroup           string `json:"resourceGroup"`
+	Region                  string `json:"location"`
+	VNetName                string `json:"vnetName"`
+	VNetResourceGroup       string `json:"vnetResourceGroup"`
+	RouteTableName          string `json:"routeTableName"`
+	RouteTableResourceGroup string `json:"routeTableResourceGroup"`
+	UserAssignedIdentityID  string `json:"userAssignedIdentityID"`
 }
 
 // NewAzContext returns an AzContext struct from file path

--- a/pkg/azure/fake.go
+++ b/pkg/azure/fake.go
@@ -24,7 +24,7 @@ type DeployGatewayFunc func(string) error
 type GetPublicIPFunc func(string) (n.PublicIPAddress, error)
 
 // ApplyRouteTableFunc is a function type
-type ApplyRouteTableFunc  func(ResourceGroup, ResourceName, ResourceName, ResourceName) error
+type ApplyRouteTableFunc func(string, string) error
 
 // FakeAzClient is a fake struct for AzClient
 type FakeAzClient struct {
@@ -85,9 +85,9 @@ func (az *FakeAzClient) GetPublicIP(resourceID string) (n.PublicIPAddress, error
 }
 
 // ApplyRouteTable runs ApplyRouteTableFunc
-func (az *FakeAzClient) ApplyRouteTable(resourceGroup ResourceGroup, vnetName ResourceName, subnetName ResourceName, routeTableName ResourceName) error {
+func (az *FakeAzClient) ApplyRouteTable(subnetID string, routeTableID string) error {
 	if az.ApplyRouteTableFunc != nil {
-		return az.ApplyRouteTableFunc(resourceGroup, vnetName, subnetName, routeTableName)
+		return az.ApplyRouteTableFunc(subnetID, routeTableID)
 	}
 	return nil
 }

--- a/pkg/azure/fake.go
+++ b/pkg/azure/fake.go
@@ -23,12 +23,16 @@ type DeployGatewayFunc func(string) error
 // GetPublicIPFunc is a function type
 type GetPublicIPFunc func(string) (n.PublicIPAddress, error)
 
+// ApplyRouteTableFunc is a function type
+type ApplyRouteTableFunc  func(ResourceGroup, ResourceName, ResourceName, ResourceName) error
+
 // FakeAzClient is a fake struct for AzClient
 type FakeAzClient struct {
 	GetGatewayFunc
 	UpdateGatewayFunc
 	DeployGatewayFunc
 	GetPublicIPFunc
+	ApplyRouteTableFunc
 }
 
 // NewFakeAzClient returns a fake Azure Client
@@ -78,4 +82,12 @@ func (az *FakeAzClient) GetPublicIP(resourceID string) (n.PublicIPAddress, error
 		return az.GetPublicIPFunc(resourceID)
 	}
 	return n.PublicIPAddress{}, nil
+}
+
+// ApplyRouteTable runs ApplyRouteTableFunc
+func (az *FakeAzClient) ApplyRouteTable(resourceGroup ResourceGroup, vnetName ResourceName, subnetName ResourceName, routeTableName ResourceName) error {
+	if az.ApplyRouteTableFunc != nil {
+		return az.ApplyRouteTableFunc(resourceGroup, vnetName, subnetName, routeTableName)
+	}
+	return nil
 }


### PR DESCRIPTION
This PR allows AGIC to associate AKS cluster's route table to AppGW's subnet, This is required for supporting kubenet which uses route table for routing.

We extract the route table name from `azure.json` mounted through the node and then check for it's existence.
If it exists, then if appgw subnet has a route table already, we skip the assignment, else we update the subnet with the route table.
We perform these checks as best effort. If any of these fail, we simply move forward after logging error.

* If route table is not found, following is the error message:
```
I0127 16:06:08.530284   32437 client.go:190] Error getting route table '/subscriptions/xxxx/resourceGroups/resgp/providers/Microsoft.Network/routeTables/aks-agentpool-10660215-routetable1' (this is relevant for AKS clusters using 'Kubenet' network plugin): network.RouteTablesClient#Get: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceNotFound" Message="The Resource 'Microsoft.Network/routeTables/aks-agentpool-10660215-routetable1' under resource group 'resgp' was not found."
```
* If subnet already has a different route table:
```
I0127 16:07:22.179863   32603 client.go:210] Skipping associating Application Gateway subnet '<subnet-id>' with route table '<other-route-table-id>' used by k8s cluster as it is already associated to route table '<route-table-id>'.
```

* If subnet already has same route table:
```
I0127 14:59:44.216101   25838 client.go:206] Application Gateway subnet appgw-subnet is associated with route table aks-agentpool-10660215-routetable used by k8s cluster. 
```

* If the operation succeeds:
```
I0127 14:58:41.972538   25671 client.go:214] Associating Application Gateway subnet appgw-subnet with route table aks-agentpool-10660215-routetable used by k8s cluster. 
```