### PR TITLE
deployment: wait for vnet to complete deployment

### DIFF
--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -115,15 +115,15 @@ var _ = Describe("Azure", func() {
 			})
 		})
 
-		Context("test RouteTableID func", func(){
-			It("generate correct route table ID", func(){
+		Context("test RouteTableID func", func() {
+			It("generate correct route table ID", func() {
 				expectedRouteTable := "/subscriptions/subID/resourceGroups/resGp/providers/Microsoft.Network/routeTables/rt"
 				Expect(RouteTableID(SubscriptionID("subID"), ResourceGroup("resGp"), ResourceName("rt"))).To(Equal(expectedRouteTable))
 			})
 		})
 
-		Context("test ParseSubResourceID func", func(){
-			It("parses sub resource ID correctly", func(){
+		Context("test ParseSubResourceID func", func() {
+			It("parses sub resource ID correctly", func() {
 				subResourceID := "/subscriptions/subID/resourceGroups/resGp/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/cert"
 				subID, resourceGp, resource, subResource := ParseSubResourceID(subResourceID)
 				Expect(subID).To(Equal(SubscriptionID("subID")))
@@ -132,7 +132,7 @@ var _ = Describe("Azure", func() {
 				Expect(subResource).To(Equal(ResourceName("cert")))
 			})
 
-			It("should give error if segements are less", func(){
+			It("should give error if segements are less", func() {
 				subResourceID := "/subscriptions/subID/resourceGroups/resGp/providers/Microsoft.Network/applicationGateways/appgw"
 				subID, resourceGp, resource, subResource := ParseSubResourceID(subResourceID)
 				Expect(subID).To(Equal(SubscriptionID("")))

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -197,7 +197,7 @@ func (az *azClient) ApplyRouteTable(subnetID string, routeTableID string) error 
 		// no access or no route table
 		return err
 	}
-	
+
 	// Get subnet and check if it is already associated to a route table
 	_, subnetResourceGroup, subnetVnetName, subnetName := ParseSubResourceID(subnetID)
 	subnet, err := az.subnetsClient.Get(az.ctx, string(subnetResourceGroup), string(subnetVnetName), string(subnetName), "")
@@ -307,6 +307,10 @@ func (az *azClient) getVnet(resourceGroupName ResourceGroup, vnetName ResourceNa
 	utils.Retry(extendedRetryCount, retryPause,
 		func() (utils.Retriable, error) {
 			vnet, err = az.virtualNetworksClient.Get(az.ctx, string(resourceGroupName), string(vnetName), "")
+			if vnet.ProvisioningState == n.Updating {
+				return utils.Retriable(true), ErrVnetUpdating
+			}
+
 			if err != nil {
 				glog.Errorf("Error while getting virtual network '%s': %s", vnetName, err)
 			}

--- a/pkg/azure/errors.go
+++ b/pkg/azure/errors.go
@@ -24,4 +24,7 @@ var (
 
 	// ErrAppGatewayNotFound is an error message.
 	ErrAppGatewayNotFound = errors.New("unable to find Application Gateway (AZUR005)")
+
+	// ErrVnetUpdating is an error message.
+	ErrVnetUpdating = errors.New("Virtual network is in provisioning state: 'Updating'")
 )


### PR DESCRIPTION
This PR add retries on get if the vnet is in updating state. This solves the race condition b/w vnet creation operation tracked by ARM and update by AGIC.