### PR TITLE
docs: Update Windows containers equivalent sleep command

### DIFF
--- a/docs/how-tos/minimize-downtime-during-deployments.md
+++ b/docs/how-tos/minimize-downtime-during-deployments.md
@@ -55,7 +55,7 @@ spec:
 ```
 
 
-> Note: The "sleep" command assumes the container is based on Linux. For Windows containers the equivalent command is "timeout".
+> Note: The "sleep" command assumes the container is based on Linux. For Windows containers the equivalent command is `["powershell.exe","-c","sleep","90"]`.
 
 The addition of the `preStop` container life cycle hook will:
   - delay Kubernetes sending `SIGTERM` to the container by 90 seconds, but put the pod immediately in `Terminating` state


### PR DESCRIPTION
## Checklist
- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

With the timeout command I got the next error:

`Exec lifecycle hook ([timeout 90]) for Container "<pod-name>" in Pod "<pod-name>-8654f6d665-wnwk7_universidades(e0af2c47-c900-4d35-9209-7723fcc3681b)" failed - error: command 'timeout 90' exited with 1: ERROR: Input redirection is not supported, exiting the process immediately.
 , message: "ERROR: Input redirection is not supported, exiting the process immediately.\r\n"`

## Fixes

None
