### PR TITLE
pipeline: add unittest tag to test and modify pipeline to use tag

### DIFF
--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -67,7 +67,7 @@ steps:
     go get github.com/axw/gocov/gocov
     go get github.com/AlekSi/gocov-xml
     go get github.com/matm/gocov-html
-    go test -timeout 80s -v -coverprofile=coverage.txt -covermode count ./... > testoutput.txt || { echo "go test returned non-zero"; cat testoutput.txt; exit 1; }
+    go test -timeout 80s -v -coverprofile=coverage.txt -covermode count -tags unittest ./... > testoutput.txt || { echo "go test returned non-zero"; cat testoutput.txt; exit 1; }
     cat testoutput.txt | go-junit-report > report.xml
     gocov convert coverage.txt > coverage.json
     gocov-xml < coverage.json > coverage.xml

--- a/cmd/appgw-ingress/main_test.go
+++ b/cmd/appgw-ingress/main_test.go
@@ -3,6 +3,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
+// +build unittest
+
 package main
 
 import (
@@ -13,7 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func TestIt(t *testing.T) {
+func TestMain(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Run All main.go Tests")
 }

--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -3,6 +3,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
+// +build unittest
+
 package functests
 
 import (

--- a/pkg/annotations/errors.go
+++ b/pkg/annotations/errors.go
@@ -1,15 +1,7 @@
-/*
-Copyright 2017 The Kubernetes Authors.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
 
 package annotations
 

--- a/pkg/annotations/errors_test.go
+++ b/pkg/annotations/errors_test.go
@@ -1,15 +1,9 @@
-/*
-Copyright 2017 The Kubernetes Authors.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+// +build unittest
 
 package annotations
 

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -3,6 +3,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
+// +build unittest
+
 package annotations
 
 import (

--- a/pkg/appgw/appgw_suite_test.go
+++ b/pkg/appgw/appgw_suite_test.go
@@ -3,6 +3,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
+// +build unittest
+
 package appgw
 
 import (

--- a/pkg/appgw/identifier_test.go
+++ b/pkg/appgw/identifier_test.go
@@ -1,3 +1,10 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+// +build unittest
+
 package appgw
 
 import (

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -3,6 +3,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
+// +build unittest
+
 package azure
 
 import (

--- a/pkg/brownfield/brownfield_suite_test.go
+++ b/pkg/brownfield/brownfield_suite_test.go
@@ -3,6 +3,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
+// +build unittest
+
 package brownfield
 
 import (

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -1,3 +1,10 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+// +build unittest
+
 package controller
 
 import (

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -3,6 +3,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
+// +build unittest
+
 package environment
 
 import (

--- a/pkg/k8scontext/k8scontext_suite_test.go
+++ b/pkg/k8scontext/k8scontext_suite_test.go
@@ -3,6 +3,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
+// +build unittest
+
 package k8scontext
 
 import (

--- a/pkg/tests/fixtures/fixtures_suite_test.go
+++ b/pkg/tests/fixtures/fixtures_suite_test.go
@@ -3,6 +3,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
+// +build unittest
+
 package fixtures
 
 import (

--- a/pkg/tests/fixtures_test.go
+++ b/pkg/tests/fixtures_test.go
@@ -3,6 +3,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
+// +build unittest
+
 package tests
 
 import (

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -3,6 +3,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
+// +build unittest
+
 package utils
 
 import (

--- a/pkg/worker/worker_suite_test.go
+++ b/pkg/worker/worker_suite_test.go
@@ -1,3 +1,10 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// --------------------------------------------------------------------------------------------
+
+// +build unittest
+
 package worker_test
 
 import (


### PR DESCRIPTION
This PR adds build tag `unittest` to all the unit tests and uses the tag in the `build.yaml` pipeline file.