### PR TITLE
Fixing GreenDeployment command error for appId=$(jq -re ".appId" auth.json)

### DIFF
--- a/docs/setup/install-new.md
+++ b/docs/setup/install-new.md
@@ -29,8 +29,8 @@ Follow the steps below to create an Azure Active Directory (AAD) [service princi
 1. Create AD service principal ([Read more about RBAC](https://docs.microsoft.com/en-us/azure/role-based-access-control/overview)). Paste the following lines in your [Azure Cloud Shell](https://shell.azure.com/):
     ```bash
     az ad sp create-for-rbac --skip-assignment -o json > auth.json
-    appId=$(jq -r ".appId" auth.json)
-    password=$(jq -r ".password" auth.json)
+    $appId=$(jq -r ".appId" auth.json)
+    $password=$(jq -r ".password" auth.json)
     ```
         These commands will create `appId` and `password` bash variables, which will be used in the steps below. You can view the value of these with `echo $appId` and `echo $password`.
 


### PR DESCRIPTION
Running: appId=$(jq -re ".appId" auth.json) gives error: 

The term 'appId=$(jq -re ".appId" auth.json)' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again

Fixing it

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [ ] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
