### PR TITLE
probe: set hostname based on backend hostname if provided; respect readiness/livesness scheme fix

### DIFF
--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -96,6 +96,10 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 		probe.Host = hostName
 	}
 
+	if hostName, err := annotations.BackendHostName(backendID.Ingress); err == nil {
+		probe.Host = to.StringPtr(hostName)
+	}
+
 	pathPrefix, err := annotations.BackendPathPrefix(backendID.Ingress)
 	if err == nil {
 		probe.Path = to.StringPtr(pathPrefix)

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -126,6 +126,9 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 		if k8sProbeForServiceContainer.Handler.HTTPGet.Scheme == v1.URISchemeHTTPS {
 			probe.Protocol = n.HTTPS
 		}
+		if k8sProbeForServiceContainer.Handler.HTTPGet.Scheme == v1.URISchemeHTTP {
+			probe.Protocol = n.HTTP
+		}
 		if k8sProbeForServiceContainer.PeriodSeconds != 0 {
 			probe.Interval = to.Int32Ptr(k8sProbeForServiceContainer.PeriodSeconds)
 		}


### PR DESCRIPTION
a) This PR uses the backend hostname annotation to set the host in probe.
So, in order of priority, here is how properties for probe are selected:
1) Readiness Probe
2) Liveness Probe
3) backend-prefixed Annotations
4) ingress.rules for host and path

b) This PR also fixes a small issue in translating liveness and readiness probes.
Fixes: #789