### PR TITLE
httpsetting to have https protocol in case port is at 443

### DIFF
--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -729,6 +729,26 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 			check(cbCtx, "one_ingress_https_backend.json", stopChannel, ctxt, configBuilder)
 		})
 
+		ginkgo.It("Https Backend Ingress Resources without backend-protocol specified", func() {
+			newAnnotation := map[string]string{
+				annotations.IngressClassKey:     annotations.ApplicationGatewayIngressClass,
+				annotations.AppGwSslCertificate: "ssl-certificate",
+			}
+
+			ingressHttpsBackend.SetAnnotations(newAnnotation)
+			cbCtx := &ConfigBuilderContext{
+				IngressList: []*v1beta1.Ingress{
+					ingressHttpsBackend,
+				},
+				ServiceList:           serviceList,
+				EnvVariables:          environment.GetFakeEnv(),
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
+			}
+			// protocol of httpSettings, probe should be https when backend port is at 443
+			check(cbCtx, "one_ingress_https_backend_without_backend_protocol.json", stopChannel, ctxt, configBuilder)
+		})
+
 		ginkgo.It("ONE Ingress Resources with / (nothing) path", func() {
 			cbCtx := &ConfigBuilderContext{
 				IngressList: []*v1beta1.Ingress{

--- a/functional_tests/one_ingress_https_backend_without_backend_protocol.json
+++ b/functional_tests/one_ingress_https_backend_without_backend_protocol.json
@@ -1,0 +1,212 @@
+{
+    "properties": {
+        "backendAddressPools": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/defaultaddresspool",
+                "name": "defaultaddresspool",
+                "properties": {
+                    "backendAddresses": []
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---https-backend-namespace---hello-world-https-443-bp-443",
+                "name": "pool---https-backend-namespace---hello-world-https-443-bp-443",
+                "properties": {
+                    "backendAddresses": [
+                        {
+                            "ipAddress": "11.21.21.21"
+                        },
+                        {
+                            "ipAddress": "11.21.21.22"
+                        },
+                        {
+                            "ipAddress": "11.21.21.23"
+                        }
+                    ]
+                }
+            }
+        ],
+        "backendHttpSettingsCollection": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---https-backend-namespace---hello-world-https-443-443---name--",
+                "name": "bp---https-backend-namespace---hello-world-https-443-443---name--",
+                "properties": {
+                    "cookieBasedAffinity": "Disabled",
+                    "pickHostNameFromBackendAddress": false,
+                    "port": 443,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---https-backend-namespace---hello-world-https-443---name--"
+                    },
+                    "protocol": "Https",
+                    "requestTimeout": 30
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/defaulthttpsetting",
+                "name": "defaulthttpsetting",
+                "properties": {
+                    "cookieBasedAffinity": "Disabled",
+                    "pickHostNameFromBackendAddress": false,
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http"
+                    },
+                    "protocol": "Http",
+                    "requestTimeout": 30
+                }
+            }
+        ],
+        "frontendIPConfigurations": [
+            {
+                "id": "--front-end-ip-id-1--",
+                "name": "xx3",
+                "properties": {
+                    "publicIPAddress": {
+                        "id": "xyz"
+                    }
+                }
+            },
+            {
+                "id": "--front-end-ip-id-2--",
+                "name": "yy3",
+                "properties": {
+                    "privateIPAddress": "abc"
+                }
+            }
+        ],
+        "frontendPorts": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-443",
+                "name": "fp-443",
+                "properties": {
+                    "port": 443
+                }
+            }
+        ],
+        "httpListeners": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-c61dda7ff9748ec5f51989767db5afd0",
+                "name": "fl-c61dda7ff9748ec5f51989767db5afd0",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-443"
+                    },
+                    "hostnames": [],
+                    "protocol": "Https",
+                    "requireServerNameIndication": false,
+                    "sslCertificate": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/ssl-certificate"
+                    }
+                }
+            }
+        ],
+        "probes": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http",
+                "name": "defaultprobe-Http",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "match": {},
+                    "minServers": 0,
+                    "path": "/",
+                    "pickHostNameFromBackendHttpSettings": false,
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Https",
+                "name": "defaultprobe-Https",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "match": {},
+                    "minServers": 0,
+                    "path": "/",
+                    "pickHostNameFromBackendHttpSettings": false,
+                    "protocol": "Https",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---https-backend-namespace---hello-world-https-443---name--",
+                "name": "pb---https-backend-namespace---hello-world-https-443---name--",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "match": {},
+                    "minServers": 0,
+                    "path": "/A/",
+                    "pickHostNameFromBackendHttpSettings": false,
+                    "protocol": "Https",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            }
+        ],
+        "redirectConfigurations": [],
+        "requestRoutingRules": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-c61dda7ff9748ec5f51989767db5afd0",
+                "name": "rr-c61dda7ff9748ec5f51989767db5afd0",
+                "properties": {
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-c61dda7ff9748ec5f51989767db5afd0"
+                    },
+                    "ruleType": "PathBasedRouting",
+                    "urlPathMap": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-c61dda7ff9748ec5f51989767db5afd0"
+                    }
+                }
+            }
+        ],
+        "sku": {
+            "capacity": 3,
+            "name": "Standard_v2",
+            "tier": "Standard_v2"
+        },
+        "sslCertificates": [],
+        "urlPathMaps": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-c61dda7ff9748ec5f51989767db5afd0",
+                "name": "url-c61dda7ff9748ec5f51989767db5afd0",
+                "properties": {
+                    "defaultBackendAddressPool": {
+                        "id": "xx"
+                    },
+                    "defaultBackendHttpSettings": {
+                        "id": "yy"
+                    },
+                    "pathRules": [
+                        {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-c61dda7ff9748ec5f51989767db5afd0/pathRules/pr---https-backend-namespace-----name---0",
+                            "name": "pr---https-backend-namespace-----name---0",
+                            "properties": {
+                                "backendAddressPool": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---https-backend-namespace---hello-world-https-443-bp-443"
+                                },
+                                "backendHttpSettings": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---https-backend-namespace---hello-world-https-443-443---name--"
+                                },
+                                "paths": [
+                                    "/A/"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "tags": {
+        "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
+        "managed-by-k8s-ingress": "a/b/c"
+    }
+}

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -220,7 +220,6 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 			RequestTimeout:                 to.Int32Ptr(30),
 		},
 	}
-
 	_, probesMap := c.newProbesMap(cbCtx)
 
 	if probesMap[backendID] != nil {
@@ -286,6 +285,11 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 
 	} else if err != nil && !controllererrors.IsErrorCode(err, controllererrors.ErrorMissingAnnotation) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
+	}
+
+	// when ingress is defined with backend at port 443 but without annotation backend-protocol set to https.
+	if int32(port) == 443 {
+		httpSettings.Protocol = n.HTTPS
 	}
 
 	// To use an HTTP setting with a trusted root certificate, we must either override with a specific domain name or choose "Pick host name from backend target".

--- a/pkg/appgw/backendhttpsettings_test.go
+++ b/pkg/appgw/backendhttpsettings_test.go
@@ -41,17 +41,9 @@ var _ = Describe("Test the creation of Backend http settings from Ingress defini
 		// based on backend protocol annotation and then test against expected backend http settings.
 		checkBackendProtocolAnnotation := func(annotationValue string, protocolEnum annotations.ProtocolEnum, expectedProtocolValue n.ApplicationGatewayProtocol) {
 			// Setup
-			if len(annotationValue) > 0 {
-				ingress.Annotations[annotations.BackendProtocolKey] = annotationValue
-				_ = configBuilder.k8sContext.Caches.Ingress.Update(ingress)
-				Expect(annotations.BackendProtocol(ingress)).To(Equal(protocolEnum))
-			} else {
-				// disable ssl-redirect
-				newAnnotation := map[string]string{
-					annotations.IngressClassKey: annotations.ApplicationGatewayIngressClass,
-				}
-				ingress.SetAnnotations(newAnnotation)
-			}
+			ingress.Annotations[annotations.BackendProtocolKey] = annotationValue
+			_ = configBuilder.k8sContext.Caches.Ingress.Update(ingress)
+			Expect(annotations.BackendProtocol(ingress)).To(Equal(protocolEnum))
 
 			cbCtx := &ConfigBuilderContext{
 				IngressList:           []*v1beta1.Ingress{ingress},
@@ -83,10 +75,6 @@ var _ = Describe("Test the creation of Backend http settings from Ingress defini
 
 		It("should have all backend http settings with http", func() {
 			checkBackendProtocolAnnotation("HttP", annotations.HTTP, n.HTTP)
-		})
-
-		It("should have all but default backend http settings with https without backend protocol defined", func() {
-			checkBackendProtocolAnnotation("", 0, n.HTTPS)
 		})
 	})
 

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -107,9 +107,16 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 		probe.Path = to.StringPtr(backendID.Path.Path)
 	}
 
-	// backend protocol "https" now supports to use certificate signed by well-known root certificate as well as trusted self-signed certificate
-	if protocol, _ := annotations.BackendProtocol(backendID.Ingress); protocol == annotations.HTTPS {
+	if backendID.Backend.ServicePort.IntVal == 443 {
 		probe.Protocol = n.HTTPS
+	}
+
+	// backend protocol take precedence over port
+	backendProtocol, err := annotations.BackendProtocol(backendID.Ingress)
+	if err == nil && backendProtocol == annotations.HTTPS {
+		probe.Protocol = n.HTTPS
+	} else if err == nil && backendProtocol == annotations.HTTP {
+		probe.Protocol = n.HTTP
 	}
 
 	k8sProbeForServiceContainer := c.getProbeForServiceContainer(service, backendID)

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -107,7 +107,7 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 		probe.Path = to.StringPtr(backendID.Path.Path)
 	}
 
-	if backendID.Backend.ServicePort.IntVal == 443 {
+	if backendID.Backend.ServicePort.String() == "443" {
 		probe.Protocol = n.HTTPS
 	}
 

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -575,6 +575,9 @@ func (c *Context) listServicesByPodSelector(pod *v1.Pod) []*v1.Service {
 func (c *Context) isServiceReferencedByAnyIngress(service *v1.Service) bool {
 	for _, ingress := range c.ListHTTPIngresses() {
 		for _, rule := range ingress.Spec.Rules {
+			if rule.HTTP == nil {
+				continue
+			}
 			for _, path := range rule.HTTP.Paths {
 				// TODO(akshaysngupta) Use service ports
 				if path.Backend.ServiceName == service.Name {


### PR DESCRIPTION
This PR addresses two issues:
1) When a service uses port 443, this change will initialise the protocol to HTTPS by default. This behaviour can changed by using the backend-protocol annotation.
2) Fix for nil exception when looking for a service.

Fixes: #851, #779, #752, #635, #629