### PR TITLE
Added binding for APPGW_CONFIG_NAME_PREFIX in helm chart

### DIFF
--- a/docs/helm-values-documenation.md
+++ b/docs/helm-values-documenation.md
@@ -12,7 +12,7 @@
 | `appgw.name` | | Name of the Application Gateway. Example: `applicationgatewayd0f0` |
 | `appgw.environment`| `AZUREPUBLICCLOUD` | Specify which cloud environment. Possbile values: `AZURECHINACLOUD`, `AZUREGERMANCLOUD`, `AZUREPUBLICCLOUD`, `AZUREUSGOVERNMENTCLOUD` |
 | `appgw.shared` | false | This boolean flag should be defaulted to `false`. Set to `true` should you need a [Shared App Gateway](setup/install-existing.md#multi-cluster--shared-app-gateway). |
-| `appgw.prefix` | No prefix if empty | Prefix that should be used in the naming of the Application Gateway's sub-resources|
+| `appgw.subResourceNamePrefix` | No prefix if empty | Prefix that should be used in the naming of the Application Gateway's sub-resources|
 | `kubernetes.watchNamespace` | Watches all if empty | Specify the name space, which AGIC should watch. This could be a single string value, or a comma-separated list of namespaces. |
 | `kubernetes.rbac` | false | Specify true if kubernetes cluster is rbac enabled |
 | `armAuth.type` | | could be `aadPodIdentity` or `servicePrincipal` |

--- a/docs/helm-values-documenation.md
+++ b/docs/helm-values-documenation.md
@@ -12,6 +12,7 @@
 | `appgw.name` | | Name of the Application Gateway. Example: `applicationgatewayd0f0` |
 | `appgw.environment`| `AZUREPUBLICCLOUD` | Specify which cloud environment. Possbile values: `AZURECHINACLOUD`, `AZUREGERMANCLOUD`, `AZUREPUBLICCLOUD`, `AZUREUSGOVERNMENTCLOUD` |
 | `appgw.shared` | false | This boolean flag should be defaulted to `false`. Set to `true` should you need a [Shared App Gateway](setup/install-existing.md#multi-cluster--shared-app-gateway). |
+| `appgw.prefix` | No prefix if empty | Prefix that should be used in the naming of the agw internal resources|
 | `kubernetes.watchNamespace` | Watches all if empty | Specify the name space, which AGIC should watch. This could be a single string value, or a comma-separated list of namespaces. |
 | `kubernetes.rbac` | false | Specify true if kubernetes cluster is rbac enabled |
 | `armAuth.type` | | could be `aadPodIdentity` or `servicePrincipal` |

--- a/docs/helm-values-documenation.md
+++ b/docs/helm-values-documenation.md
@@ -12,7 +12,7 @@
 | `appgw.name` | | Name of the Application Gateway. Example: `applicationgatewayd0f0` |
 | `appgw.environment`| `AZUREPUBLICCLOUD` | Specify which cloud environment. Possbile values: `AZURECHINACLOUD`, `AZUREGERMANCLOUD`, `AZUREPUBLICCLOUD`, `AZUREUSGOVERNMENTCLOUD` |
 | `appgw.shared` | false | This boolean flag should be defaulted to `false`. Set to `true` should you need a [Shared App Gateway](setup/install-existing.md#multi-cluster--shared-app-gateway). |
-| `appgw.prefix` | No prefix if empty | Prefix that should be used in the naming of the agw internal resources|
+| `appgw.prefix` | No prefix if empty | Prefix that should be used in the naming of the Application Gateway's sub-resources|
 | `kubernetes.watchNamespace` | Watches all if empty | Specify the name space, which AGIC should watch. This could be a single string value, or a comma-separated list of namespaces. |
 | `kubernetes.rbac` | false | Specify true if kubernetes cluster is rbac enabled |
 | `armAuth.type` | | could be `aadPodIdentity` or `servicePrincipal` |

--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -33,8 +33,8 @@ data:
   APPGW_RESOURCE_GROUP:  {{ .Values.appgw.resourceGroup | quote }}
   APPGW_NAME:            {{ .Values.appgw.name | quote }}
 
-  {{- if .Values.appgw.prefix }}
-  APPGW_CONFIG_NAME_PREFIX: {{ .Values.appgw.prefix | quote }}
+  {{- if .Values.appgw.subResourceNamePrefix }}
+  APPGW_CONFIG_NAME_PREFIX: {{ .Values.appgw.subResourceNamePrefix | quote }}
   {{- else }}
 
   {{- if or .Values.appgw.subnetID .Values.appgw.subnetName .Values.appgw.subnetPrefix }}

--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -33,6 +33,10 @@ data:
   APPGW_RESOURCE_GROUP:  {{ .Values.appgw.resourceGroup | quote }}
   APPGW_NAME:            {{ .Values.appgw.name | quote }}
 
+  {{- if .Values.appgw.prefix }}
+  APPGW_CONFIG_NAME_PREFIX: {{ .Values.appgw.prefix | quote }}
+  {{- else }}
+
   {{- if or .Values.appgw.subnetID .Values.appgw.subnetName .Values.appgw.subnetPrefix }}
   #if subnet is provided, we treat it as a create case
   APPGW_ENABLE_DEPLOY:   "true"

--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -35,7 +35,7 @@ kubernetes:
 #   name: myApplicationGateway
 #   # Whether to force private IP for all the listeners on Application Gateway
 #   usePrivateIP: false
-#   prefix: "myPrefix"
+#   subResourceNamePrefix: "myPrefix"
 
 ################################################################################
 # Specify the authentication with Azure Resource Manager

--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -35,6 +35,7 @@ kubernetes:
 #   name: myApplicationGateway
 #   # Whether to force private IP for all the listeners on Application Gateway
 #   usePrivateIP: false
+#   prefix: "myPrefix"
 
 ################################################################################
 # Specify the authentication with Azure Resource Manager

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -36,7 +36,7 @@ appgw: {}
 #   name: myApplicationGateway
 #   # Whether to force private IP for all the listeners on Application Gateway
 #   usePrivateIP: false
-#   prefix: "myPrefix"
+#   subResourceNamePrefix: "myPrefix"
 
 ################################################################################
 # Specify the authentication with Azure Resource Manager

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -36,6 +36,7 @@ appgw: {}
 #   name: myApplicationGateway
 #   # Whether to force private IP for all the listeners on Application Gateway
 #   usePrivateIP: false
+#   prefix: "myPrefix"
 
 ################################################################################
 # Specify the authentication with Azure Resource Manager


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
When work with agic in shared mode, is a normal scenario when you have 2 or more environment behind the same agw and promote from one to the next (dev -> uat -> prod).  In this case, the namespaces and services have the same naming, so all the agw internal resources are in conflict between them in the different environments. 
Agic supports the use of prefix that is added in each resource but that setting is not editable using helm. 
This PR added support to manage the prefix in order to allow share the same agw between different clusters those have the same application in different environments.

<!-- Please add a brief description of the changes made in this PR -->

## Fixes
#957
<!-- Please mention #issues that are fixed in this PR -->
