### PR TITLE
helm: remove replicaCount parameter and set count to 1

### DIFF
--- a/crds/examples/AzureApplicationGatewayBackendPool.yaml
+++ b/crds/examples/AzureApplicationGatewayBackendPool.yaml
@@ -1,4 +1,4 @@
-apiVersion: appgw.ingress.azure.io/v1
+apiVersion: appgw.ingress.azure.io/v1beta1
 kind: AzureApplicationGatewayBackendPool
 metadata:
   name: subscription-resourcegroup-gatewayname
@@ -10,4 +10,4 @@ spec:
         - ipAddress: 10.0.1.11
     - name: "backendPoolName2"
       backendAddresses:
-        - ipAdress: 10.1.1.12
+        - ipAddress: 10.1.1.12

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1 # TODO: Make configurable when leader election is supported.
   selector:
     matchLabels:
       app: {{ template "application-gateway-kubernetes-ingress.name" . }}

--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -1,5 +1,3 @@
-replicaCount: 1
-
 # Verbosity level of the App Gateway Ingress Controller
 verbosityLevel: 3
 

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -2,8 +2,6 @@
 # This file contains the default values for a chart.
 # These values may be overridden during helm install or helm upgrade.
 
-replicaCount: 1
-
 # Verbosity level of the App Gateway Ingress Controller
 verbosityLevel: 3
 


### PR DESCRIPTION
This PR removes the replicaCount parameter from helm config.

**Explanation**:
Right now, AGIC doesn't support leader election. When multiple replicas are created, all the `n` pods in the deployment will try to update the Application Gateway `n` times for each change in the cluster. This can cause an operation build up on the gateway and also, led to throttling by ARM.