### PR TITLE
Added check to prevent UnhealthyThreshold to go beyond 20

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -395,8 +395,7 @@ spec:
           servicePort: 80
 ```
 
-
-## Attach firewall policy to a host and path
+## Azure Waf Policy For Path
 This annotation allows you to attach an already created WAF policy to the list paths for a host within a Kubernetes
 Ingress resource being annotated.
 
@@ -410,6 +409,8 @@ The URI would have the following format:
 ```bash
 /subscriptions/<YOUR-SUBSCRIPTION>/resourceGroups/<YOUR-RESOURCE-GROUP>/providers/Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/<YOUR-POLICY-NAME>
 ```
+> **Note**
+1) Waf policy will only be applied to a listener if ingress rule path is not set or set to "/" or "/*"
 
 ### Usage
 

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -148,6 +148,8 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 			probe.Timeout = to.Int32Ptr(k8sProbeForServiceContainer.TimeoutSeconds)
 		}
 		if k8sProbeForServiceContainer.FailureThreshold != 0 {
+			// UnhealthyThreshold must be in range of 0 - 20, otherwise Application Gateway will not
+			// accept the configuration and all new pods will not be configured.
 			if k8sProbeForServiceContainer.FailureThreshold > 20 {
 				probe.UnhealthyThreshold = to.Int32Ptr(20)
 			} else {

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -148,7 +148,11 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 			probe.Timeout = to.Int32Ptr(k8sProbeForServiceContainer.TimeoutSeconds)
 		}
 		if k8sProbeForServiceContainer.FailureThreshold != 0 {
-			probe.UnhealthyThreshold = to.Int32Ptr(k8sProbeForServiceContainer.FailureThreshold)
+			if k8sProbeForServiceContainer.FailureThreshold > 20 {
+				probe.UnhealthyThreshold = to.Int32Ptr(20)
+			} else {
+				probe.UnhealthyThreshold = to.Int32Ptr(k8sProbeForServiceContainer.FailureThreshold)
+			}
 		}
 	}
 


### PR DESCRIPTION
When deploying Prometheus Operator on our cluster we run into the problem that the UnhealthyThreshold goes beyond 20 and the ingress controller gives an error: ApplicationGatewayProbeUnhealthyThresholdIsInvalid.

See: 

> error: network.ApplicationGatewaysClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="ApplicationGatewayProbeUnhealthyThresholdIsInvalid" Message="Unhealthy threshold specified for Probe /subscriptions/.../resourceGroups/rg-gateway/providers/Microsoft.Network/applicationGateways/gateway/probes/pb-monitoring-mdf-prometheus-operator-prometheu-cc513868657fb3a5420b340c3bd9625c is not valid. Supported range is [0, 20]." Details=[]'

Currently the code just grabs the `FailureThreshold` from the Probe, but in the case of Prometheus we have no control over it. See: https://github.com/coreos/prometheus-operator/blob/6b1a5276fe42efd355b001cd891cf169b9bd6775/pkg/prometheus/statefulset.go#L651
