### PR TITLE
Fixed broken chart and added a check for helm chart during the integration

### DIFF
--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -76,6 +76,10 @@ steps:
   workingDirectory: '$(modulePath)'
   displayName: 'Run unit tests with code coverage'
 
+- script: |
+    helm lint $(Build.SourcesDirectory)/helm/ingress-azure
+  displayName: 'Lint helm chart'
+
 - task: PublishTestResults@2
   continueOnError: true
   condition: succeededOrFailed()

--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -77,7 +77,8 @@ steps:
   displayName: 'Run unit tests with code coverage'
 
 - script: |
-    helm lint $(Build.SourcesDirectory)/helm/ingress-azure
+    helm lint ./helm/ingress-azure
+  workingDirectory: '$(modulePath)'    
   displayName: 'Helm lint'
 
 - task: PublishTestResults@2

--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -78,7 +78,7 @@ steps:
 
 - script: |
     helm lint $(Build.SourcesDirectory)/helm/ingress-azure
-  displayName: 'Lint helm chart'
+  displayName: 'Helm lint'
 
 - task: PublishTestResults@2
   continueOnError: true

--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -35,7 +35,7 @@ data:
 
   {{- if .Values.appgw.subResourceNamePrefix }}
   APPGW_CONFIG_NAME_PREFIX: {{ .Values.appgw.subResourceNamePrefix | quote }}
-  {{- else }}
+  {{- end }}
 
   {{- if or .Values.appgw.subnetID .Values.appgw.subnetName .Values.appgw.subnetPrefix }}
   #if subnet is provided, we treat it as a create case


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
As @rbickel mentioned in the commit, https://github.com/Azure/application-gateway-kubernetes-ingress/commit/b3464c9a540aa03984fa8be1347769ac1d788f2c#r41249662,  I introduced an error that breaks the chart. 
This PR fix the broken chart and add a task during the integration to lint the chart in order to detect errors  before the merge and to block it.
<!-- Please add a brief description of the changes made in this PR -->

## Fixes
https://github.com/Azure/application-gateway-kubernetes-ingress/commit/b3464c9a540aa03984fa8be1347769ac1d788f2c#r41249662
<!-- Please mention #issues that are fixed in this PR -->
