### PR TITLE
doc: Describe how to enable AGIC w/ WAF

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -288,6 +288,9 @@ spec:
 
 
 ## Attach firewall policy to a host and path
+
+> Prerequisite: AGIC must be installed with `appgw.waf_listener=true` in the `helm-config.yaml`. Read more in the [Install Ingress Controller Heml Chart](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/setup/install-new.md#install-ingress-controller-helm-chart) document.
+
 This annotation allows you to attach an already created WAF policy to the list paths for a host within a Kubernetes
 Ingress resource being annotated.
 
@@ -309,7 +312,7 @@ appgw.ingress.kubernetes.io/waf-policy-for-path: "/subscriptions/abcd/resourceGr
 ```
 
 ### Example
-The example below will apply the WAF policy 
+The example below will apply the WAF policy
 ```yaml
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -327,7 +330,7 @@ spec:
         backend:
           serviceName: ad-server
           servicePort: 80
-          
+
       - path: /auth
         backend:
           serviceName: auth-server

--- a/docs/examples/sample-helm-config.yaml
+++ b/docs/examples/sample-helm-config.yaml
@@ -17,6 +17,10 @@ appgw:
     # Use "kubectl get AzureIngressProhibitedTargets" to view and change this.
     shared: false
 
+    # Setting waf_listener to "true" enables Web Application Functionality
+    # This is a prerequisite for https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/annotations.md#azure-waf-policy-for-path
+    waf_listener: false
+
 ################################################################################
 # Specify which kubernetes namespace the ingress controller will watch
 # Default value is "default"

--- a/docs/setup/install-new-windows-cluster.md
+++ b/docs/setup/install-new-windows-cluster.md
@@ -263,6 +263,7 @@ Values:
 - `appgw.name`: Name of the Application Gateway. Example: `applicationgatewayd0f0`
 - `appgw.usePrivateIP`: The boolean flag if all Ingresses are exposed over Private IP. Set to `false` should you use an [Application Gateway v2 SKU](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/features/private-ip.md#assign-globally)
 - `appgw.shared`: This boolean flag should be defaulted to `false`. Set to `true` should you need a [Shared App Gateway](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/072626cb4e37f7b7a1b0c4578c38d1eadc3e8701/docs/setup/install-existing.md#multi-cluster--shared-app-gateway).
+- `appgw.waf_listener`: Setting this boolean flag to `true` enables Web Application Firewall functionality as described in [the following document](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/annotations.md#azure-waf-policy-for-path)
 - `kubernetes.watchNamespace`: Specify the name space, which AGIC should watch. This could be a single string value, or a comma-separated list of namespaces.
 - `armAuth.type`: could be `aadPodIdentity` or `servicePrincipal`
 - `armAuth.identityResourceID`: Resource ID of the Azure Managed Identity
@@ -276,7 +277,7 @@ Values:
    ```bash
    az identity show -g <resource-group> -n <identity-name>
    ```
-- `<resource-group>` in the command above is the resource group of your App Gateway. 
+- `<resource-group>` in the command above is the resource group of your App Gateway.
 - `<identity-name>` is the name of the created identity. All identities for a given subscription can be listed using: `az identity list`
 
 

--- a/docs/setup/install-new.md
+++ b/docs/setup/install-new.md
@@ -195,10 +195,9 @@ Kubernetes. This document will use version 3 of helm, which is not backwards com
     sed -i "s|<applicationGatewayName>|${applicationGatewayName}|g" helm-config.yaml
     sed -i "s|<identityResourceId>|${identityResourceId}|g" helm-config.yaml
     sed -i "s|<identityClientId>|${identityClientId}|g" helm-config.yaml
-
-    # You can further modify the helm config to enable/disable features
-    nano helm-config.yaml
     ```
+
+  You can further modify the helm config to enable/disable features with: `nano helm-config.yaml`
 
 Values:
 - `verbosityLevel`: Sets the verbosity level of the AGIC logging infrastructure. See [Logging Levels](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/463a87213bbc3106af6fce0f4023477216d2ad78/docs/troubleshooting.md#logging-levels) for possible values.
@@ -207,6 +206,7 @@ Values:
 - `appgw.name`: Name of the Application Gateway. Example: `applicationgatewayd0f0`
 - `appgw.usePrivateIP`: The boolean flag if all Ingresses are exposed over Private IP. Set to `false` should you use an [Application Gateway v2 SKU](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/features/private-ip.md#assign-globally)
 - `appgw.shared`: This boolean flag should be defaulted to `false`. Set to `true` should you need a [Shared App Gateway](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/072626cb4e37f7b7a1b0c4578c38d1eadc3e8701/docs/setup/install-existing.md#multi-cluster--shared-app-gateway).
+- `appgw.waf_listener`: Setting this boolean flag to `true` enables Web Application Firewall functionality as described in [the following document](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/annotations.md#azure-waf-policy-for-path)
 - `kubernetes.watchNamespace`: Specify the name space, which AGIC should watch. This could be a single string value, or a comma-separated list of namespaces.
 - `armAuth.type`: could be `aadPodIdentity` or `servicePrincipal`
 - `armAuth.identityResourceID`: Resource ID of the Azure Managed Identity
@@ -220,7 +220,7 @@ Values:
    ```bash
    az identity show -g <resource-group> -n <identity-name>
    ```
-- `<resource-group>` in the command above is the resource group of your App Gateway. 
+- `<resource-group>` in the command above is the resource group of your App Gateway.
 - `<identity-name>` is the name of the created identity. All identities for a given subscription can be listed using: `az identity list`
 
 


### PR DESCRIPTION
Our documentation seems to be missing the fact that `appgw.waf_listener` must be set to `true` in the `helm-config.yaml` for the `appgw.ingress.kubernetes.io/waf-policy-for-path` annotation to work.

This fixes #766

@akshaysngupta @mscatyao I wonder if we should enable this by default?