### PR TITLE
fix: assign resource ID to path rule; refactor other assignments; ignore resource guid and location

### DIFF
--- a/functional_tests/health_probes_same_labels_different_namespaces.json
+++ b/functional_tests/health_probes_same_labels_different_namespaces.json
@@ -290,6 +290,7 @@
                     },
                     "pathRules": [
                         {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---other-namespace-----name---0",
                             "name": "pr---other-namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/health_probes_same_labels_different_namespaces.json
+++ b/functional_tests/health_probes_same_labels_different_namespaces.json
@@ -290,7 +290,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---other-namespace-----name---0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-d8f5c23dcab3db80f8466dbc57706908/pathRules/pr---other-namespace-----name---0",
                             "name": "pr---other-namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/one_ingress_slash_slashnothing.json
+++ b/functional_tests/one_ingress_slash_slashnothing.json
@@ -228,6 +228,7 @@
                     },
                     "pathRules": [
                         {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/one_ingress_slash_slashnothing.json
+++ b/functional_tests/one_ingress_slash_slashnothing.json
@@ -228,7 +228,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-6d1d6d2bd4405b8228172c2ef8a065fb/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/three_ingresses.json
+++ b/functional_tests/three_ingresses.json
@@ -367,7 +367,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-6d1d6d2bd4405b8228172c2ef8a065fb/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {
@@ -382,7 +382,7 @@
                             }
                         },
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-6d1d6d2bd4405b8228172c2ef8a065fb/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/three_ingresses.json
+++ b/functional_tests/three_ingresses.json
@@ -367,6 +367,7 @@
                     },
                     "pathRules": [
                         {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {
@@ -381,6 +382,7 @@
                             }
                         },
                         {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/two_ingresses_same_domain_tls_notls.json
+++ b/functional_tests/two_ingresses_same_domain_tls_notls.json
@@ -290,6 +290,7 @@
                     },
                     "pathRules": [
                         {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/two_ingresses_same_domain_tls_notls.json
+++ b/functional_tests/two_ingresses_same_domain_tls_notls.json
@@ -290,7 +290,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-d8f5c23dcab3db80f8466dbc57706908/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/two_ingresses_same_hostname_value_different_locations.json
+++ b/functional_tests/two_ingresses_same_hostname_value_different_locations.json
@@ -183,7 +183,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-d8f5c23dcab3db80f8466dbc57706908/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {
@@ -198,7 +198,7 @@
                             }
                         },
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-d8f5c23dcab3db80f8466dbc57706908/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/two_ingresses_same_hostname_value_different_locations.json
+++ b/functional_tests/two_ingresses_same_hostname_value_different_locations.json
@@ -183,6 +183,7 @@
                     },
                     "pathRules": [
                         {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {
@@ -197,6 +198,7 @@
                             }
                         },
                         {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/two_ingresses_slash_slashsomething.json
+++ b/functional_tests/two_ingresses_slash_slashsomething.json
@@ -228,6 +228,7 @@
                     },
                     "pathRules": [
                         {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/two_ingresses_slash_slashsomething.json
+++ b/functional_tests/two_ingresses_slash_slashsomething.json
@@ -228,7 +228,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-6d1d6d2bd4405b8228172c2ef8a065fb/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/two_ingresses_with_and_without_extended_hostname.json
+++ b/functional_tests/two_ingresses_with_and_without_extended_hostname.json
@@ -259,6 +259,7 @@
                     },
                     "pathRules": [
                         {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {
@@ -287,6 +288,7 @@
                     },
                     "pathRules": [
                         {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/two_ingresses_with_and_without_extended_hostname.json
+++ b/functional_tests/two_ingresses_with_and_without_extended_hostname.json
@@ -259,7 +259,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-6d1d6d2bd4405b8228172c2ef8a065fb/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {
@@ -288,7 +288,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-a47dbcb5b127e93cf290db4066b660b5/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/waf_annotation.json
+++ b/functional_tests/waf_annotation.json
@@ -178,6 +178,7 @@
                     "defaultBackendHttpSettings": {},
                     "pathRules": [
                         {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/waf_annotation.json
+++ b/functional_tests/waf_annotation.json
@@ -178,7 +178,7 @@
                     "defaultBackendHttpSettings": {},
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/pathRules/pr---namespace-----name---0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-6d1d6d2bd4405b8228172c2ef8a065fb/pathRules/pr---namespace-----name---0",
                             "name": "pr---namespace-----name---0",
                             "properties": {
                                 "backendAddressPool": {

--- a/pkg/appgw/backendaddresspools_test.go
+++ b/pkg/appgw/backendaddresspools_test.go
@@ -217,7 +217,6 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 
 			expectedListerID80, _ := newTestListenerID(Port(80), nil, false)
 			expected := map[listenerIdentifier]*n.ApplicationGatewayURLPathMap{
-
 				expectedListerID80: {
 					ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 						DefaultBackendAddressPool: &n.SubResource{
@@ -238,7 +237,9 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 					Name: to.StringPtr("url-" + utils.GetHashCode(expectedListerID80)),
 					Etag: to.StringPtr("*"),
 					Type: nil,
-					ID:   nil,
+					ID: to.StringPtr("/subscriptions/--subscription--/resourceGroups/--resource-group--" +
+						"/providers/Microsoft.Network/applicationGateways/--app-gw-name--" + 
+						"/urlPathMaps/url-6d1d6d2bd4405b8228172c2ef8a065fb"),
 				},
 			}
 

--- a/pkg/appgw/certificates.go
+++ b/pkg/appgw/certificates.go
@@ -132,10 +132,11 @@ func (c *appGwConfigBuilder) newHostToSecretMap(ingress *v1beta1.Ingress) map[st
 }
 
 func (c *appGwConfigBuilder) newCert(secretID secretIdentifier, cert *string) n.ApplicationGatewaySslCertificate {
+	sslCertName := secretID.secretFullName()
 	return n.ApplicationGatewaySslCertificate{
 		Etag: to.StringPtr("*"),
-		Name: to.StringPtr(secretID.secretFullName()),
-		ID:   to.StringPtr(c.appGwIdentifier.sslCertificateID(secretID.secretFullName())),
+		Name: to.StringPtr(sslCertName),
+		ID:   to.StringPtr(c.appGwIdentifier.sslCertificateID(sslCertName)),
 		ApplicationGatewaySslCertificatePropertiesFormat: &n.ApplicationGatewaySslCertificatePropertiesFormat{
 			Data:     cert,
 			Password: to.StringPtr("msazure"),

--- a/pkg/appgw/identifier.go
+++ b/pkg/appgw/identifier.go
@@ -59,8 +59,9 @@ func (agw Identifier) urlPathMapID(urlPathMapName string) string {
 	return agw.gatewayResourceID("urlPathMaps", urlPathMapName)
 }
 
-func (agw Identifier) pathRuleID(probeName string) string {
-	return agw.gatewayResourceID("pathRules", probeName)
+func (agw Identifier) pathRuleID(pathMapName string, pathRuleName string) string {
+	pathRuleSuffix := fmt.Sprintf("%s/pathRules/%s", pathMapName, pathRuleName)
+	return agw.urlPathMapID(pathRuleSuffix)
 }
 
 func (agw Identifier) listenerID(listenerName string) string {

--- a/pkg/appgw/identifier.go
+++ b/pkg/appgw/identifier.go
@@ -59,6 +59,10 @@ func (agw Identifier) urlPathMapID(urlPathMapName string) string {
 	return agw.gatewayResourceID("urlPathMaps", urlPathMapName)
 }
 
+func (agw Identifier) pathRuleID(probeName string) string {
+	return agw.gatewayResourceID("pathRules", probeName)
+}
+
 func (agw Identifier) listenerID(listenerName string) string {
 	return agw.gatewayResourceID("httpListeners", listenerName)
 }

--- a/pkg/appgw/istio_routing_rules.go
+++ b/pkg/appgw/istio_routing_rules.go
@@ -59,10 +59,11 @@ func (c *appGwConfigBuilder) getIstioPathMaps(cbCtx *ConfigBuilderContext) map[l
 				if !found {
 					continue
 				}
+				pathMapName := generateURLPathMapName(listenerID)
 				pathMap := n.ApplicationGatewayURLPathMap{
 					Etag: to.StringPtr("*"),
-					Name: to.StringPtr(generateURLPathMapName(listenerID)),
-					ID:   to.StringPtr(c.appGwIdentifier.urlPathMapID(generateURLPathMapName(listenerID))),
+					Name: to.StringPtr(pathMapName),
+					ID:   to.StringPtr(c.appGwIdentifier.urlPathMapID(pathMapName)),
 					ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 						DefaultBackendAddressPool:  &n.SubResource{ID: defaultAddressPoolID},
 						DefaultBackendHTTPSettings: &n.SubResource{ID: defaultHTTPSettingsID},
@@ -72,9 +73,11 @@ func (c *appGwConfigBuilder) getIstioPathMaps(cbCtx *ConfigBuilderContext) map[l
 
 				pathRuleIdx := fmt.Sprintf("%d-%d", virtSvcIdx, matchIdx)
 
+				pathRuleName := generatePathRuleName(virtSvc.Namespace, virtSvc.Name, pathRuleIdx)
 				pathRule := n.ApplicationGatewayPathRule{
 					Etag: to.StringPtr("*"),
-					Name: to.StringPtr(generatePathRuleName(virtSvc.Namespace, virtSvc.Name, pathRuleIdx)),
+					Name: to.StringPtr(pathRuleName),
+					ID:   to.StringPtr(c.appGwIdentifier.pathRuleID(pathRuleName)),
 					ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 						Paths: &[]string{
 							match.URI.Prefix,
@@ -98,9 +101,11 @@ func (c *appGwConfigBuilder) getIstioPathMaps(cbCtx *ConfigBuilderContext) map[l
 		defaultAddressPoolID := c.appGwIdentifier.AddressPoolID(DefaultBackendAddressPoolName)
 		defaultHTTPSettingsID := c.appGwIdentifier.HTTPSettingsID(DefaultBackendHTTPSettingsName)
 		listenerID := defaultFrontendListenerIdentifier()
+		pathMapName := generateURLPathMapName(listenerID)
 		urlPathMaps[listenerID] = &n.ApplicationGatewayURLPathMap{
 			Etag: to.StringPtr("*"),
-			Name: to.StringPtr(generateURLPathMapName(listenerID)),
+			Name: to.StringPtr(pathMapName),
+			ID:   to.StringPtr(c.appGwIdentifier.urlPathMapID(pathMapName)),
 			ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 				DefaultBackendAddressPool:  &n.SubResource{ID: &defaultAddressPoolID},
 				DefaultBackendHTTPSettings: &n.SubResource{ID: &defaultHTTPSettingsID},

--- a/pkg/appgw/istio_routing_rules.go
+++ b/pkg/appgw/istio_routing_rules.go
@@ -77,7 +77,7 @@ func (c *appGwConfigBuilder) getIstioPathMaps(cbCtx *ConfigBuilderContext) map[l
 				pathRule := n.ApplicationGatewayPathRule{
 					Etag: to.StringPtr("*"),
 					Name: to.StringPtr(pathRuleName),
-					ID:   to.StringPtr(c.appGwIdentifier.pathRuleID(pathRuleName)),
+					ID:   to.StringPtr(c.appGwIdentifier.pathRuleID(pathMapName, pathRuleName)),
 					ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 						Paths: &[]string{
 							match.URI.Prefix,

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -78,7 +78,7 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 		rule := n.ApplicationGatewayRequestRoutingRule{
 			Etag: to.StringPtr("*"),
 			Name: to.StringPtr(routingRuleName),
-			ID:   to.StringPtr(c.appGwIdentifier.requestRoutingRuleID(generateRequestRoutingRuleName(listenerID))),
+			ID:   to.StringPtr(c.appGwIdentifier.requestRoutingRuleID(routingRuleName)),
 			ApplicationGatewayRequestRoutingRulePropertiesFormat: &n.ApplicationGatewayRequestRoutingRulePropertiesFormat{
 				HTTPListener: &n.SubResource{ID: to.StringPtr(c.appGwIdentifier.listenerID(*httpListener.Name))},
 			},
@@ -135,9 +135,11 @@ func (c *appGwConfigBuilder) noRulesIngress(cbCtx *ConfigBuilderContext, ingress
 		defaultAddressPoolID := c.appGwIdentifier.AddressPoolID(poolName)
 		defaultHTTPSettingsID := c.appGwIdentifier.HTTPSettingsID(DefaultBackendHTTPSettingsName)
 		listenerID := defaultFrontendListenerIdentifier()
+		pathMapName := generateURLPathMapName(listenerID)
 		(*urlPathMaps)[listenerID] = &n.ApplicationGatewayURLPathMap{
 			Etag: to.StringPtr("*"),
-			Name: to.StringPtr(generateURLPathMapName(listenerID)),
+			Name: to.StringPtr(pathMapName),
+			ID:   to.StringPtr(c.appGwIdentifier.urlPathMapID(pathMapName)),
 			ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 				DefaultBackendAddressPool:  &n.SubResource{ID: &defaultAddressPoolID},
 				DefaultBackendHTTPSettings: &n.SubResource{ID: &defaultHTTPSettingsID},
@@ -166,10 +168,11 @@ func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listen
 			_, azListenerConfig := c.processIngressRule(rule, ingress, cbCtx.EnvVariables)
 			for listenerID, listenerAzConfig := range azListenerConfig {
 				if _, exists := urlPathMaps[listenerID]; !exists {
+					pathMapName := generateURLPathMapName(listenerID)
 					urlPathMaps[listenerID] = &n.ApplicationGatewayURLPathMap{
 						Etag: to.StringPtr("*"),
-						Name: to.StringPtr(generateURLPathMapName(listenerID)),
-						ID:   to.StringPtr(c.appGwIdentifier.urlPathMapID(generateURLPathMapName(listenerID))),
+						Name: to.StringPtr(pathMapName),
+						ID:   to.StringPtr(c.appGwIdentifier.urlPathMapID(pathMapName)),
 						ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 							DefaultBackendAddressPool:  &n.SubResource{ID: cbCtx.DefaultAddressPoolID},
 							DefaultBackendHTTPSettings: &n.SubResource{ID: cbCtx.DefaultHTTPSettingsID},
@@ -189,9 +192,11 @@ func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listen
 		defaultAddressPoolID := c.appGwIdentifier.AddressPoolID(DefaultBackendAddressPoolName)
 		defaultHTTPSettingsID := c.appGwIdentifier.HTTPSettingsID(DefaultBackendHTTPSettingsName)
 		listenerID := defaultFrontendListenerIdentifier()
+		pathMapName := generateURLPathMapName(listenerID)
 		urlPathMaps[listenerID] = &n.ApplicationGatewayURLPathMap{
 			Etag: to.StringPtr("*"),
-			Name: to.StringPtr(generateURLPathMapName(listenerID)),
+			Name: to.StringPtr(pathMapName),
+			ID:   to.StringPtr(c.appGwIdentifier.urlPathMapID(pathMapName)),
 			ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 				DefaultBackendAddressPool:  &n.SubResource{ID: &defaultAddressPoolID},
 				DefaultBackendHTTPSettings: &n.SubResource{ID: &defaultHTTPSettingsID},
@@ -213,10 +218,11 @@ func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listen
 
 func (c *appGwConfigBuilder) getPathMap(cbCtx *ConfigBuilderContext, listenerID listenerIdentifier, listenerAzConfig listenerAzConfig, ingress *v1beta1.Ingress, rule *v1beta1.IngressRule) *n.ApplicationGatewayURLPathMap {
 	// initialize a path map for this listener if doesn't exists
+	pathMapName := generateURLPathMapName(listenerID)
 	pathMap := n.ApplicationGatewayURLPathMap{
 		Etag: to.StringPtr("*"),
-		Name: to.StringPtr(generateURLPathMapName(listenerID)),
-		ID:   to.StringPtr(c.appGwIdentifier.urlPathMapID(generateURLPathMapName(listenerID))),
+		Name: to.StringPtr(pathMapName),
+		ID:   to.StringPtr(c.appGwIdentifier.urlPathMapID(pathMapName)),
 		ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{},
 	}
 
@@ -291,9 +297,11 @@ func (c *appGwConfigBuilder) getPathRules(cbCtx *ConfigBuilderContext, listenerI
 			continue
 		}
 
+		pathRuleName := generatePathRuleName(ingress.Namespace, ingress.Name, strconv.Itoa(pathIdx))
 		pathRule := n.ApplicationGatewayPathRule{
 			Etag: to.StringPtr("*"),
-			Name: to.StringPtr(generatePathRuleName(ingress.Namespace, ingress.Name, strconv.Itoa(pathIdx))),
+			Name: to.StringPtr(pathRuleName),
+			ID:   to.StringPtr(c.appGwIdentifier.pathRuleID(pathRuleName)),
 			ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 				Paths: &[]string{path.Path},
 			},

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -297,11 +297,12 @@ func (c *appGwConfigBuilder) getPathRules(cbCtx *ConfigBuilderContext, listenerI
 			continue
 		}
 
+		pathMapName := generateURLPathMapName(listenerID)
 		pathRuleName := generatePathRuleName(ingress.Namespace, ingress.Name, strconv.Itoa(pathIdx))
 		pathRule := n.ApplicationGatewayPathRule{
 			Etag: to.StringPtr("*"),
 			Name: to.StringPtr(pathRuleName),
-			ID:   to.StringPtr(c.appGwIdentifier.pathRuleID(pathRuleName)),
+			ID:   to.StringPtr(c.appGwIdentifier.pathRuleID(pathMapName, pathRuleName)),
 			ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 				Paths: &[]string{path.Path},
 			},

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Test routing rules generations", func() {
 						expectedPathRule := n.ApplicationGatewayPathRule{
 							Name: to.StringPtr(pathRuleName),
 							Etag: to.StringPtr("*"),
-							ID:   to.StringPtr(configBuilder.appGwIdentifier.pathRuleID(pathRuleName)),
+							ID:   to.StringPtr(configBuilder.appGwIdentifier.pathRuleID(*generatedPathMap.Name, pathRuleName)),
 							ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 								Paths: &[]string{
 									path.Path,
@@ -167,7 +167,7 @@ var _ = Describe("Test routing rules generations", func() {
 					pathRuleName := generatePathRuleName(backendID.Ingress.Namespace, backendID.Ingress.Name, "0")
 					expectedPathRule := n.ApplicationGatewayPathRule{
 						Name: to.StringPtr(pathRuleName),
-						ID:   to.StringPtr(configBuilder.appGwIdentifier.pathRuleID(pathRuleName)),
+						ID:   to.StringPtr(configBuilder.appGwIdentifier.pathRuleID(*generatedPathMap.Name, pathRuleName)),
 						Etag: to.StringPtr("*"),
 						ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 							Paths: &[]string{

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -82,9 +82,11 @@ var _ = Describe("Test routing rules generations", func() {
 						backendID := generateBackendID(ingress, &rule, &path, &path.Backend)
 						backendPoolID := configBuilder.appGwIdentifier.AddressPoolID(generateAddressPoolName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), Port(tests.ContainerPort)))
 						httpSettingID := configBuilder.appGwIdentifier.HTTPSettingsID(generateHTTPSettingsName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), Port(tests.ContainerPort), backendID.Ingress.Name))
+						pathRuleName := generatePathRuleName(backendID.Ingress.Namespace, backendID.Ingress.Name, "0")
 						expectedPathRule := n.ApplicationGatewayPathRule{
-							Name: to.StringPtr(generatePathRuleName(backendID.Ingress.Namespace, backendID.Ingress.Name, "0")),
+							Name: to.StringPtr(pathRuleName),
 							Etag: to.StringPtr("*"),
+							ID:   to.StringPtr(configBuilder.appGwIdentifier.pathRuleID(pathRuleName)),
 							ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 								Paths: &[]string{
 									path.Path,
@@ -162,8 +164,10 @@ var _ = Describe("Test routing rules generations", func() {
 					backendID := generateBackendID(ingressPathBased, &rule, &path, &path.Backend)
 					backendPoolID := configBuilder.appGwIdentifier.AddressPoolID(generateAddressPoolName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), Port(tests.ContainerPort)))
 					httpSettingID := configBuilder.appGwIdentifier.HTTPSettingsID(generateHTTPSettingsName(backendID.serviceFullName(), backendID.Backend.ServicePort.String(), Port(tests.ContainerPort), backendID.Ingress.Name))
+					pathRuleName := generatePathRuleName(backendID.Ingress.Namespace, backendID.Ingress.Name, "0")
 					expectedPathRule := n.ApplicationGatewayPathRule{
-						Name: to.StringPtr(generatePathRuleName(backendID.Ingress.Namespace, backendID.Ingress.Name, "0")),
+						Name: to.StringPtr(pathRuleName),
+						ID:   to.StringPtr(configBuilder.appGwIdentifier.pathRuleID(pathRuleName)),
 						Etag: to.StringPtr("*"),
 						ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 							Paths: &[]string{


### PR DESCRIPTION
This PR sets the resource ID for path rules in url path map. Also, performed refactoring and ignoring location and resource guid when comparing input gateway with cached gateway.