### PR TITLE
docs: Update deployment links in tutorial.general

### DIFF
--- a/docs/tutorials/tutorial.general.md
+++ b/docs/tutorials/tutorial.general.md
@@ -15,8 +15,8 @@ These tutorials help illustrate the usage of [Kubernetes Ingress Resources](http
 ## Prerequisites
 
 - Installed `ingress-azure` helm chart.
-  - [**Greenfield Deployment**](setup/install-new.md): If you are starting from scratch, refer to these installation instructions which outlines steps to deploy an AKS cluster with Application Gateway and install application gateway ingress controller on the AKS cluster.
-  - [**Brownfield Deployment**](setup/install-existing.md): If you have an existing AKS cluster and Application Gateway, refer to these instructions to install application gateway ingress controller on the AKS cluster.
+  - [**Greenfield Deployment**](../setup/install-new.md): If you are starting from scratch, refer to these installation instructions which outlines steps to deploy an AKS cluster with Application Gateway and install application gateway ingress controller on the AKS cluster.
+  - [**Brownfield Deployment**](../setup/install-existing.md): If you have an existing AKS cluster and Application Gateway, refer to these instructions to install application gateway ingress controller on the AKS cluster.
 - If you want to use HTTPS on this application, you will need a x509 certificate and its private key.
 
 ## Deploy `guestbook` application


### PR DESCRIPTION
The docs linked for deployment are up one directory.
Links updated to match the location of the files referenced

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [X] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
Clicking the links for deployment led to a Github 404 page or, if looking at the MkDocs site, a style-less 404.
Updated the link destination to use the (relative) parent directory to match where the files are located in the repository

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
No issue related to the links were found when searching the term "deployment" in the issues
