### PR TITLE
e2e: add test case to test backend availability with health probing

### DIFF
--- a/scripts/e2e/cmd/runner/testdata/one-namespace-one-ingress/container-readiness-probe/app.yaml
+++ b/scripts/e2e/cmd/runner/testdata/one-namespace-one-ingress/container-readiness-probe/app.yaml
@@ -1,0 +1,138 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: websocket-deployment
+  namespace: e2e-probe1
+spec:
+  selector:
+    matchLabels:
+      app: ws-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ws-app
+    spec:
+      containers:
+        - name: websocket-app
+          imagePullPolicy: Always
+          image: docker.io/kennethreitz/httpbin
+          ports:
+            - containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /status/201
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /status/202
+              port: 80
+              scheme: HTTP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: websocket-service
+  namespace: e2e-probe1
+spec:
+  selector:
+    app: ws-app
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: websocket-ingress
+  namespace: e2e-probe1
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/backend-path-prefix: "/"
+spec:
+  rules:
+    - host: ws.mis.li.probe
+      http:
+        paths:
+        - path: /good
+          backend:
+            serviceName: websocket-service
+            servicePort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: websocket-deployment
+  namespace: e2e-probe2
+spec:
+  selector:
+    matchLabels:
+      app: ws-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ws-app
+    spec:
+      containers:
+        - name: websocket-app
+          imagePullPolicy: Always
+          image: docker.io/kennethreitz/httpbin
+          ports:
+            - containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /status/201
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /status/404
+              port: 80
+              scheme: HTTP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: websocket-service
+  namespace: e2e-probe2
+spec:
+  selector:
+    app: ws-app
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: websocket-ingress
+  namespace: e2e-probe2
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/backend-path-prefix: "/"
+spec:
+  rules:
+    - host: ws.mis.li.probe
+      http:
+        paths:
+        - path: /bad
+          backend:
+            serviceName: websocket-service
+            servicePort: 80

--- a/scripts/e2e/cmd/runner/testdata/one-namespace-one-ingress/container-readiness-probe/app.yaml
+++ b/scripts/e2e/cmd/runner/testdata/one-namespace-one-ingress/container-readiness-probe/app.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: websocket-deployment
+  name: backend-deployment
   namespace: e2e-probe1
 spec:
   selector:
@@ -14,7 +14,7 @@ spec:
         app: ws-app
     spec:
       containers:
-        - name: websocket-app
+        - name: backend-app
           imagePullPolicy: Always
           image: docker.io/kennethreitz/httpbin
           ports:
@@ -37,7 +37,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: websocket-service
+  name: backend-service
   namespace: e2e-probe1
 spec:
   selector:
@@ -52,7 +52,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: websocket-ingress
+  name: backend-ingress
   namespace: e2e-probe1
   annotations:
     kubernetes.io/ingress.class: azure/application-gateway
@@ -64,14 +64,14 @@ spec:
         paths:
         - path: /good
           backend:
-            serviceName: websocket-service
+            serviceName: backend-service
             servicePort: 80
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: websocket-deployment
+  name: unhealthy-backend-deployment
   namespace: e2e-probe2
 spec:
   selector:
@@ -84,7 +84,7 @@ spec:
         app: ws-app
     spec:
       containers:
-        - name: websocket-app
+        - name: backend-app
           imagePullPolicy: Always
           image: docker.io/kennethreitz/httpbin
           ports:
@@ -107,7 +107,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: websocket-service
+  name: backend-service
   namespace: e2e-probe2
 spec:
   selector:
@@ -122,7 +122,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: websocket-ingress
+  name: backend-ingress
   namespace: e2e-probe2
   annotations:
     kubernetes.io/ingress.class: azure/application-gateway
@@ -134,5 +134,5 @@ spec:
         paths:
         - path: /bad
           backend:
-            serviceName: websocket-service
+            serviceName: backend-service
             servicePort: 80

--- a/scripts/e2e/cmd/runner/testdata/one-namespace-one-ingress/container-readiness-probe/deploy.sh
+++ b/scripts/e2e/cmd/runner/testdata/one-namespace-one-ingress/container-readiness-probe/deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -auexo pipefail
+
+echo -e "The goal of this is to ensure health probe is generated from container readiness probe and backend should be removed when the probe is unhealthy"
+
+for ns in e2e-probe1 e2e-probe2; do
+    kubectl create namespace "${ns}" || true
+
+kubectl apply -f app.yaml


### PR DESCRIPTION
## Description
- backend will be removed when health probe is unhealthy
-  appgw health probe is determined by the readiness probe defined in the container
