### PR TITLE
chore: consolidate env and move helper functions to utils.go

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -64,7 +64,6 @@ func main() {
 		glog.Fatal("Error parsing command line arguments:", err)
 	}
 
-	// Setup enviroment
 	env := environment.GetEnv()
 	verbosity = to.IntPtr(getVerbosity(*verbosity, env.VerbosityLevel))
 	if *versionInfo {

--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -22,15 +21,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/record"
 
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/azure"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/controller"
@@ -72,12 +64,21 @@ func main() {
 		glog.Fatal("Error parsing command line arguments:", err)
 	}
 
+	// Setup enviroment
 	env := environment.GetEnv()
-
 	verbosity = to.IntPtr(getVerbosity(*verbosity, env.VerbosityLevel))
 	if *versionInfo {
 		version.PrintVersionAndExit()
 	}
+
+	// get the details from Azure Context
+	// Reference: https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/docs/cloud-provider-config.md#cloud-provider-config
+	azContext, err := azure.NewAzContext(env.AzContextLocation)
+	if err != nil {
+		glog.Info("Unable to load Azure Context file:", env.AzContextLocation)
+	}
+
+	env.Consolidate(azContext)
 
 	// Workaround for "ERROR: logging before flag.Parse"
 	// See: https://github.com/kubernetes/kubernetes/issues/17162#issuecomment-225596212
@@ -95,37 +96,6 @@ func main() {
 	metricStore.Start()
 	k8sContext := k8scontext.NewContext(kubeClient, crdClient, istioCrdClient, namespaces, *resyncPeriod, metricStore)
 	agicPod := k8sContext.GetAGICPod(env)
-
-	// get the details from Azure Context
-	// Reference: https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/docs/cloud-provider-config.md#cloud-provider-config
-	azContext, err := azure.NewAzContext(env.AzContextLocation)
-	if err != nil {
-		glog.Info("Unable to load Azure Context file:", env.AzContextLocation)
-	} else {
-		if azContext.VNetResourceGroup == "" {
-			azContext.VNetResourceGroup = azContext.ResourceGroup
-		}
-		if azContext.RouteTableResourceGroup == "" {
-			azContext.RouteTableResourceGroup = azContext.ResourceGroup
-		}
-	}
-
-	// adjust env variable
-	if env.AppGwResourceID != "" {
-		subscriptionID, resourceGroupName, applicationGatewayName := azure.ParseResourceID(env.AppGwResourceID)
-		env.SubscriptionID = string(subscriptionID)
-		env.ResourceGroupName = string(resourceGroupName)
-		env.AppGwName = string(applicationGatewayName)
-	}
-	if azContext != nil && env.SubscriptionID == "" {
-		env.SubscriptionID = string(azContext.SubscriptionID)
-	}
-	if azContext != nil && env.ResourceGroupName == "" {
-		env.ResourceGroupName = string(azContext.ResourceGroup)
-	}
-	if env.AppGwSubnetName == "" {
-		env.AppGwSubnetName = env.AppGwName + "-subnet"
-	}
 
 	if err := environment.ValidateEnv(env); err != nil {
 		errorLine := fmt.Sprint("Error while initializing values from environment. Please check helm configuration for missing values: ", err)
@@ -244,85 +214,4 @@ func main() {
 	appGwIngressController.Stop()
 	httpServer.Stop()
 	glog.Info("Goodbye!")
-}
-
-func validateNamespaces(namespaces []string, kubeClient *kubernetes.Clientset) error {
-	var nonExistent []string
-	for _, ns := range namespaces {
-		if _, err := kubeClient.CoreV1().Namespaces().Get(ns, metav1.GetOptions{}); err != nil {
-			nonExistent = append(nonExistent, ns)
-		}
-	}
-	if len(nonExistent) > 0 {
-		glog.Errorf("Error creating informers; Namespaces do not exist or Ingress Controller has no access to: %v", strings.Join(nonExistent, ","))
-		return ErrNoSuchNamespace
-	}
-	return nil
-}
-
-func getNamespacesToWatch(namespaceEnvVar string) []string {
-	// Returning an empty array effectively switches Ingress Controller
-	// in a mode of observing all accessible namespaces.
-	if namespaceEnvVar == "" {
-		return []string{}
-	}
-
-	// Namespaces (DNS-1123 label) can have lower case alphanumeric characters or '-'
-	// Commas are safe to use as a separator
-	if strings.Contains(namespaceEnvVar, ",") {
-		var namespaces []string
-		for _, ns := range strings.Split(namespaceEnvVar, ",") {
-			if len(ns) > 0 {
-				namespaces = append(namespaces, strings.TrimSpace(ns))
-			}
-		}
-		sort.Strings(namespaces)
-		return namespaces
-	}
-	return []string{namespaceEnvVar}
-}
-
-func getKubeClientConfig() *rest.Config {
-	if *inCluster {
-		config, err := rest.InClusterConfig()
-		if err != nil {
-			glog.Fatal("Error creating client configuration:", err)
-		}
-		return config
-	}
-
-	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeConfigFile)
-	if err != nil {
-		glog.Fatal("error creating client configuration:", err)
-	}
-
-	return config
-}
-
-func getEventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {
-	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(glog.V(5).Infof)
-	sink := &typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")}
-	eventBroadcaster.StartRecordingToSink(sink)
-	hostname, err := os.Hostname()
-	if err != nil {
-		glog.Error("Could not obtain host name from the operating system", err)
-		hostname = "unknown-hostname"
-	}
-	source := v1.EventSource{
-		Component: annotations.ApplicationGatewayIngressClass,
-		Host:      hostname,
-	}
-	return eventBroadcaster.NewRecorder(scheme.Scheme, source)
-}
-
-func getVerbosity(flagVerbosity int, envVerbosity string) int {
-	envVerbosityInt, err := strconv.Atoi(envVerbosity)
-	if err != nil {
-		glog.Infof("Using verbosity level %d from CLI flag %s", flagVerbosity, verbosityFlag)
-		return flagVerbosity
-	}
-	glog.Infof("Using verbosity level %d from environment variable %s", envVerbosityInt, environment.VerbosityLevelVarName)
-	return envVerbosityInt
 }

--- a/cmd/appgw-ingress/utils.go
+++ b/cmd/appgw-ingress/utils.go
@@ -1,0 +1,107 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+package main
+
+import (
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/scheme"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
+)
+
+func validateNamespaces(namespaces []string, kubeClient *kubernetes.Clientset) error {
+	var nonExistent []string
+	for _, ns := range namespaces {
+		if _, err := kubeClient.CoreV1().Namespaces().Get(ns, metav1.GetOptions{}); err != nil {
+			nonExistent = append(nonExistent, ns)
+		}
+	}
+	if len(nonExistent) > 0 {
+		glog.Errorf("Error creating informers; Namespaces do not exist or Ingress Controller has no access to: %v", strings.Join(nonExistent, ","))
+		return ErrNoSuchNamespace
+	}
+	return nil
+}
+
+func getNamespacesToWatch(namespaceEnvVar string) []string {
+	// Returning an empty array effectively switches Ingress Controller
+	// in a mode of observing all accessible namespaces.
+	if namespaceEnvVar == "" {
+		return []string{}
+	}
+
+	// Namespaces (DNS-1123 label) can have lower case alphanumeric characters or '-'
+	// Commas are safe to use as a separator
+	if strings.Contains(namespaceEnvVar, ",") {
+		var namespaces []string
+		for _, ns := range strings.Split(namespaceEnvVar, ",") {
+			if len(ns) > 0 {
+				namespaces = append(namespaces, strings.TrimSpace(ns))
+			}
+		}
+		sort.Strings(namespaces)
+		return namespaces
+	}
+	return []string{namespaceEnvVar}
+}
+
+func getKubeClientConfig() *rest.Config {
+	if *inCluster {
+		config, err := rest.InClusterConfig()
+		if err != nil {
+			glog.Fatal("Error creating in-cluster client configuration:", err)
+		}
+		return config
+	}
+
+	// use the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeConfigFile)
+	if err != nil {
+		glog.Fatal("error creating client configuration:", err)
+	}
+
+	return config
+}
+
+func getEventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.V(5).Infof)
+	sink := &typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")}
+	eventBroadcaster.StartRecordingToSink(sink)
+	hostname, err := os.Hostname()
+	if err != nil {
+		glog.Error("Could not obtain host name from the operating system", err)
+		hostname = "unknown-hostname"
+	}
+	source := v1.EventSource{
+		Component: annotations.ApplicationGatewayIngressClass,
+		Host:      hostname,
+	}
+	return eventBroadcaster.NewRecorder(scheme.Scheme, source)
+}
+
+func getVerbosity(flagVerbosity int, envVerbosity string) int {
+	envVerbosityInt, err := strconv.Atoi(envVerbosity)
+	if err != nil {
+		glog.Infof("Using verbosity level %d from CLI flag %s", flagVerbosity, verbosityFlag)
+		return flagVerbosity
+	}
+	glog.Infof("Using verbosity level %d from environment variable %s", envVerbosityInt, environment.VerbosityLevelVarName)
+	return envVerbosityInt
+}

--- a/pkg/azure/context.go
+++ b/pkg/azure/context.go
@@ -40,5 +40,12 @@ func NewAzContext(path string) (*AzContext, error) {
 		return nil, err
 	}
 
+	if context.VNetResourceGroup == "" {
+		context.VNetResourceGroup = context.ResourceGroup
+	}
+	if context.RouteTableResourceGroup == "" {
+		context.RouteTableResourceGroup = context.ResourceGroup
+	}
+
 	return &context, nil
 }

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -17,9 +17,6 @@ const (
 	// AzContextLocationVarName is an environment variable name. This file is available on azure cluster.
 	AzContextLocationVarName = "AZURE_CONTEXT_LOCATION"
 
-	// AzureEnvironmentVarName is an evironment variable name. It represents the cloud in which the application is running.
-	AzureEnvironmentVarName = "AZURE_ENVIRONMENT"
-
 	// SubscriptionIDVarName is the name of the APPGW_SUBSCRIPTION_ID
 	SubscriptionIDVarName = "APPGW_SUBSCRIPTION_ID"
 
@@ -95,7 +92,6 @@ var (
 // EnvVariables is a struct storing values for environment variables.
 type EnvVariables struct {
 	AzContextLocation          string
-	AzureEnvironment           string
 	SubscriptionID             string
 	ResourceGroupName          string
 	AppGwName                  string
@@ -120,7 +116,7 @@ type EnvVariables struct {
 	HostedOnUnderlay           bool
 }
 
-// Consolidate sets values from azContext and provide defaults
+// Consolidate sets defaults and missing values using azContext
 func (env *EnvVariables) Consolidate(azContext *azure.AzContext) {
 	// adjust env variable
 	if env.AppGwResourceID != "" {
@@ -139,18 +135,11 @@ func (env *EnvVariables) Consolidate(azContext *azure.AzContext) {
 		if env.ResourceGroupName == "" {
 			env.ResourceGroupName = string(azContext.ResourceGroup)
 		}
-
-		if env.AzureEnvironment == "" {
-			env.AzureEnvironment = azContext.Cloud
-		}
 	}
 
 	// Set defaults
 	if env.AppGwSubnetName == "" {
 		env.AppGwSubnetName = env.AppGwName + "-subnet"
-	}
-	if env.AzureEnvironment == "" {
-		env.AzureEnvironment = "AZUREPUBLICCLOUD"
 	}
 }
 
@@ -158,7 +147,6 @@ func (env *EnvVariables) Consolidate(azContext *azure.AzContext) {
 func GetEnv() EnvVariables {
 	env := EnvVariables{
 		AzContextLocation:          os.Getenv(AzContextLocationVarName),
-		AzureEnvironment:           os.Getenv(AzureEnvironmentVarName),
 		SubscriptionID:             os.Getenv(SubscriptionIDVarName),
 		ResourceGroupName:          os.Getenv(ResourceGroupNameVarName),
 		AppGwName:                  os.Getenv(AppGwNameVarName),

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -9,12 +9,16 @@ import (
 	"os"
 	"regexp"
 
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/azure"
 	"github.com/golang/glog"
 )
 
 const (
 	// AzContextLocationVarName is an environment variable name. This file is available on azure cluster.
 	AzContextLocationVarName = "AZURE_CONTEXT_LOCATION"
+
+	// AzureEnvironmentVarName is an evironment variable name. It represents the cloud in which the application is running.
+	AzureEnvironmentVarName = "AZURE_ENVIRONMENT"
 
 	// SubscriptionIDVarName is the name of the APPGW_SUBSCRIPTION_ID
 	SubscriptionIDVarName = "APPGW_SUBSCRIPTION_ID"
@@ -83,9 +87,15 @@ const (
 	HostedOnUnderlayVarName = "HOSTED_ON_UNDERLAY"
 )
 
+var (
+	portNumberValidator = regexp.MustCompile(`^[0-9]{4,5}$`)
+	boolValidator       = regexp.MustCompile(`^(?i)(true|false)$`)
+)
+
 // EnvVariables is a struct storing values for environment variables.
 type EnvVariables struct {
 	AzContextLocation          string
+	AzureEnvironment           string
 	SubscriptionID             string
 	ResourceGroupName          string
 	AppGwName                  string
@@ -110,13 +120,45 @@ type EnvVariables struct {
 	HostedOnUnderlay           bool
 }
 
-var portNumberValidator = regexp.MustCompile(`^[0-9]{4,5}$`)
-var boolValidator = regexp.MustCompile(`^(?i)(true|false)$`)
+// Consolidate sets values from azContext and provide defaults
+func (env *EnvVariables) Consolidate(azContext *azure.AzContext) {
+	// adjust env variable
+	if env.AppGwResourceID != "" {
+		subscriptionID, resourceGroupName, applicationGatewayName := azure.ParseResourceID(env.AppGwResourceID)
+		env.SubscriptionID = string(subscriptionID)
+		env.ResourceGroupName = string(resourceGroupName)
+		env.AppGwName = string(applicationGatewayName)
+	}
+
+	// Set using cloud provider config (AzContext)
+	if azContext != nil {
+		if env.SubscriptionID == "" {
+			env.SubscriptionID = string(azContext.SubscriptionID)
+		}
+
+		if env.ResourceGroupName == "" {
+			env.ResourceGroupName = string(azContext.ResourceGroup)
+		}
+
+		if env.AzureEnvironment == "" {
+			env.AzureEnvironment = azContext.Cloud
+		}
+	}
+
+	// Set defaults
+	if env.AppGwSubnetName == "" {
+		env.AppGwSubnetName = env.AppGwName + "-subnet"
+	}
+	if env.AzureEnvironment == "" {
+		env.AzureEnvironment = "AZUREPUBLICCLOUD"
+	}
+}
 
 // GetEnv returns values for defined environment variables for Ingress Controller.
 func GetEnv() EnvVariables {
 	env := EnvVariables{
 		AzContextLocation:          os.Getenv(AzContextLocationVarName),
+		AzureEnvironment:           os.Getenv(AzureEnvironmentVarName),
 		SubscriptionID:             os.Getenv(SubscriptionIDVarName),
 		ResourceGroupName:          os.Getenv(ResourceGroupNameVarName),
 		AppGwName:                  os.Getenv(AppGwNameVarName),


### PR DESCRIPTION
This PR aims at cleaning up main.go.
1. move helper functions to a different file.
1. add function consolidating the env variable; setup defaults and use azContext.