### PR TITLE
chore: rename AzContext to CloudProviderConfig

### DIFF
--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         env:
-        - name: AZURE_CONTEXT_LOCATION
+        - name: AZURE_CLOUD_PROVIDER_LOCATION
           value: /etc/appgw/azure.json
         - name: AGIC_POD_NAME
           valueFrom:

--- a/pkg/azure/auth.go
+++ b/pkg/azure/auth.go
@@ -17,29 +17,29 @@ import (
 )
 
 // GetAuthorizerWithRetry return azure.Authorizer
-func GetAuthorizerWithRetry(authLocation string, useManagedidentity bool, azContext *AzContext, maxAuthRetryCount int, retryPause time.Duration) (authorizer autorest.Authorizer, err error) {
+func GetAuthorizerWithRetry(authLocation string, useManagedidentity bool, cpConfig *CloudProviderConfig, maxAuthRetryCount int, retryPause time.Duration) (authorizer autorest.Authorizer, err error) {
 	utils.Retry(maxAuthRetryCount, retryPause,
 		func() (utils.Retriable, error) {
 			// Fetch a new token
-			authorizer, err = getAuthorizer(authLocation, useManagedidentity, azContext)
+			authorizer, err = getAuthorizer(authLocation, useManagedidentity, cpConfig)
 			return utils.Retriable(true), err
 		})
 	return authorizer, nil
 }
 
-func getAuthorizer(authLocation string, useManagedidentity bool, azContext *AzContext) (autorest.Authorizer, error) {
+func getAuthorizer(authLocation string, useManagedidentity bool, cpConfig *CloudProviderConfig) (autorest.Authorizer, error) {
 	// Authorizer logic:
 	// 1. If User provided authLocation, then use the file.
 	// 2. If User provided a managed identity in ex: helm config, then use Environment
-	// 3. If User provided nothing and AzContext has value, then use AzContext
+	// 3. If User provided nothing and CloudProviderConfig has value, then use CloudProviderConfig
 	// 4. Fall back to environment
 	if authLocation != "" {
 		glog.V(1).Infof("Creating authorizer from file referenced by environment variable: %s", authLocation)
 		return auth.NewAuthorizerFromFile(n.DefaultBaseURI)
 	}
-	if !useManagedidentity && azContext != nil {
+	if !useManagedidentity && cpConfig != nil {
 		glog.V(1).Info("Creating authorizer using Cluster Service Principal.")
-		credAuthorizer := auth.NewClientCredentialsConfig(azContext.ClientID, azContext.ClientSecret, azContext.TenantID)
+		credAuthorizer := auth.NewClientCredentialsConfig(cpConfig.ClientID, cpConfig.ClientSecret, cpConfig.TenantID)
 		return credAuthorizer.Authorizer()
 	}
 

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Azure", func() {
 		})
 
 		Context("test AzContext struct", func() {
-			contextFile := `{
+			cpConfigFile := `{
 				"cloud": "xxxx",
 				"tenantId": "t",
 				"subscriptionId": "s",
@@ -107,23 +107,23 @@ var _ = Describe("Azure", func() {
 			}`
 
 			It("should deserialize correctly", func() {
-				var context AzContext
-				err := json.Unmarshal([]byte(contextFile), &context)
+				var cpConfig CloudProviderConfig
+				err := json.Unmarshal([]byte(cpConfigFile), &cpConfig)
 				Ω(err).ToNot(HaveOccurred())
-				Ω(context.TenantID).To(Equal("t"))
-				Ω(context.Region).To(Equal("l"))
+				Ω(cpConfig.TenantID).To(Equal("t"))
+				Ω(cpConfig.Region).To(Equal("l"))
 			})
 		})
 
-		Context("test RouteTableID func", func(){
-			It("generate correct route table ID", func(){
+		Context("test RouteTableID func", func() {
+			It("generate correct route table ID", func() {
 				expectedRouteTable := "/subscriptions/subID/resourceGroups/resGp/providers/Microsoft.Network/routeTables/rt"
 				Expect(RouteTableID(SubscriptionID("subID"), ResourceGroup("resGp"), ResourceName("rt"))).To(Equal(expectedRouteTable))
 			})
 		})
 
-		Context("test ParseSubResourceID func", func(){
-			It("parses sub resource ID correctly", func(){
+		Context("test ParseSubResourceID func", func() {
+			It("parses sub resource ID correctly", func() {
 				subResourceID := "/subscriptions/subID/resourceGroups/resGp/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/cert"
 				subID, resourceGp, resource, subResource := ParseSubResourceID(subResourceID)
 				Expect(subID).To(Equal(SubscriptionID("subID")))
@@ -132,7 +132,7 @@ var _ = Describe("Azure", func() {
 				Expect(subResource).To(Equal(ResourceName("cert")))
 			})
 
-			It("should give error if segements are less", func(){
+			It("should give error if segements are less", func() {
 				subResourceID := "/subscriptions/subID/resourceGroups/resGp/providers/Microsoft.Network/applicationGateways/appgw"
 				subID, resourceGp, resource, subResource := ParseSubResourceID(subResourceID)
 				Expect(subID).To(Equal(SubscriptionID("")))

--- a/pkg/azure/cloudproviderconfig.go
+++ b/pkg/azure/cloudproviderconfig.go
@@ -11,7 +11,7 @@ import (
 	"io/ioutil"
 )
 
-// CloudProviderConfig represents the Cloud Provider file format
+// CloudProviderConfig represent the CloudProvider Context file such as Azure
 type CloudProviderConfig struct {
 	Cloud                   string `json:"cloud"`
 	TenantID                string `json:"tenantId"`

--- a/pkg/azure/cloudproviderconfig.go
+++ b/pkg/azure/cloudproviderconfig.go
@@ -11,7 +11,7 @@ import (
 	"io/ioutil"
 )
 
-// CloudProviderConfig represents the Azure context file
+// CloudProviderConfig represents the Cloud Provider file format
 type CloudProviderConfig struct {
 	Cloud                   string `json:"cloud"`
 	TenantID                string `json:"tenantId"`

--- a/pkg/azure/cloudproviderconfig.go
+++ b/pkg/azure/cloudproviderconfig.go
@@ -11,8 +11,8 @@ import (
 	"io/ioutil"
 )
 
-// AzContext represents the Azure context file
-type AzContext struct {
+// CloudProviderConfig represents the Azure context file
+type CloudProviderConfig struct {
 	Cloud                   string `json:"cloud"`
 	TenantID                string `json:"tenantId"`
 	SubscriptionID          string `json:"subscriptionId"`
@@ -27,15 +27,15 @@ type AzContext struct {
 	UserAssignedIdentityID  string `json:"userAssignedIdentityID"`
 }
 
-// NewAzContext returns an AzContext struct from file path
-func NewAzContext(path string) (*AzContext, error) {
+// NewCloudProviderConfig returns an CloudProviderConfig struct from file path
+func NewCloudProviderConfig(path string) (*CloudProviderConfig, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("Reading Az Context file %q failed: %v", path, err)
 	}
 
 	// Unmarshal the authentication file.
-	var context AzContext
+	var context CloudProviderConfig
 	if err := json.Unmarshal(b, &context); err != nil {
 		return nil, err
 	}

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	// AzContextLocationVarName is an environment variable name. This file is available on azure cluster.
-	AzContextLocationVarName = "AZURE_CONTEXT_LOCATION"
+	// CloudProviderConfigLocationVarName is an environment variable name. This file is available on azure cluster.
+	CloudProviderConfigLocationVarName = "AZURE_CONTEXT_LOCATION"
 
 	// SubscriptionIDVarName is the name of the APPGW_SUBSCRIPTION_ID
 	SubscriptionIDVarName = "APPGW_SUBSCRIPTION_ID"
@@ -91,33 +91,33 @@ var (
 
 // EnvVariables is a struct storing values for environment variables.
 type EnvVariables struct {
-	AzContextLocation          string
-	SubscriptionID             string
-	ResourceGroupName          string
-	AppGwName                  string
-	AppGwSubnetName            string
-	AppGwSubnetPrefix          string
-	AppGwResourceID            string
-	AppGwSubnetID              string
-	AuthLocation               string
-	WatchNamespace             string
-	UsePrivateIP               string
-	VerbosityLevel             string
-	AGICPodName                string
-	AGICPodNamespace           string
-	EnableBrownfieldDeployment bool
-	EnableIstioIntegration     bool
-	EnableSaveConfigToFile     bool
-	EnablePanicOnPutError      bool
-	EnableDeployAppGateway     bool
-	UseManagedIdentityForPod   bool
-	HTTPServicePort            string
-	AttachWAFPolicyToListener  bool
-	HostedOnUnderlay           bool
+	CloudProviderConfigLocation string
+	SubscriptionID              string
+	ResourceGroupName           string
+	AppGwName                   string
+	AppGwSubnetName             string
+	AppGwSubnetPrefix           string
+	AppGwResourceID             string
+	AppGwSubnetID               string
+	AuthLocation                string
+	WatchNamespace              string
+	UsePrivateIP                string
+	VerbosityLevel              string
+	AGICPodName                 string
+	AGICPodNamespace            string
+	EnableBrownfieldDeployment  bool
+	EnableIstioIntegration      bool
+	EnableSaveConfigToFile      bool
+	EnablePanicOnPutError       bool
+	EnableDeployAppGateway      bool
+	UseManagedIdentityForPod    bool
+	HTTPServicePort             string
+	AttachWAFPolicyToListener   bool
+	HostedOnUnderlay            bool
 }
 
-// Consolidate sets defaults and missing values using azContext
-func (env *EnvVariables) Consolidate(azContext *azure.AzContext) {
+// Consolidate sets defaults and missing values using cpConfig
+func (env *EnvVariables) Consolidate(cpConfig *azure.CloudProviderConfig) {
 	// adjust env variable
 	if env.AppGwResourceID != "" {
 		subscriptionID, resourceGroupName, applicationGatewayName := azure.ParseResourceID(env.AppGwResourceID)
@@ -126,14 +126,14 @@ func (env *EnvVariables) Consolidate(azContext *azure.AzContext) {
 		env.AppGwName = string(applicationGatewayName)
 	}
 
-	// Set using cloud provider config (AzContext)
-	if azContext != nil {
+	// Set using cloud provider config
+	if cpConfig != nil {
 		if env.SubscriptionID == "" {
-			env.SubscriptionID = string(azContext.SubscriptionID)
+			env.SubscriptionID = string(cpConfig.SubscriptionID)
 		}
 
 		if env.ResourceGroupName == "" {
-			env.ResourceGroupName = string(azContext.ResourceGroup)
+			env.ResourceGroupName = string(cpConfig.ResourceGroup)
 		}
 	}
 
@@ -146,29 +146,29 @@ func (env *EnvVariables) Consolidate(azContext *azure.AzContext) {
 // GetEnv returns values for defined environment variables for Ingress Controller.
 func GetEnv() EnvVariables {
 	env := EnvVariables{
-		AzContextLocation:          os.Getenv(AzContextLocationVarName),
-		SubscriptionID:             os.Getenv(SubscriptionIDVarName),
-		ResourceGroupName:          os.Getenv(ResourceGroupNameVarName),
-		AppGwName:                  os.Getenv(AppGwNameVarName),
-		AppGwSubnetName:            os.Getenv(AppGwSubnetNameVarName),
-		AppGwSubnetPrefix:          os.Getenv(AppGwSubnetPrefixVarName),
-		AppGwResourceID:            os.Getenv(AppGwResourceIDVarName),
-		AppGwSubnetID:              os.Getenv(AppGwSubnetIDVarName),
-		AuthLocation:               os.Getenv(AuthLocationVarName),
-		WatchNamespace:             os.Getenv(WatchNamespaceVarName),
-		UsePrivateIP:               os.Getenv(UsePrivateIPVarName),
-		VerbosityLevel:             os.Getenv(VerbosityLevelVarName),
-		AGICPodName:                os.Getenv(AGICPodNameVarName),
-		AGICPodNamespace:           os.Getenv(AGICPodNamespaceVarName),
-		EnableBrownfieldDeployment: GetEnvironmentVariable(EnableBrownfieldDeploymentVarName, "false", boolValidator) == "true",
-		EnableIstioIntegration:     GetEnvironmentVariable(EnableIstioIntegrationVarName, "false", boolValidator) == "true",
-		EnableSaveConfigToFile:     GetEnvironmentVariable(EnableSaveConfigToFileVarName, "false", boolValidator) == "true",
-		EnablePanicOnPutError:      GetEnvironmentVariable(EnablePanicOnPutErrorVarName, "false", boolValidator) == "true",
-		EnableDeployAppGateway:     GetEnvironmentVariable(EnableDeployAppGatewayVarName, "false", boolValidator) == "true",
-		UseManagedIdentityForPod:   GetEnvironmentVariable(UseManagedIdentityForPodVarName, "false", boolValidator) == "true",
-		HTTPServicePort:            GetEnvironmentVariable(HTTPServicePortVarName, "8123", portNumberValidator),
-		AttachWAFPolicyToListener:  GetEnvironmentVariable(AttachWAFPolicyToListenerVarName, "false", boolValidator) == "true",
-		HostedOnUnderlay:           GetEnvironmentVariable(HostedOnUnderlayVarName, "false", boolValidator) == "true",
+		CloudProviderConfigLocation: os.Getenv(CloudProviderConfigLocationVarName),
+		SubscriptionID:              os.Getenv(SubscriptionIDVarName),
+		ResourceGroupName:           os.Getenv(ResourceGroupNameVarName),
+		AppGwName:                   os.Getenv(AppGwNameVarName),
+		AppGwSubnetName:             os.Getenv(AppGwSubnetNameVarName),
+		AppGwSubnetPrefix:           os.Getenv(AppGwSubnetPrefixVarName),
+		AppGwResourceID:             os.Getenv(AppGwResourceIDVarName),
+		AppGwSubnetID:               os.Getenv(AppGwSubnetIDVarName),
+		AuthLocation:                os.Getenv(AuthLocationVarName),
+		WatchNamespace:              os.Getenv(WatchNamespaceVarName),
+		UsePrivateIP:                os.Getenv(UsePrivateIPVarName),
+		VerbosityLevel:              os.Getenv(VerbosityLevelVarName),
+		AGICPodName:                 os.Getenv(AGICPodNameVarName),
+		AGICPodNamespace:            os.Getenv(AGICPodNamespaceVarName),
+		EnableBrownfieldDeployment:  GetEnvironmentVariable(EnableBrownfieldDeploymentVarName, "false", boolValidator) == "true",
+		EnableIstioIntegration:      GetEnvironmentVariable(EnableIstioIntegrationVarName, "false", boolValidator) == "true",
+		EnableSaveConfigToFile:      GetEnvironmentVariable(EnableSaveConfigToFileVarName, "false", boolValidator) == "true",
+		EnablePanicOnPutError:       GetEnvironmentVariable(EnablePanicOnPutErrorVarName, "false", boolValidator) == "true",
+		EnableDeployAppGateway:      GetEnvironmentVariable(EnableDeployAppGatewayVarName, "false", boolValidator) == "true",
+		UseManagedIdentityForPod:    GetEnvironmentVariable(UseManagedIdentityForPodVarName, "false", boolValidator) == "true",
+		HTTPServicePort:             GetEnvironmentVariable(HTTPServicePortVarName, "8123", portNumberValidator),
+		AttachWAFPolicyToListener:   GetEnvironmentVariable(AttachWAFPolicyToListenerVarName, "false", boolValidator) == "true",
+		HostedOnUnderlay:            GetEnvironmentVariable(HostedOnUnderlayVarName, "false", boolValidator) == "true",
 	}
 
 	return env

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// CloudProviderConfigLocationVarName is an environment variable name. This file is available on azure cluster.
-	CloudProviderConfigLocationVarName = "AZURE_CONTEXT_LOCATION"
+	CloudProviderConfigLocationVarName = "AZURE_CLOUD_PROVIDER_LOCATION"
 
 	// SubscriptionIDVarName is the name of the APPGW_SUBSCRIPTION_ID
 	SubscriptionIDVarName = "APPGW_SUBSCRIPTION_ID"


### PR DESCRIPTION
This PR simply renames the AzContext to CloudProviderConfig.

**About CloudProviderConfig:**
CloudProviderConfig is standard file configuration file used by cloud provider as an input to the cloud controller manager. It is present on every node. We use this file to get information about node resource group's subscriptionID, resource group name, vnet/route table information.

We use this file if it present and mounted to the pod.

https://github.com/kubernetes-sigs/cloud-provider-azure/blob/master/docs/cloud-provider-config.md

```json
{
    "cloud": "xxxx",
    "tenantId": "t",
    "subscriptionId": "s",
    "aadClientId": "c",
    "aadClientSecret": "cs",
    "resourceGroup": "r",
    "location": "l",
    "vmType": "xxxx",
    "subnetName": "xxxx",
    "securityGroupName": "xxxx",
    "vnetName": "xxxx",
    "vnetResourceGroup": "xxxx",
    "routeTableName": "xxxx",
    "primaryAvailabilitySetName": "xxxx",
    "primaryScaleSetName": "xxxx",
    "cloudProviderBackoff": "xxxx",
    "cloudProviderBackoffRetries": "xxxx",
    "cloudProviderBackoffExponent": "xxxx",
    "cloudProviderBackoffDuration": "xxxx",
    "cloudProviderBackoffJitter": "xxxx",
    "cloudProviderRatelimit": "xxxx",
    "cloudProviderRateLimitQPS": "xxxx",
    "cloudProviderRateLimitBucket": "xxxx",
    "useManagedIdentityExtension": "xxxx",
    "userAssignedIdentityID": "xxxx",
    "useInstanceMetadata": true,
    "loadBalancerSku": "xxxx",
    "excludeMasterFromStandardLB": "xxxx",
    "providerVaultName": "xxxx",
    "maximumLoadBalancerRuleCount": "xxxx",
    "providerKeyName": "xxxx",
    "providerKeyVersion": "xxxx"
}
```
