### PR TITLE
template: remove addonProfiles from deployment yaml

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -594,14 +594,6 @@
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "enableRBAC": "[parameters('aksEnableRBAC')]",
                 "dnsPrefix": "[parameters('aksDnsPrefix')]",
-                "addonProfiles": {
-                    "httpApplicationRouting": {
-                        "enabled": false
-                    },
-                    "omsagent": {
-                        "enabled": false
-                    }
-                },
                 "agentPoolProfiles": [
                     {
                         "name": "agentpool",


### PR DESCRIPTION
This PR removes the addon profile from the aks resource definition as it is not needed any more.