### PR TITLE
brownfield: convert hostName to hostnames in brownfield

### DIFF
--- a/pkg/brownfield/listeners_test.go
+++ b/pkg/brownfield/listeners_test.go
@@ -22,6 +22,7 @@ var _ = Describe("Test blacklist listeners", func() {
 	listener2 := (*appGw.HTTPListeners)[2]
 	listener3 := (*appGw.HTTPListeners)[3]
 	listenerUnassociated := (*appGw.HTTPListeners)[4]
+	listenerWildcard := (*appGw.HTTPListeners)[5]
 
 	Context("Test GetBlacklistedListeners() with a blacklist", func() {
 		It("should create a list of blacklisted and non blacklisted listeners", func() {
@@ -29,10 +30,11 @@ var _ = Describe("Test blacklist listeners", func() {
 			er := NewExistingResources(appGw, prohibitedTargets, nil)
 			blacklisted, nonBlacklisted := er.GetBlacklistedListeners()
 
-			Expect(len(blacklisted)).To(Equal(3))
+			Expect(len(blacklisted)).To(Equal(4))
 			Expect(blacklisted).To(ContainElement(listener1))
 			Expect(blacklisted).To(ContainElement(listener2))
 			Expect(blacklisted).To(ContainElement(listener3))
+			Expect(blacklisted).To(ContainElement(listenerWildcard))
 
 			Expect(len(nonBlacklisted)).To(Equal(2))
 			Expect(nonBlacklisted).To(ContainElement(defaultListener))
@@ -56,10 +58,12 @@ var _ = Describe("Test blacklist listeners", func() {
 			Expect(len(blacklisted)).To(Equal(1))
 			Expect(blacklisted).To(ContainElement(listener2))
 
-			Expect(len(nonBlacklisted)).To(Equal(4))
+			Expect(len(nonBlacklisted)).To(Equal(5))
 			Expect(nonBlacklisted).To(ContainElement(defaultListener))
 			Expect(nonBlacklisted).To(ContainElement(listener1))
 			Expect(nonBlacklisted).To(ContainElement(listener3))
+			Expect(nonBlacklisted).To(ContainElement(listenerUnassociated))
+			Expect(nonBlacklisted).To(ContainElement(listenerWildcard))
 		})
 	})
 
@@ -70,11 +74,12 @@ var _ = Describe("Test blacklist listeners", func() {
 			er := NewExistingResources(appGw, prohibitedTargets, nil)
 			blacklisted, nonBlacklisted := er.GetBlacklistedListeners()
 
-			Expect(len(blacklisted)).To(Equal(4))
+			Expect(len(blacklisted)).To(Equal(5))
 			Expect(blacklisted).To(ContainElement(listener1))
 			Expect(blacklisted).To(ContainElement(listener2))
 			Expect(blacklisted).To(ContainElement(listener3))
 			Expect(blacklisted).To(ContainElement(defaultListener))
+			Expect(blacklisted).To(ContainElement(listenerWildcard))
 
 			Expect(len(nonBlacklisted)).To(Equal(1))
 		})
@@ -92,7 +97,7 @@ var _ = Describe("Test blacklist listeners", func() {
 			er := NewExistingResources(appGw, prohibitedTargets, nil)
 			set := er.getBlacklistedListenersSet()
 
-			Expect(len(set)).To(Equal(4))
+			Expect(len(set)).To(Equal(5))
 			_, exists := set[fixtures.HTTPListenerPathBased1]
 			Expect(exists).To(BeTrue())
 			_, exists = set[fixtures.HTTPListenerPathBased2]
@@ -100,6 +105,8 @@ var _ = Describe("Test blacklist listeners", func() {
 			_, exists = set[fixtures.HTTPListenerNameBasic]
 			Expect(exists).To(BeTrue())
 			_, exists = set[fixtures.HTTPListenerUnassociated]
+			Expect(exists).To(BeTrue())
+			_, exists = set[fixtures.HTTPListenerWildcard]
 			Expect(exists).To(BeTrue())
 		})
 	})
@@ -112,8 +119,8 @@ var _ = Describe("Test blacklist listeners", func() {
 			listenersByName := er.getListenersByName()
 			Expect(er.listenersByName).ToNot(BeNil())
 
-			Expect(len(er.listenersByName)).To(Equal(5))
-			Expect(len(listenersByName)).To(Equal(5))
+			Expect(len(er.listenersByName)).To(Equal(6))
+			Expect(len(listenersByName)).To(Equal(6))
 
 			_, exists := listenersByName[fixtures.HTTPListenerPathBased1]
 			Expect(exists).To(BeTrue())
@@ -124,6 +131,8 @@ var _ = Describe("Test blacklist listeners", func() {
 			_, exists = listenersByName[fixtures.DefaultHTTPListenerName]
 			Expect(exists).To(BeTrue())
 			_, exists = listenersByName[fixtures.HTTPListenerUnassociated]
+			Expect(exists).To(BeTrue())
+			_, exists = listenersByName[fixtures.HTTPListenerWildcard]
 			Expect(exists).To(BeTrue())
 		})
 	})

--- a/pkg/brownfield/pathmaps_test.go
+++ b/pkg/brownfield/pathmaps_test.go
@@ -20,6 +20,7 @@ var _ = Describe("Test blacklisting path maps", func() {
 	pathMap1 := (*appGw.URLPathMaps)[0]
 	pathMap2 := (*appGw.URLPathMaps)[1]
 	pathMap3 := (*appGw.URLPathMaps)[2]
+	pathMap4 := (*appGw.URLPathMaps)[3]
 
 	Context("Test GetBlacklistedHTTPSettings() with a blacklist", func() {
 		It("should create a list of blacklisted and non blacklisted path maps", func() {
@@ -27,9 +28,10 @@ var _ = Describe("Test blacklisting path maps", func() {
 			er := NewExistingResources(appGw, prohibitedTargets, nil)
 
 			blacklisted, nonBlacklisted := er.GetBlacklistedPathMaps()
-			Expect(len(blacklisted)).To(Equal(2))
+			Expect(len(blacklisted)).To(Equal(3))
 			Expect(blacklisted).To(ContainElement(pathMap2))
 			Expect(blacklisted).To(ContainElement(pathMap3))
+			Expect(blacklisted).To(ContainElement(pathMap4))
 
 			Expect(len(nonBlacklisted)).To(Equal(1))
 			Expect(nonBlacklisted).To(ContainElement(pathMap1))
@@ -45,9 +47,10 @@ var _ = Describe("Test blacklisting path maps", func() {
 
 			er := NewExistingResources(appGw, prohibitedTargets, nil)
 			blacklisted, nonBlacklisted := er.GetBlacklistedPathMaps()
-			Expect(len(blacklisted)).To(Equal(2))
+			Expect(len(blacklisted)).To(Equal(3))
 			Expect(blacklisted).To(ContainElement(pathMap2))
 			Expect(blacklisted).To(ContainElement(pathMap3))
+			Expect(blacklisted).To(ContainElement(pathMap4))
 
 			// One HTTP Setting is not associated with a listener, so we can't blacklist it.
 			Expect(len(nonBlacklisted)).To(Equal(1))

--- a/pkg/brownfield/routing_rules_test.go
+++ b/pkg/brownfield/routing_rules_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Test blacklist request routing rules", func() {
 	ruleBasic := (*appGw.RequestRoutingRules)[1]
 	rulePathBased1 := (*appGw.RequestRoutingRules)[2]
 	rulePathBased2 := (*appGw.RequestRoutingRules)[3]
+	rulePathBased3 := (*appGw.RequestRoutingRules)[4]
 
 	Context("Test getRoutingRuleToTargetsMap()", func() {
 		It("should create a map of routing rules to targets", func() {
@@ -29,8 +30,8 @@ var _ = Describe("Test blacklist request routing rules", func() {
 
 			ruleToTargets, pathMapToTargets := er.getRuleToTargets()
 
-			Expect(len(ruleToTargets)).To(Equal(3))
-			Expect(len(pathMapToTargets)).To(Equal(2))
+			Expect(len(ruleToTargets)).To(Equal(4))
+			Expect(len(pathMapToTargets)).To(Equal(3))
 
 			targetFoo := Target{Hostname: tests.Host, Path: fixtures.PathFoo}
 			targetBar := Target{Hostname: tests.Host, Path: fixtures.PathBar}
@@ -50,6 +51,16 @@ var _ = Describe("Test blacklist request routing rules", func() {
 			Expect(ruleToTargets[fixtures.RequestRoutingRuleName2]).To(ContainElement(targetFox))
 			Expect(ruleToTargets[fixtures.RequestRoutingRuleName2]).To(ContainElement(targetOtherHostNoPath))
 
+			targetWildcard1 := Target{Hostname: tests.WildcardHost1, Path: fixtures.PathFox}
+			targetWildcard2 := Target{Hostname: tests.WildcardHost2, Path: fixtures.PathFox}
+			targetWildcard1NoPath := Target{Hostname: tests.WildcardHost1}
+			targetWildcard2NoPath := Target{Hostname: tests.WildcardHost2}
+
+			Expect(len(ruleToTargets[fixtures.RequestRoutingRuleName3])).To(Equal(4))
+			Expect(ruleToTargets[fixtures.RequestRoutingRuleName3]).To(ContainElement(targetWildcard1))
+			Expect(ruleToTargets[fixtures.RequestRoutingRuleName3]).To(ContainElement(targetWildcard2))
+			Expect(ruleToTargets[fixtures.RequestRoutingRuleName3]).To(ContainElement(targetWildcard1NoPath))
+			Expect(ruleToTargets[fixtures.RequestRoutingRuleName3]).To(ContainElement(targetWildcard2NoPath))
 		})
 	})
 
@@ -59,10 +70,11 @@ var _ = Describe("Test blacklist request routing rules", func() {
 			er := NewExistingResources(appGw, prohibitedTargets, nil)
 			blacklisted, nonBlacklisted := er.GetBlacklistedRoutingRules()
 
-			Expect(len(blacklisted)).To(Equal(3))
+			Expect(len(blacklisted)).To(Equal(4))
 			Expect(blacklisted).To(ContainElement(rulePathBased1))
 			Expect(blacklisted).To(ContainElement(rulePathBased2))
 			Expect(blacklisted).To(ContainElement(ruleBasic))
+			Expect(blacklisted).To(ContainElement(rulePathBased3))
 
 			Expect(len(nonBlacklisted)).To(Equal(1))
 			Expect(nonBlacklisted).To(ContainElement(ruleDefault))
@@ -79,13 +91,14 @@ var _ = Describe("Test blacklist request routing rules", func() {
 
 			blacklisted, nonBlacklisted := er.GetBlacklistedRoutingRules()
 
-			Expect(len(blacklisted)).To(Equal(4))
+			Expect(len(blacklisted)).To(Equal(5))
 			Expect(len(nonBlacklisted)).To(Equal(0))
 
 			Expect(blacklisted).To(ContainElement(ruleBasic))
 			Expect(blacklisted).To(ContainElement(rulePathBased1))
 			Expect(blacklisted).To(ContainElement(rulePathBased2))
 			Expect(blacklisted).To(ContainElement(ruleDefault))
+			Expect(blacklisted).To(ContainElement(rulePathBased3))
 		})
 	})
 })

--- a/pkg/brownfield/targets_test.go
+++ b/pkg/brownfield/targets_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Test blacklisting targets", func() {
 	Context("test GetTargetBlacklist", func() {
 		blacklist := GetTargetBlacklist(fixtures.GetAzureIngressProhibitedTargets())
 		It("should have produced correct Prohibited Targets list", func() {
-			Expect(len(*blacklist)).To(Equal(4))
+			Expect(len(*blacklist)).To(Equal(5))
 
 			// Targets /fox and /bar are in the blacklist
 			for _, path := range []string{fixtures.PathFox, fixtures.PathBar} {

--- a/pkg/brownfield/types_test.go
+++ b/pkg/brownfield/types_test.go
@@ -44,6 +44,7 @@ var _ = Describe("Test NewExistingResources", func() {
 			expected := map[string]interface{}{
 				"bye.com":                 nil,
 				"--some-other-hostname--": nil,
+				"*.hi.com":                nil,
 			}
 			Expect(actual).To(Equal(expected))
 		})

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -30,6 +30,8 @@ const (
 	Host                         = "bye.com"
 	OtherHost                    = "--some-other-hostname--"
 	HostUnassociated             = "---some-host-without-routing-rules---"
+	WildcardHost1                = "*.hi.com"
+	WildcardHost2                = "hola.com"
 	NameOfSecret                 = "--the-name-of-the-secret--"
 	ServiceName                  = "--service-name--"
 	NodeName                     = "--node-name--"

--- a/pkg/tests/fixtures/app_gateway.go
+++ b/pkg/tests/fixtures/app_gateway.go
@@ -24,11 +24,13 @@ func GetAppGateway() n.ApplicationGateway {
 				*GetRequestRoutingRuleBasic(),
 				*GetRequestRoutingRulePathBased1(),
 				*GetRequestRoutingRulePathBased2(),
+				*GetRequestRoutingRulePathBased3(),
 			},
 			URLPathMaps: &[]n.ApplicationGatewayURLPathMap{
 				*GetDefaultURLPathMap(),
 				*GetURLPathMap1(),
 				*GetURLPathMap2(),
+				*GetURLPathMap3(),
 			},
 
 			HTTPListeners: &[]n.ApplicationGatewayHTTPListener{
@@ -37,6 +39,7 @@ func GetAppGateway() n.ApplicationGateway {
 				*GetListenerPathBased1(),
 				*GetListenerPathBased2(),
 				*GetListenerUnassociated(),
+				*GetListenerWildcard(),
 			},
 
 			SslCertificates: &[]n.ApplicationGatewaySslCertificate{

--- a/pkg/tests/fixtures/listeners.go
+++ b/pkg/tests/fixtures/listeners.go
@@ -27,6 +27,9 @@ const (
 
 	// HTTPListenerUnassociated is a string constant.
 	HTTPListenerUnassociated = "HTTPListener-Unassociated"
+
+	// HTTPListenerWildcard is a string constant.
+	HTTPListenerWildcard = "HTTPListener-Wildcard"
 )
 
 // GetListenerBasic creates a new struct for use in unit tests.
@@ -95,6 +98,20 @@ func GetListenerUnassociated() *n.ApplicationGatewayHTTPListener {
 			FrontendPort:                &n.SubResource{ID: to.StringPtr("")},
 			Protocol:                    n.HTTP,
 			HostName:                    to.StringPtr(tests.HostUnassociated),
+			RequireServerNameIndication: to.BoolPtr(true),
+		},
+	}
+}
+
+// GetListenerWildcard creates a new listener which is associated to a rule and uses wild card hostnames
+func GetListenerWildcard() *n.ApplicationGatewayHTTPListener {
+	return &n.ApplicationGatewayHTTPListener{
+		Name: to.StringPtr(HTTPListenerWildcard),
+		ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
+			FrontendIPConfiguration:     &n.SubResource{ID: to.StringPtr("")},
+			FrontendPort:                &n.SubResource{ID: to.StringPtr("")},
+			Protocol:                    n.HTTP,
+			Hostnames:                   &[]string{tests.WildcardHost1, tests.WildcardHost2},
 			RequireServerNameIndication: to.BoolPtr(true),
 		},
 	}

--- a/pkg/tests/fixtures/paths.go
+++ b/pkg/tests/fixtures/paths.go
@@ -20,6 +20,9 @@ const (
 	// URLPathMapName2 is a string constant.
 	URLPathMapName2 = "URLPathMap-2"
 
+	// URLPathMapName3 is a string constant.
+	URLPathMapName3 = "URLPathMap-3"
+
 	// PathRuleName is a string constant.
 	PathRuleName = "PathRule-1"
 
@@ -174,6 +177,72 @@ func GetURLPathMap2() *n.ApplicationGatewayURLPathMap {
 
 // GetPathRulePathBased2 creates a new struct for use in unit tests.
 func GetPathRulePathBased2() *n.ApplicationGatewayPathRule {
+	return &n.ApplicationGatewayPathRule{
+		Name: to.StringPtr(PathRuleName),
+		ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
+			// Paths - Path rules of URL path map.
+			Paths: &[]string{
+				PathFox,
+			},
+
+			// BackendAddressPool - Backend address pool resource of URL path map path rule.
+			BackendAddressPool: &n.SubResource{
+				ID: to.StringPtr("x/y/z/" + BackendAddressPoolName1),
+			},
+
+			// BackendHTTPSettings - Backend http settings resource of URL path map path rule.
+			BackendHTTPSettings: &n.SubResource{
+				ID: to.StringPtr("x/y/z/BackendHTTPSettings-1"),
+			},
+
+			// RedirectConfiguration - Redirect configuration resource of URL path map path rule.
+			RedirectConfiguration: &n.SubResource{
+				ID: to.StringPtr("x/y/z/RedirectConfiguration-1"),
+			},
+
+			// RewriteRuleSet - Rewrite rule set resource of URL path map path rule.
+			RewriteRuleSet: &n.SubResource{
+				ID: to.StringPtr("x/y/z/RewriteRuleSet-1"),
+			},
+		},
+	}
+}
+
+// GetURLPathMap3 creates a new struct for use in unit tests.
+func GetURLPathMap3() *n.ApplicationGatewayURLPathMap {
+	return &n.ApplicationGatewayURLPathMap{
+		Name: to.StringPtr(URLPathMapName3),
+		ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
+			// DefaultBackendAddressPool - Default backend address pool resource of URL path map.
+			DefaultBackendAddressPool: &n.SubResource{
+				ID: to.StringPtr(""),
+			},
+
+			// DefaultBackendHTTPSettings - Default backend http settings resource of URL path map.
+			DefaultBackendHTTPSettings: &n.SubResource{
+				ID: to.StringPtr(BackendHTTPSettingsName2),
+			},
+
+			// DefaultRewriteRuleSet - Default Rewrite rule set resource of URL path map.
+			DefaultRewriteRuleSet: &n.SubResource{
+				ID: to.StringPtr(""),
+			},
+
+			// DefaultRedirectConfiguration - Default redirect configuration resource of URL path map.
+			DefaultRedirectConfiguration: &n.SubResource{
+				ID: to.StringPtr(""),
+			},
+
+			// PathRules - Path rule of URL path map resource.
+			PathRules: &[]n.ApplicationGatewayPathRule{
+				*GetPathRulePathBased3(),
+			},
+		},
+	}
+}
+
+// GetPathRulePathBased3 creates a new struct for use in unit tests.
+func GetPathRulePathBased3() *n.ApplicationGatewayPathRule {
 	return &n.ApplicationGatewayPathRule{
 		Name: to.StringPtr(PathRuleName),
 		ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{

--- a/pkg/tests/fixtures/routing_rules.go
+++ b/pkg/tests/fixtures/routing_rules.go
@@ -19,6 +19,9 @@ const (
 
 	// RequestRoutingRuleName2 is a string constant.
 	RequestRoutingRuleName2 = "RequestRoutingRule-2"
+
+	// RequestRoutingRuleName3 is a string constant.
+	RequestRoutingRuleName3 = "RequestRoutingRule-3"
 )
 
 // GetRequestRoutingRulePathBased1 creates a new struct for use in unit tests.
@@ -88,6 +91,47 @@ func GetRequestRoutingRulePathBased2() *n.ApplicationGatewayRequestRoutingRule {
 			// URLPathMap - URL path map resource of the application gateway.
 			URLPathMap: &n.SubResource{
 				ID: to.StringPtr("x/y/z/" + URLPathMapName2),
+			},
+
+			// RewriteRuleSet - Rewrite Rule Set resource in Basic rule of the application gateway.
+			RewriteRuleSet: &n.SubResource{
+				ID: to.StringPtr("x/y/z/RewriteRuleSet-1"),
+			},
+
+			// RedirectConfiguration - Redirect configuration resource of the application gateway.
+			RedirectConfiguration: &n.SubResource{
+				ID: to.StringPtr("x/y/z/RedirectConfiguration-1"),
+			},
+		},
+	}
+}
+
+// GetRequestRoutingRulePathBased3 creates a new struct for use in unit tests.
+func GetRequestRoutingRulePathBased3() *n.ApplicationGatewayRequestRoutingRule {
+	return &n.ApplicationGatewayRequestRoutingRule{
+		Name: to.StringPtr(RequestRoutingRuleName3),
+		ApplicationGatewayRequestRoutingRulePropertiesFormat: &n.ApplicationGatewayRequestRoutingRulePropertiesFormat{
+			// RuleType - Rule type. Possible values include: 'Basic', 'PathBasedRouting'
+			RuleType: n.PathBasedRouting,
+
+			// BackendAddressPool - Backend address pool resource of the application gateway.
+			BackendAddressPool: &n.SubResource{
+				ID: to.StringPtr("x/y/z/" + BackendAddressPoolName1),
+			},
+
+			// BackendHTTPSettings - Backend http settings resource of the application gateway.
+			BackendHTTPSettings: &n.SubResource{
+				ID: to.StringPtr("x/y/z/" + BackendHTTPSettingsName1),
+			},
+
+			// HTTPListener - Http listener resource of the application gateway.
+			HTTPListener: &n.SubResource{
+				ID: to.StringPtr("x/y/z/" + HTTPListenerWildcard),
+			},
+
+			// URLPathMap - URL path map resource of the application gateway.
+			URLPathMap: &n.SubResource{
+				ID: to.StringPtr("x/y/z/" + URLPathMapName3),
 			},
 
 			// RewriteRuleSet - Rewrite Rule Set resource in Basic rule of the application gateway.

--- a/pkg/tests/fixtures/targets.go
+++ b/pkg/tests/fixtures/targets.go
@@ -51,5 +51,10 @@ func GetAzureIngressProhibitedTargets() []*ptv1.AzureIngressProhibitedTarget {
 				},
 			},
 		},
+		{
+			Spec: ptv1.AzureIngressProhibitedTargetSpec{
+				Hostname: tests.WildcardHost1,
+			},
+		},
 	}
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
This PR updates the brownfield workflow to use hostnames field from the HTTP listener in App Gateway for determining the blacklists.
I have tried to handle both hostName and HostNames in the HTTP listener to maintain backend compatibility.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
