### PR TITLE
support install crd by helm3

### DIFF
--- a/helm/ingress-azure/crds/azureingressprohibitedtarget.yaml
+++ b/helm/ingress-azure/crds/azureingressprohibitedtarget.yaml
@@ -1,14 +1,7 @@
-{{- if .Values.appgw -}}
-{{- if .Values.appgw.shared -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: azureingressprohibitedtargets.appgw.ingress.k8s.io
-  labels:
-    app: {{ template "application-gateway-kubernetes-ingress.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
   annotations:	  
     "helm.sh/hook": crd-install
 spec:
@@ -32,15 +25,3 @@ spec:
               items:
                   type: string
                   pattern: '^\/(?:.+\/)?\*$'
-
----
-
-apiVersion: appgw.ingress.k8s.io/v1
-kind: AzureIngressProhibitedTarget
-metadata:
-  name: prohibit-all-targets
-spec:
-  paths:
-    - /*
-{{- end -}}
-{{- end -}}

--- a/helm/ingress-azure/crds/azureingressprohibitedtarget.yaml
+++ b/helm/ingress-azure/crds/azureingressprohibitedtarget.yaml
@@ -9,6 +9,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:	  
+    "helm.sh/hook": crd-install
 spec:
   group: appgw.ingress.k8s.io
   version: v1

--- a/helm/ingress-azure/templates/crds.yaml
+++ b/helm/ingress-azure/templates/crds.yaml
@@ -1,4 +1,15 @@
+{{- if .Values.appgw -}}
+{{- if .Values.appgw.shared -}}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
   {{ $.Files.Get $path }}
 ---
 {{- end }}
+apiVersion: appgw.ingress.k8s.io/v1
+kind: AzureIngressProhibitedTarget
+metadata:
+  name: prohibit-all-targets
+spec:
+  paths:
+    - /*
+{{- end -}}
+{{- end -}}

--- a/helm/ingress-azure/templates/crds.yaml
+++ b/helm/ingress-azure/templates/crds.yaml
@@ -1,0 +1,4 @@
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
+  {{ $.Files.Get $path }}
+---
+{{- end }}


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Now support to install crd by helm 2 as well as helm 3
hook: "crd-install will be unknown and skipped when helm3 is used

## Fixes
crd cannot be installed neither by helm 2 nor helm 3