### PR TITLE
doc: Correct the field used for identityPrincipal

### DIFF
--- a/docs/features/appgw-ssl-certificate.md
+++ b/docs/features/appgw-ssl-certificate.md
@@ -53,7 +53,7 @@ az keyvault create -n $vaultName -g $resgp --enable-soft-delete -l $location
 # One time operation, create user-assigned managed identity
 az identity create -n appgw-id -g $resgp -l $location
 identityID=$(az identity show -n appgw-id -g $resgp -o tsv --query "id")
-identityPrincipal=$(az identity show -n appgw-id -g $resgp -o tsv --query "objectId")
+identityPrincipal=$(az identity show -n appgw-id -g $resgp -o tsv --query "principalId")
 
 # One time operation, assign AGIC identity to have operator access over AppGw identity
 az role assignment create --role "Managed Identity Operator" --assignee $agicIdentityPrincipalId --scope $identityID


### PR DESCRIPTION
Since it's a managed identity, the field `principalId` should be used.