### PR TITLE
docs: update install instruction to use 1.2.0-rc1 when using k8s >= 1.16

### DIFF
--- a/docs/setup/install-existing.md
+++ b/docs/setup/install-existing.md
@@ -141,7 +141,7 @@ You can use [Cloud Shell](https://shell.azure.com/) to install the AGIC Helm pac
       --version 1.0.0
     ```
 
-    >Note: Use `--version 1.2.0-rc1` when installing on k8s version >= 1.16
+    >Note: Use atleast version 1.20-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
 
     Alternatively you can combine the `helm-config.yaml` and the Helm command in one step:
     ```bash
@@ -161,7 +161,7 @@ You can use [Cloud Shell](https://shell.azure.com/) to install the AGIC Helm pac
          --version 1.0.0
     ```
 
-    >Note: Use `--version 1.2.0-rc1` when installing on k8s version >= 1.16
+    >Note: Use atleast version 1.20-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
 
 1. Check the log of the newly created pod to verify if it started properly
 

--- a/docs/setup/install-existing.md
+++ b/docs/setup/install-existing.md
@@ -141,7 +141,7 @@ You can use [Cloud Shell](https://shell.azure.com/) to install the AGIC Helm pac
       --version 1.0.0
     ```
 
-    >Note: Use atleast version 1.2.0-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
+    >Note: Use at least version 1.2.0-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
 
     Alternatively you can combine the `helm-config.yaml` and the Helm command in one step:
     ```bash
@@ -161,7 +161,7 @@ You can use [Cloud Shell](https://shell.azure.com/) to install the AGIC Helm pac
          --version 1.0.0
     ```
 
-    >Note: Use atleast version 1.2.0-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
+    >Note: Use at least version 1.2.0-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
 
 1. Check the log of the newly created pod to verify if it started properly
 

--- a/docs/setup/install-existing.md
+++ b/docs/setup/install-existing.md
@@ -141,7 +141,7 @@ You can use [Cloud Shell](https://shell.azure.com/) to install the AGIC Helm pac
       --version 1.0.0
     ```
 
-    >Note: Use atleast version 1.20-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
+    >Note: Use atleast version 1.2.0-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
 
     Alternatively you can combine the `helm-config.yaml` and the Helm command in one step:
     ```bash
@@ -161,7 +161,7 @@ You can use [Cloud Shell](https://shell.azure.com/) to install the AGIC Helm pac
          --version 1.0.0
     ```
 
-    >Note: Use atleast version 1.20-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
+    >Note: Use atleast version 1.2.0-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
 
 1. Check the log of the newly created pod to verify if it started properly
 

--- a/docs/setup/install-existing.md
+++ b/docs/setup/install-existing.md
@@ -135,8 +135,13 @@ You can use [Cloud Shell](https://shell.azure.com/) to install the AGIC Helm pac
 1. Install Helm chart `application-gateway-kubernetes-ingress` with the `helm-config.yaml` configuration from the previous step
 
     ```bash
-    helm install ingress-azure -f <helm-config.yaml> application-gateway-kubernetes-ingress/ingress-azure
+    helm install ingress-azure \
+      -f helm-config.yaml \
+      application-gateway-kubernetes-ingress/ingress-azure \
+      --version 1.0.0
     ```
+
+    >Note: Use `--version 1.2.0-rc1` when installing on k8s version >= 1.16
 
     Alternatively you can combine the `helm-config.yaml` and the Helm command in one step:
     ```bash
@@ -153,8 +158,10 @@ You can use [Cloud Shell](https://shell.azure.com/) to install the AGIC Helm pac
          --set rbac.enabled=true \
          --set verbosityLevel=3 \
          --set kubernetes.watchNamespace=default \
-         --set aksClusterConfiguration.apiServerAddress=aks-abcdefg.hcp.westus2.azmk8s.io
+         --version 1.0.0
     ```
+
+    >Note: Use `--version 1.2.0-rc1` when installing on k8s version >= 1.16
 
 1. Check the log of the newly created pod to verify if it started properly
 

--- a/docs/setup/install-new-windows-cluster.md
+++ b/docs/setup/install-new-windows-cluster.md
@@ -298,7 +298,7 @@ Values:
       --version 1.0.0
     ```
 
-    >Note: Use atleast version 1.2.0-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
+    >Note: Use at least version 1.2.0-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
 
 ### Install a Sample App
 Now that we have App Gateway, AKS, and AGIC installed we can install a sample app

--- a/docs/setup/install-new-windows-cluster.md
+++ b/docs/setup/install-new-windows-cluster.md
@@ -298,7 +298,7 @@ Values:
       --version 1.0.0
     ```
 
-    >Note: Use `--version 1.2.0-rc1` when installing on k8s version >= 1.16
+    >Note: Use atleast version 1.20-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
 
 ### Install a Sample App
 Now that we have App Gateway, AKS, and AGIC installed we can install a sample app

--- a/docs/setup/install-new-windows-cluster.md
+++ b/docs/setup/install-new-windows-cluster.md
@@ -283,8 +283,14 @@ Values:
 4. Install the Application Gateway ingress controller package:
 
     ```bash
-    helm install ingress-azure -f helm-config.yaml application-gateway-kubernetes-ingress/ingress-azure --set nodeSelector."beta\.kubernetes\.io/os"=linux
+    helm install ingress-azure \
+      -f helm-config.yaml \
+      application-gateway-kubernetes-ingress/ingress-azure \
+      --set nodeSelector."beta\.kubernetes\.io/os"=linux \
+      --version 1.0.0
     ```
+
+    >Note: Use `--version 1.2.0-rc1` when installing on k8s version >= 1.16
 
 ### Install a Sample App
 Now that we have App Gateway, AKS, and AGIC installed we can install a sample app

--- a/docs/setup/install-new-windows-cluster.md
+++ b/docs/setup/install-new-windows-cluster.md
@@ -298,7 +298,7 @@ Values:
       --version 1.0.0
     ```
 
-    >Note: Use atleast version 1.20-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
+    >Note: Use atleast version 1.2.0-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
 
 ### Install a Sample App
 Now that we have App Gateway, AKS, and AGIC installed we can install a sample app

--- a/docs/setup/install-new.md
+++ b/docs/setup/install-new.md
@@ -227,8 +227,13 @@ Values:
 4. Install the Application Gateway ingress controller package:
 
     ```bash
-    helm install ingress-azure -f helm-config.yaml application-gateway-kubernetes-ingress/ingress-azure
+    helm install ingress-azure \
+      -f helm-config.yaml \
+      application-gateway-kubernetes-ingress/ingress-azure \
+      --version 1.0.0
     ```
+
+    >Note: Use `--version 1.2.0-rc1` when installing on k8s version >= 1.16
 
 ### Install a Sample App
 Now that we have App Gateway, AKS, and AGIC installed we can install a sample app

--- a/docs/setup/install-new.md
+++ b/docs/setup/install-new.md
@@ -241,7 +241,7 @@ Values:
       --version 1.0.0
     ```
 
-    >Note: Use `--version 1.2.0-rc1` when installing on k8s version >= 1.16
+    >Note: Use atleast version 1.20-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
 
 ### Install a Sample App
 Now that we have App Gateway, AKS, and AGIC installed we can install a sample app

--- a/docs/setup/install-new.md
+++ b/docs/setup/install-new.md
@@ -241,7 +241,7 @@ Values:
       --version 1.0.0
     ```
 
-    >Note: Use atleast version 1.2.0-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
+    >Note: Use at least version 1.2.0-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
 
 ### Install a Sample App
 Now that we have App Gateway, AKS, and AGIC installed we can install a sample app

--- a/docs/setup/install-new.md
+++ b/docs/setup/install-new.md
@@ -241,7 +241,7 @@ Values:
       --version 1.0.0
     ```
 
-    >Note: Use atleast version 1.20-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
+    >Note: Use atleast version 1.2.0-rc1, e.g. `--version 1.2.0-rc1`, when installing on k8s version >= 1.16
 
 ### Install a Sample App
 Now that we have App Gateway, AKS, and AGIC installed we can install a sample app


### PR DESCRIPTION
Fixes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/822