### PR TITLE
fix: correct the usage of scheme for recorder

### DIFF
--- a/cmd/appgw-ingress/utils.go
+++ b/cmd/appgw-ingress/utils.go
@@ -16,6 +16,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -23,7 +24,6 @@ import (
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/controllererrors"
-	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/scheme"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 )
 
@@ -112,9 +112,9 @@ func getVerbosity(flagVerbosity int, envVerbosity string) int {
 	return envVerbosityInt
 }
 
-func setIngressClass(customIngressClass string){
+func setIngressClass(customIngressClass string) {
 	if customIngressClass != "" {
 		annotations.ApplicationGatewayIngressClass = customIngressClass
 	}
-	
+
 }

--- a/cmd/appgw-ingress/utils.go
+++ b/cmd/appgw-ingress/utils.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/controllererrors"
+	agiccrdscheme "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/scheme"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 )
 
@@ -99,6 +100,9 @@ func getEventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {
 		Component: annotations.ApplicationGatewayIngressClass,
 		Host:      hostname,
 	}
+
+	s := scheme.Scheme
+	agiccrdscheme.AddToScheme(s)
 	return eventBroadcaster.NewRecorder(scheme.Scheme, source)
 }
 
@@ -116,5 +120,4 @@ func setIngressClass(customIngressClass string) {
 	if customIngressClass != "" {
 		annotations.ApplicationGatewayIngressClass = customIngressClass
 	}
-
 }

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -83,7 +83,6 @@ var (
 	ApplicationGatewayIngressClass = DefaultIngressClass
 )
 
-
 // ProtocolEnum is the type for protocol
 type ProtocolEnum int
 

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Test ingress annotation functions", func() {
 
 	Context("test IsApplicationGatewayIngress", func() {
 
-		BeforeEach(func(){
+		BeforeEach(func() {
 			ApplicationGatewayIngressClass = DefaultIngressClass
 		})
 

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -109,7 +109,7 @@ type EnvVariables struct {
 	AppGwResourceID             string
 	AppGwSubnetID               string
 	AuthLocation                string
-	IngressClass               string
+	IngressClass                string
 	WatchNamespace              string
 	UsePrivateIP                string
 	VerbosityLevel              string


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
This PR addresses the error when creating an event on ingress or pod object.
`no kind is registered for the type v1.Pod in scheme "pkg/runtime/scheme.go:101"`

The problem was due to using incorrect scheme. Scheme is used from the k8s package and the schemes coming from crd package are merged and provided to the recorder.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
