### PR TITLE
doc: update the instruction to use AAD Pod identity v1.5.5

### DIFF
--- a/docs/setup/install-existing.md
+++ b/docs/setup/install-existing.md
@@ -50,7 +50,7 @@ AKS. It binds Azure Active Directory identities to your Kubernetes pods. Identit
 Kubernetes pod to be able to communicate with other Azure components. In the particular case here we need authorization
 for the AGIC pod to make HTTP requests to [ARM](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview).
 
-Follow the [AAD Pod Identity installation instructions](https://github.com/Azure/aad-pod-identity#deploy-the-azure-aad-identity-infra) to add this component to your AKS.
+Follow the [AAD Pod Identity installation instructions](https://github.com/Azure/aad-pod-identity#demo) to add this component to your AKS.
 
 Next we need to create an Azure identity and give it permissions ARM.
 Use [Cloud Shell](https://shell.azure.com/) to run all of the following commands and create an identity:

--- a/docs/setup/install-new-windows-cluster.md
+++ b/docs/setup/install-new-windows-cluster.md
@@ -201,8 +201,8 @@ az aks get-credentials --resource-group $resourceGroupName --name $aksClusterNam
 
   [AAD Pod Identity](https://github.com/Azure/aad-pod-identity) will add the following components to your Kubernetes cluster:
    1. Kubernetes [CRDs](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/): `AzureIdentity`, `AzureAssignedIdentity`, `AzureIdentityBinding`
-   1. [Managed Identity Controller (MIC)](https://github.com/Azure/aad-pod-identity#managed-identity-controllermic) component
-   1. [Node Managed Identity (NMI)](https://github.com/Azure/aad-pod-identity#node-managed-identitynmi) component
+   1. [Managed Identity Controller (MIC)](https://github.com/Azure/aad-pod-identity#managed-identity-controller) component
+   1. [Node Managed Identity (NMI)](https://github.com/Azure/aad-pod-identity#node-managed-identity) component
 
 
   To install AAD Pod Identity to your cluster:
@@ -210,12 +210,20 @@ az aks get-credentials --resource-group $resourceGroupName --name $aksClusterNam
    - *RBAC enabled* AKS cluster
 
   ```bash
+  # Use AAD Pod Identity v1.5.5 when using AGIC <= 1.2.0-rc1 issue: https://github.com/Azure/application-gateway-kubernetes-ingress/issues/828
+  kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/v1.5.5/deploy/infra/deployment-rbac.yaml
+
+  # To install from AAD Pod identity master branch, use the following
   kubectl create -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment-rbac.yaml
   ```
 
    - *RBAC disabled* AKS cluster
 
   ```bash
+  # Use AAD Pod Identity v1.5.5 when using AGIC <= 1.2.0-rc1 issue: https://github.com/Azure/application-gateway-kubernetes-ingress/issues/828
+  kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/v1.5.5/deploy/infra/deployment.yaml
+
+  # To install from AAD Pod identity master branch, use the following
   kubectl create -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment.yaml
   ```
 

--- a/docs/setup/install-new.md
+++ b/docs/setup/install-new.md
@@ -145,8 +145,8 @@ az aks get-credentials --resource-group $resourceGroupName --name $aksClusterNam
 
   [AAD Pod Identity](https://github.com/Azure/aad-pod-identity) will add the following components to your Kubernetes cluster:
    1. Kubernetes [CRDs](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/): `AzureIdentity`, `AzureAssignedIdentity`, `AzureIdentityBinding`
-   1. [Managed Identity Controller (MIC)](https://github.com/Azure/aad-pod-identity#managed-identity-controllermic) component
-   1. [Node Managed Identity (NMI)](https://github.com/Azure/aad-pod-identity#node-managed-identitynmi) component
+   1. [Managed Identity Controller (MIC)](https://github.com/Azure/aad-pod-identity#managed-identity-controller) component
+   1. [Node Managed Identity (NMI)](https://github.com/Azure/aad-pod-identity#node-managed-identity) component
 
 
   To install AAD Pod Identity to your cluster:
@@ -154,12 +154,20 @@ az aks get-credentials --resource-group $resourceGroupName --name $aksClusterNam
    - *RBAC enabled* AKS cluster
 
   ```bash
+  # Use AAD Pod Identity v1.5.5 when using AGIC <= 1.2.0-rc1 issue: https://github.com/Azure/application-gateway-kubernetes-ingress/issues/828
+  kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/v1.5.5/deploy/infra/deployment-rbac.yaml
+
+  # To install from AAD Pod identity master branch, use the following
   kubectl create -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment-rbac.yaml
   ```
 
    - *RBAC disabled* AKS cluster
 
   ```bash
+  # Use AAD Pod Identity v1.5.5 when using AGIC <= 1.2.0-rc1 issue: https://github.com/Azure/application-gateway-kubernetes-ingress/issues/828
+  kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/v1.5.5/deploy/infra/deployment.yaml
+
+  # To install from AAD Pod identity master branch, use the following
   kubectl create -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/deployment.yaml
   ```
 


### PR DESCRIPTION
This PR updates the install documentation to use the AAD Pod Identity v1.5.5 as the latest version in the master has a breaking change.

https://github.com/Azure/application-gateway-kubernetes-ingress/issues/828