### PR TITLE
fix: update the casing for aad-pod-identity crds

### DIFF
--- a/helm/ingress-azure/templates/aadpodidbinding.yaml
+++ b/helm/ingress-azure/templates/aadpodidbinding.yaml
@@ -7,8 +7,8 @@ kind: AzureIdentityBinding
 metadata:
   name: {{ template "application-gateway-kubernetes-ingress.azureidbinding" . }}
 spec: 
-  AzureIdentity: {{ template "application-gateway-kubernetes-ingress.azureidentity" . }}
-  Selector: {{ template "application-gateway-kubernetes-ingress.fullname" . }}
+  azureIdentity: {{ template "application-gateway-kubernetes-ingress.azureidentity" . }}
+  selector: {{ template "application-gateway-kubernetes-ingress.fullname" . }}
 
 {{- end}}
 {{- end}}

--- a/helm/ingress-azure/templates/aadpodidentity.yaml
+++ b/helm/ingress-azure/templates/aadpodidentity.yaml
@@ -12,8 +12,8 @@ metadata:
   {{- end }}
 spec:
   type: 0
-  ResourceID: {{ required "armAuth.identityResourceID is required if using AAD-Pod-Identity" .Values.armAuth.identityResourceID }}
-  ClientID: {{ required "armAuth.identityClientID is required if using AAD-Pod-Identity" .Values.armAuth.identityClientID }}
+  resourceID: {{ required "armAuth.identityResourceID is required if using AAD-Pod-Identity" .Values.armAuth.identityResourceID }}
+  clientID: {{ required "armAuth.identityClientID is required if using AAD-Pod-Identity" .Values.armAuth.identityClientID }}
 
 {{- end}}
 {{- end}}


### PR DESCRIPTION
This PR fix the casing in the AAD Pod identity CRDs created when using user assigned identity with AGIC.
This is to address the breaking change introduced in the AAD POD identity.
https://github.com/Azure/aad-pod-identity#v160-breaking-change

We create the AzureIdentity and AzureIdentityBinding resources.

Will go out in `1.2.0-rc2`.

Fixes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/823