### PR TITLE
version: update k8s version

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -281,7 +281,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.15.5",
+            "defaultValue": "1.15.10",
             "type": "string",
             "metadata": {
                 "description": "The version of Kubernetes."


### PR DESCRIPTION
Currently, when trying to run the ARM template it throws an error due to incorrect kubernetes version.
The correct version is 1.15.10