### PR TITLE
Fixed value to AAD POD identity

### DIFF
--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         release: {{ .Release.Name }}
         {{- if .Values.armAuth }}
         {{- if eq .Values.armAuth.type "aadPodIdentity"}}
-        aadpodidbinding: {{ template "application-gateway-kubernetes-ingress.fullname" . }}
+        aadpodidbinding: {{ .Values.armAuth.identityClientID }}
         {{- end }}
         {{- end }}
       annotations:


### PR DESCRIPTION
According to https://github.com/Azure/aad-pod-identity this should be the value of the identity created not the fullname (ingress-azure).

Or the guide should mention, that the created identity needs to be called "ingress-azure".