### PR TITLE
Add a new annotation, appgw-trusted-root-certificate. 

### DIFF
--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -71,9 +71,9 @@ const (
 	// AppGwSslCertificate indicates the name of ssl certificate installed by AppGw
 	AppGwSslCertificate = ApplicationGatewayPrefix + "/appgw-ssl-certificate"
 
-	// AppGwWhitelistRootCertificate indicates the names of root certificates need to be whitelisted by AppGw
+	// AppGwTrustedRootCertificate indicates the names of trusted root certificates
 	// Multiple root certificates seperated by comma, e.g. "cert1,cert2"
-	AppGwWhitelistRootCertificate = ApplicationGatewayPrefix + "/appgw-whitelist-root-certificate"
+	AppGwTrustedRootCertificate = ApplicationGatewayPrefix + "/appgw-trusted-root-certificate"
 )
 
 // ProtocolEnum is the type for protocol
@@ -128,9 +128,9 @@ func GetAppGwSslCertificate(ing *v1beta1.Ingress) (string, error) {
 	return parseString(ing, AppGwSslCertificate)
 }
 
-// GetAppGwWhitelistRootCertificate refer to appgw installed root certificate
-func GetAppGwWhitelistRootCertificate(ing *v1beta1.Ingress) (string, error) {
-	return parseString(ing, AppGwWhitelistRootCertificate)
+// GetAppGwTrustedRootCertificate refer to appgw installed root certificate
+func GetAppGwTrustedRootCertificate(ing *v1beta1.Ingress) (string, error) {
+	return parseString(ing, AppGwTrustedRootCertificate)
 }
 
 // RequestTimeout provides value for request timeout on the backend connection

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -70,6 +70,10 @@ const (
 
 	// AppGwSslCertificate indicates the name of ssl certificate installed by AppGw
 	AppGwSslCertificate = ApplicationGatewayPrefix + "/appgw-ssl-certificate"
+
+	// AppGwWhitelistRootCertificate indicates the names of root certificates need to be whitelisted by AppGw
+	// Multiple root certificates seperated by comma, e.g. "cert1,cert2"
+	AppGwWhitelistRootCertificate = ApplicationGatewayPrefix + "/appgw-whitelist-root-certificate"
 )
 
 // ProtocolEnum is the type for protocol
@@ -122,6 +126,11 @@ func BackendHostName(ing *v1beta1.Ingress) (string, error) {
 // GetAppGwSslCertificate refer to appgw installed certificate
 func GetAppGwSslCertificate(ing *v1beta1.Ingress) (string, error) {
 	return parseString(ing, AppGwSslCertificate)
+}
+
+// GetAppGwWhitelistRootCertificate refer to appgw installed root certificate
+func GetAppGwWhitelistRootCertificate(ing *v1beta1.Ingress) (string, error) {
+	return parseString(ing, AppGwWhitelistRootCertificate)
 }
 
 // RequestTimeout provides value for request timeout on the backend connection

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -35,21 +35,21 @@ func TestIt(t *testing.T) {
 
 var _ = Describe("Test ingress annotation functions", func() {
 	annotations := map[string]string{
-		"appgw.ingress.kubernetes.io/use-private-ip":                   "true",
-		"appgw.ingress.kubernetes.io/connection-draining":              "true",
-		"appgw.ingress.kubernetes.io/cookie-based-affinity":            "true",
-		"appgw.ingress.kubernetes.io/ssl-redirect":                     "true",
-		"appgw.ingress.kubernetes.io/request-timeout":                  "123456",
-		"appgw.ingress.kubernetes.io/connection-draining-timeout":      "3456",
-		"appgw.ingress.kubernetes.io/backend-path-prefix":              "prefix-here",
-		"appgw.ingress.kubernetes.io/backend-hostname":                 "www.backend.com",
-		"appgw.ingress.kubernetes.io/hostname-extension":               "www.bye.com, www.b*.com",
-		"appgw.ingress.kubernetes.io/appgw-ssl-certificate":            "appgw-cert",
-		"appgw.ingress.kubernetes.io/appgw-whitelist-root-certificate": "appgw-root-cert1,appgw-root-cert2",
-		"kubernetes.io/ingress.class":                                  "azure/application-gateway",
-		"appgw.ingress.istio.io/v1alpha3":                              "azure/application-gateway",
-		"falseKey":                                                     "false",
-		"errorKey":                                                     "234error!!",
+		"appgw.ingress.kubernetes.io/use-private-ip":                 "true",
+		"appgw.ingress.kubernetes.io/connection-draining":            "true",
+		"appgw.ingress.kubernetes.io/cookie-based-affinity":          "true",
+		"appgw.ingress.kubernetes.io/ssl-redirect":                   "true",
+		"appgw.ingress.kubernetes.io/request-timeout":                "123456",
+		"appgw.ingress.kubernetes.io/connection-draining-timeout":    "3456",
+		"appgw.ingress.kubernetes.io/backend-path-prefix":            "prefix-here",
+		"appgw.ingress.kubernetes.io/backend-hostname":               "www.backend.com",
+		"appgw.ingress.kubernetes.io/hostname-extension":             "www.bye.com, www.b*.com",
+		"appgw.ingress.kubernetes.io/appgw-ssl-certificate":          "appgw-cert",
+		"appgw.ingress.kubernetes.io/appgw-trusted-root-certificate": "appgw-root-cert1,appgw-root-cert2",
+		"kubernetes.io/ingress.class":                                "azure/application-gateway",
+		"appgw.ingress.istio.io/v1alpha3":                            "azure/application-gateway",
+		"falseKey":                                                   "false",
+		"errorKey":                                                   "234error!!",
 	}
 
 	ing := &v1beta1.Ingress{
@@ -86,15 +86,15 @@ var _ = Describe("Test ingress annotation functions", func() {
 		})
 	})
 
-	Context("test appgwWhitelistRootCertificate", func() {
+	Context("test appgwTrustedRootCertificate", func() {
 		It("returns error when ingress has no annotations", func() {
 			ing := &v1beta1.Ingress{}
-			actual, err := GetAppGwWhitelistRootCertificate(ing)
+			actual, err := GetAppGwTrustedRootCertificate(ing)
 			Expect(err).To(HaveOccurred())
 			Expect(actual).To(Equal(""))
 		})
 		It("returns true", func() {
-			actual, err := GetAppGwWhitelistRootCertificate(ing)
+			actual, err := GetAppGwTrustedRootCertificate(ing)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).To(Equal("appgw-root-cert1,appgw-root-cert2"))
 		})

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -35,20 +35,21 @@ func TestIt(t *testing.T) {
 
 var _ = Describe("Test ingress annotation functions", func() {
 	annotations := map[string]string{
-		"appgw.ingress.kubernetes.io/use-private-ip":              "true",
-		"appgw.ingress.kubernetes.io/connection-draining":         "true",
-		"appgw.ingress.kubernetes.io/cookie-based-affinity":       "true",
-		"appgw.ingress.kubernetes.io/ssl-redirect":                "true",
-		"appgw.ingress.kubernetes.io/request-timeout":             "123456",
-		"appgw.ingress.kubernetes.io/connection-draining-timeout": "3456",
-		"appgw.ingress.kubernetes.io/backend-path-prefix":         "prefix-here",
-		"appgw.ingress.kubernetes.io/backend-hostname":            "www.backend.com",
-		"appgw.ingress.kubernetes.io/hostname-extension":          "www.bye.com, www.b*.com",
-		"appgw.ingress.kubernetes.io/appgw-ssl-certificate":       "appgw-cert",
-		"kubernetes.io/ingress.class":                             "azure/application-gateway",
-		"appgw.ingress.istio.io/v1alpha3":                         "azure/application-gateway",
-		"falseKey":                                                "false",
-		"errorKey":                                                "234error!!",
+		"appgw.ingress.kubernetes.io/use-private-ip":                   "true",
+		"appgw.ingress.kubernetes.io/connection-draining":              "true",
+		"appgw.ingress.kubernetes.io/cookie-based-affinity":            "true",
+		"appgw.ingress.kubernetes.io/ssl-redirect":                     "true",
+		"appgw.ingress.kubernetes.io/request-timeout":                  "123456",
+		"appgw.ingress.kubernetes.io/connection-draining-timeout":      "3456",
+		"appgw.ingress.kubernetes.io/backend-path-prefix":              "prefix-here",
+		"appgw.ingress.kubernetes.io/backend-hostname":                 "www.backend.com",
+		"appgw.ingress.kubernetes.io/hostname-extension":               "www.bye.com, www.b*.com",
+		"appgw.ingress.kubernetes.io/appgw-ssl-certificate":            "appgw-cert",
+		"appgw.ingress.kubernetes.io/appgw-whitelist-root-certificate": "appgw-root-cert1,appgw-root-cert2",
+		"kubernetes.io/ingress.class":                                  "azure/application-gateway",
+		"appgw.ingress.istio.io/v1alpha3":                              "azure/application-gateway",
+		"falseKey":                                                     "false",
+		"errorKey":                                                     "234error!!",
 	}
 
 	ing := &v1beta1.Ingress{
@@ -82,6 +83,20 @@ var _ = Describe("Test ingress annotation functions", func() {
 			actual, err := GetAppGwSslCertificate(ing)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).To(Equal("appgw-cert"))
+		})
+	})
+
+	Context("test appgwWhitelistRootCertificate", func() {
+		It("returns error when ingress has no annotations", func() {
+			ing := &v1beta1.Ingress{}
+			actual, err := GetAppGwWhitelistRootCertificate(ing)
+			Expect(err).To(HaveOccurred())
+			Expect(actual).To(Equal(""))
+		})
+		It("returns true", func() {
+			actual, err := GetAppGwWhitelistRootCertificate(ing)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal("appgw-root-cert1,appgw-root-cert2"))
 		})
 	})
 

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -264,8 +264,8 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
 	}
 
-	if whitelistRootCertificates, err := annotations.GetAppGwWhitelistRootCertificate(backendID.Ingress); err == nil {
-		certificateNames := strings.TrimRight(whitelistRootCertificates, ",")
+	if trustedRootCertificates, err := annotations.GetAppGwTrustedRootCertificate(backendID.Ingress); err == nil {
+		certificateNames := strings.TrimRight(trustedRootCertificates, ",")
 		certificateNameList := strings.Split(certificateNames, ",")
 		var certs []n.SubResource
 		for _, certName := range certificateNameList {
@@ -273,7 +273,7 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 			certs = append(certs, *resourceRef(trustCertID))
 		}
 		httpSettings.TrustedRootCertificates = &certs
-		glog.V(5).Infof("Found root certificates: %s are whitelisted", certificateNames)
+		glog.V(5).Infof("Found trusted root certificate(s): %s from ingress: %s/%s", certificateNames, backendID.Ingress.Namespace, backendID.Ingress.Name)
 
 	} else if err != nil && !annotations.IsMissingAnnotations(err) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())

--- a/pkg/appgw/backendhttpsettings_test.go
+++ b/pkg/appgw/backendhttpsettings_test.go
@@ -8,6 +8,8 @@ package appgw
 import (
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
 
+	"strings"
+
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -76,13 +78,13 @@ var _ = Describe("Test the creation of Backend http settings from Ingress defini
 		})
 	})
 
-	Context("test appgw whitelist root certificate annotation configures trusted root certificate(s) on httpsettings", func() {
+	Context("test appgw trusted root certificate annotation configures trusted root certificate(s) on httpsettings", func() {
 
-		checkWhitelistRootCertificateAnnotation := func(protocol string, whitelistRootCertificate string, protocolEnum annotations.ProtocolEnum, expectedProtocolValue n.ApplicationGatewayProtocol) {
-			// appgw whitelist root certificate needs to be used together with backend protocal annotation, and protocal "https" should be used.
+		checkTrustedRootCertificateAnnotation := func(protocol string, trustedRootCertificate string, protocolEnum annotations.ProtocolEnum, expectedProtocolValue n.ApplicationGatewayProtocol) {
+			// appgw trusted root certificate needs to be used together with backend protocal annotation, and protocal "https" should be used.
 			// PickHostNameFromBackendAddress will be true given backend hostname is not specified
 			ingress.Annotations[annotations.BackendProtocolKey] = protocol
-			ingress.Annotations[annotations.AppGwWhitelistRootCertificate] = whitelistRootCertificate
+			ingress.Annotations[annotations.AppGwTrustedRootCertificate] = trustedRootCertificate
 			_ = configBuilder.k8sContext.Caches.Ingress.Update(ingress)
 
 			cbCtx := &ConfigBuilderContext{
@@ -107,11 +109,16 @@ var _ = Describe("Test the creation of Backend http settings from Ingress defini
 				Expect(setting.Protocol).To(Equal(expectedProtocolValue), "backend %s should have %s", *setting.Name, expectedProtocolValue)
 				Expect(probes[utils.GetLastChunkOfSlashed(*setting.Probe.ID)].Protocol).To(Equal(expectedProtocolValue), "probe should have same protocol as http setting")
 				Expect(len(*setting.TrustedRootCertificates)).To(Equal(2), "backend %s should have one two trusted root certificates configured", *setting.Name)
+				for _, certID := range *setting.TrustedRootCertificates {
+					segments := strings.Split(*certID.ID, "/")
+					certName := segments[len(segments)-1]
+					Expect(strings.Contains("rootcert1,rootcert2", certName)).To(Equal(true), "root certificate %s is not found", certName)
+				}
 			}
 		}
 
 		It("should have all but default backend http settings with https and trusted root certificates", func() {
-			checkWhitelistRootCertificateAnnotation("Https", "appgw-root-certificate1,appgw-root-certificate2", annotations.HTTPS, n.HTTPS)
+			checkTrustedRootCertificateAnnotation("Https", "rootcert1,rootcert2", annotations.HTTPS, n.HTTPS)
 		})
 
 	})

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -95,7 +95,7 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 		probe.Path = to.StringPtr(backendID.Path.Path)
 	}
 
-	// backend protocol "https" now support to use both certificate signed by well-known root certificate and whitelisted self-signed certificate
+	// backend protocol "https" now supports to use certificate signed by well-known root certificate as well as trusted self-signed certificate
 	if protocol, _ := annotations.BackendProtocol(backendID.Ingress); protocol == annotations.HTTPS {
 		probe.Protocol = n.HTTPS
 	}

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -95,6 +95,7 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 		probe.Path = to.StringPtr(backendID.Path.Path)
 	}
 
+	// backend protocol "https" now support to use both certificate signed by well-known root certificate and whitelisted self-signed certificate
 	if protocol, _ := annotations.BackendProtocol(backendID.Ingress); protocol == annotations.HTTPS {
 		probe.Protocol = n.HTTPS
 	}

--- a/pkg/appgw/identifier.go
+++ b/pkg/appgw/identifier.go
@@ -46,6 +46,10 @@ func (agw Identifier) sslCertificateID(certname string) string {
 	return agw.gatewayResourceID("sslCertificates", certname)
 }
 
+func (agw Identifier) trustedRootCertificateID(certname string) string {
+	return agw.gatewayResourceID("trustedRootCertificates", certname)
+}
+
 // HTTPSettingsID generates an ID for App Gateway HTTP settings resource.
 func (agw Identifier) HTTPSettingsID(settingsName string) string {
 	return agw.gatewayResourceID("backendHttpSettingsCollection", settingsName)

--- a/pkg/controller/prune.go
+++ b/pkg/controller/prune.go
@@ -87,8 +87,15 @@ func pruneNoSslCertificate(c *AppGwIngressController, appGw *n.ApplicationGatewa
 	}
 
 	for _, ingress := range ingressList {
-		annotatedSslCertificate, _ := annotations.GetAppGwSslCertificate(ingress)
-		if _, exists := set[annotatedSslCertificate]; annotatedSslCertificate != "" && !exists {
+		annotatedSslCertificate, err := annotations.GetAppGwSslCertificate(ingress)
+		// if annotation is not specified, add the ingress and go check next
+		if err != nil && annotations.IsMissingAnnotations(err) {
+			prunedIngresses = append(prunedIngresses, ingress)
+			continue
+		}
+
+		// given empty string is a valid annotation value, we error out with a message if no match
+		if _, exists := set[annotatedSslCertificate]; !exists {
 			errorLine := fmt.Sprintf("ignoring Ingress %s/%s as it requires Application Gateway %s to have pre-installed ssl certificate '%s'", ingress.Namespace, ingress.Name, c.appGwIdentifier.AppGwName, annotatedSslCertificate)
 			glog.Error(errorLine)
 			c.recorder.Event(ingress, v1.EventTypeWarning, events.ReasonNoPreInstalledSslCertificate, errorLine)
@@ -103,7 +110,7 @@ func pruneNoSslCertificate(c *AppGwIngressController, appGw *n.ApplicationGatewa
 	return prunedIngresses
 }
 
-// pruneNoTrustedRootCertificate filters ingresses which use appgw-whitelist-root-certificate annotation when AppGw doesn't have annotated root certificate(s) installed
+// pruneNoTrustedRootCertificate filters ingresses which use appgw-trusted-root-certificate annotation when AppGw doesn't have annotated root certificate(s) installed
 func pruneNoTrustedRootCertificate(c *AppGwIngressController, appGw *n.ApplicationGateway, cbCtx *appgw.ConfigBuilderContext, ingressList []*v1beta1.Ingress) []*v1beta1.Ingress {
 	var prunedIngresses []*v1beta1.Ingress
 	set := make(map[string]bool)
@@ -112,9 +119,15 @@ func pruneNoTrustedRootCertificate(c *AppGwIngressController, appGw *n.Applicati
 	}
 
 	for _, ingress := range ingressList {
-		whitelistedRootCertificates, _ := annotations.GetAppGwWhitelistRootCertificate(ingress)
 		installed := true
-		for _, rootCert := range strings.Split(whitelistedRootCertificates, ",") {
+		trustedRootCertificates, err := annotations.GetAppGwTrustedRootCertificate(ingress)
+		// if annotation is not specified
+		if err != nil && annotations.IsMissingAnnotations(err) {
+			prunedIngresses = append(prunedIngresses, ingress)
+			continue
+		}
+
+		for _, rootCert := range strings.Split(trustedRootCertificates, ",") {
 			if _, exists := set[rootCert]; !exists {
 				installed = false
 				errorLine := fmt.Sprintf("ignoring Ingress %s/%s as it requires Application Gateway %s to have pre-installed root certificate '%s'", ingress.Namespace, ingress.Name, c.appGwIdentifier.AppGwName, rootCert)

--- a/pkg/controller/prune.go
+++ b/pkg/controller/prune.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
@@ -29,6 +30,7 @@ func (c *AppGwIngressController) PruneIngress(appGw *n.ApplicationGateway, cbCtx
 		pruneFuncList = append(pruneFuncList, pruneNoPrivateIP)
 		pruneFuncList = append(pruneFuncList, pruneRedirectWithNoTLS)
 		pruneFuncList = append(pruneFuncList, pruneNoSslCertificate)
+		pruneFuncList = append(pruneFuncList, pruneNoTrustedRootCertificate)
 	})
 	prunedIngresses := cbCtx.IngressList
 	for _, prune := range pruneFuncList {
@@ -94,6 +96,36 @@ func pruneNoSslCertificate(c *AppGwIngressController, appGw *n.ApplicationGatewa
 				c.recorder.Event(c.agicPod, v1.EventTypeWarning, events.ReasonNoPreInstalledSslCertificate, errorLine)
 			}
 		} else {
+			prunedIngresses = append(prunedIngresses, ingress)
+		}
+	}
+
+	return prunedIngresses
+}
+
+// pruneNoTrustedRootCertificate filters ingresses which use appgw-whitelist-root-certificate annotation when AppGw doesn't have annotated root certificate(s) installed
+func pruneNoTrustedRootCertificate(c *AppGwIngressController, appGw *n.ApplicationGateway, cbCtx *appgw.ConfigBuilderContext, ingressList []*v1beta1.Ingress) []*v1beta1.Ingress {
+	var prunedIngresses []*v1beta1.Ingress
+	set := make(map[string]bool)
+	for _, installedTrustedRootCertificate := range *appGw.TrustedRootCertificates {
+		set[*installedTrustedRootCertificate.Name] = true
+	}
+
+	for _, ingress := range ingressList {
+		whitelistedRootCertificates, _ := annotations.GetAppGwWhitelistRootCertificate(ingress)
+		installed := true
+		for _, rootCert := range strings.Split(whitelistedRootCertificates, ",") {
+			if _, exists := set[rootCert]; !exists {
+				installed = false
+				errorLine := fmt.Sprintf("ignoring Ingress %s/%s as it requires Application Gateway %s to have pre-installed root certificate '%s'", ingress.Namespace, ingress.Name, c.appGwIdentifier.AppGwName, rootCert)
+				glog.Error(errorLine)
+				c.recorder.Event(ingress, v1.EventTypeWarning, events.ReasonNoPreInstalledRootCertificate, errorLine)
+				if c.agicPod != nil {
+					c.recorder.Event(c.agicPod, v1.EventTypeWarning, events.ReasonNoPreInstalledRootCertificate, errorLine)
+				}
+			}
+		}
+		if installed {
 			prunedIngresses = append(prunedIngresses, ingress)
 		}
 	}

--- a/pkg/controller/prune_test.go
+++ b/pkg/controller/prune_test.go
@@ -6,6 +6,8 @@
 package controller
 
 import (
+	"fmt"
+
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
@@ -104,6 +106,44 @@ var _ = Describe("prune function tests", func() {
 			Expect(len(cbCtx.IngressList)).To(Equal(2))
 			prunedIngresses := pruneNoSslCertificate(controller, &appGw, cbCtx, cbCtx.IngressList)
 			Expect(len(prunedIngresses)).To(Equal(2))
+		})
+	})
+
+	Context("ensure pruneNoTrustedRootCertificate prunes ingress", func() {
+		ingressRootCertAnnotated := tests.NewIngressFixture()
+		ingressRootCertAnnotated.Annotations = map[string]string{
+			annotations.AppGwWhitelistRootCertificate: "appgw-installed-root-cert",
+		}
+		ingressNoRootCertAnnotated := tests.NewIngressFixture()
+		cbCtx := &appgw.ConfigBuilderContext{
+			IngressList: []*v1beta1.Ingress{
+				ingressRootCertAnnotated,
+				ingressNoRootCertAnnotated,
+			},
+			ServiceList: []*v1.Service{
+				tests.NewServiceFixture(),
+			},
+			DefaultAddressPoolID:  to.StringPtr("xx"),
+			DefaultHTTPSettingsID: to.StringPtr("yy"),
+		}
+		appGw := fixtures.GetAppGateway()
+
+		It("removes the ingress using appgw-whitelist-root-certificate and keeps others", func() {
+			Expect(len(cbCtx.IngressList)).To(Equal(2))
+			prunedIngresses := pruneNoTrustedRootCertificate(controller, &appGw, cbCtx, cbCtx.IngressList)
+			Expect(len(prunedIngresses)).To(Equal(0))
+		})
+
+		It("keeps the ingress using appgw-whitelist-root-certificate when annotated root cert is pre-installed", func() {
+			// annotate with a installed root certificate
+			installedRootCerts := fmt.Sprintf("%s,%s,%s", *fixtures.GetRootCertificate1().Name, *fixtures.GetRootCertificate2().Name, *fixtures.GetRootCertificate3().Name)
+			ingressRootCertAnnotated.Annotations = map[string]string{
+				annotations.AppGwWhitelistRootCertificate: installedRootCerts,
+			}
+
+			Expect(len(cbCtx.IngressList)).To(Equal(2))
+			prunedIngresses := pruneNoTrustedRootCertificate(controller, &appGw, cbCtx, cbCtx.IngressList)
+			Expect(len(prunedIngresses)).To(Equal(1))
 		})
 	})
 

--- a/pkg/controller/prune_test.go
+++ b/pkg/controller/prune_test.go
@@ -112,7 +112,7 @@ var _ = Describe("prune function tests", func() {
 	Context("ensure pruneNoTrustedRootCertificate prunes ingress", func() {
 		ingressRootCertAnnotated := tests.NewIngressFixture()
 		ingressRootCertAnnotated.Annotations = map[string]string{
-			annotations.AppGwWhitelistRootCertificate: "appgw-installed-root-cert",
+			annotations.AppGwTrustedRootCertificate: "appgw-installed-root-cert",
 		}
 		ingressNoRootCertAnnotated := tests.NewIngressFixture()
 		cbCtx := &appgw.ConfigBuilderContext{
@@ -128,22 +128,22 @@ var _ = Describe("prune function tests", func() {
 		}
 		appGw := fixtures.GetAppGateway()
 
-		It("removes the ingress using appgw-whitelist-root-certificate and keeps others", func() {
+		It("removes the ingress using appgw-trusted-root-certificate and keeps others", func() {
 			Expect(len(cbCtx.IngressList)).To(Equal(2))
 			prunedIngresses := pruneNoTrustedRootCertificate(controller, &appGw, cbCtx, cbCtx.IngressList)
-			Expect(len(prunedIngresses)).To(Equal(0))
+			Expect(len(prunedIngresses)).To(Equal(1))
 		})
 
-		It("keeps the ingress using appgw-whitelist-root-certificate when annotated root cert is pre-installed", func() {
+		It("keeps the ingress using appgw-trusted-root-certificate when annotated root cert is pre-installed", func() {
 			// annotate with a installed root certificate
 			installedRootCerts := fmt.Sprintf("%s,%s,%s", *fixtures.GetRootCertificate1().Name, *fixtures.GetRootCertificate2().Name, *fixtures.GetRootCertificate3().Name)
 			ingressRootCertAnnotated.Annotations = map[string]string{
-				annotations.AppGwWhitelistRootCertificate: installedRootCerts,
+				annotations.AppGwTrustedRootCertificate: installedRootCerts,
 			}
 
 			Expect(len(cbCtx.IngressList)).To(Equal(2))
 			prunedIngresses := pruneNoTrustedRootCertificate(controller, &appGw, cbCtx, cbCtx.IngressList)
-			Expect(len(prunedIngresses)).To(Equal(1))
+			Expect(len(prunedIngresses)).To(Equal(2))
 		})
 	})
 

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -30,6 +30,9 @@ const (
 	// ReasonNoPreInstalledSslCertificate is a reason for an event to be emitted.
 	ReasonNoPreInstalledSslCertificate = "NoPreInstalledSslCertificate"
 
+	// ReasonNoPreInstalledRootCertificate is a reason for an event to be emitted.
+	ReasonNoPreInstalledRootCertificate = "NoPreInstalledRootCertificate"
+
 	// ReasonRedirectWithNoTLS is a reason for an event to be emitted.
 	ReasonRedirectWithNoTLS = "RedirectWithNoTLS"
 

--- a/pkg/tests/fixtures/app_gateway.go
+++ b/pkg/tests/fixtures/app_gateway.go
@@ -45,6 +45,12 @@ func GetAppGateway() n.ApplicationGateway {
 				GetCertificate3(),
 			},
 
+			TrustedRootCertificates: &[]n.ApplicationGatewayTrustedRootCertificate{
+				GetRootCertificate1(),
+				GetRootCertificate2(),
+				GetRootCertificate3(),
+			},
+
 			Probes: &[]n.ApplicationGatewayProbe{
 				GetApplicationGatewayProbe(nil, to.StringPtr(PathFoo)), // /foo
 				GetApplicationGatewayProbe(nil, to.StringPtr(PathBar)), // /bar

--- a/pkg/tests/fixtures/certificates.go
+++ b/pkg/tests/fixtures/certificates.go
@@ -19,6 +19,15 @@ const (
 
 	// CertificateName3 is a string constant.
 	CertificateName3 = "Certificate-3"
+
+	// RootCertificateName1 is a string constant.
+	RootCertificateName1 = "RootCertificate-1"
+
+	// RootCertificateName2 is a string constant.
+	RootCertificateName2 = "RootCertificate-2"
+
+	// RootCertificateName3 is a string constant.
+	RootCertificateName3 = "RootCertificate-3"
 )
 
 // GetCertificate1 generates a certificate.
@@ -39,5 +48,26 @@ func GetCertificate2() n.ApplicationGatewaySslCertificate {
 func GetCertificate3() n.ApplicationGatewaySslCertificate {
 	return n.ApplicationGatewaySslCertificate{
 		Name: to.StringPtr(CertificateName3),
+	}
+}
+
+// GetRootCertificate1 generates a root certificate.
+func GetRootCertificate1() n.ApplicationGatewayTrustedRootCertificate {
+	return n.ApplicationGatewayTrustedRootCertificate{
+		Name: to.StringPtr(RootCertificateName1),
+	}
+}
+
+// GetRootCertificate2 generates a root certificate.
+func GetRootCertificate2() n.ApplicationGatewayTrustedRootCertificate {
+	return n.ApplicationGatewayTrustedRootCertificate{
+		Name: to.StringPtr(RootCertificateName2),
+	}
+}
+
+// GetRootCertificate3 generates a root certificate.
+func GetRootCertificate3() n.ApplicationGatewayTrustedRootCertificate {
+	return n.ApplicationGatewayTrustedRootCertificate{
+		Name: to.StringPtr(RootCertificateName3),
 	}
 }


### PR DESCRIPTION
Add a new annotation, appgw-trusted-root-certificate. The new annotation allows to whitelist appgw pre-installed root certificate(s) used by end-to-end ssl encryption. The new annotation should be used together with backend protocal annotation, https specifically