### PR TITLE
fix: choose backend port in case backend port name is resolved to multiple backend ports

### DIFF
--- a/pkg/appgw/backendhttpsettings_test.go
+++ b/pkg/appgw/backendhttpsettings_test.go
@@ -6,6 +6,8 @@
 package appgw
 
 import (
+	"strconv"
+
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 
 	"strings"
@@ -121,5 +123,62 @@ var _ = Describe("Test the creation of Backend http settings from Ingress defini
 			checkTrustedRootCertificateAnnotation("Https", "rootcert1,rootcert2", annotations.HTTPS, n.HTTPS)
 		})
 
+	})
+})
+
+var _ = Describe("Test the creation of Backend http settings from Ingress definition with target port in Service contains a name which resolved to multiple ports of PODs", func() {
+	// Setup
+	configBuilder := newConfigBuilderFixture(nil)
+
+	// contains endpoint for the service ports. Multiple ports present with name as https-port
+	endpoint := tests.NewEndpointsFixtureWithSameNameMultiplePorts()
+
+	// service contains multiple service ports with port as 80, 443, etc and target port as 9876, pod port name
+	service := tests.NewServiceFixture(*tests.NewServicePortsFixture()...)
+
+	pod := tests.NewPodTestFixture(service.Namespace, "mybackend")
+
+	// Ingress contains two rules with service port as 80 and 443
+	ingress := tests.NewIngressFixture()
+
+	_ = configBuilder.k8sContext.Caches.Pods.Add(&pod)
+	_ = configBuilder.k8sContext.Caches.Endpoints.Add(endpoint)
+	_ = configBuilder.k8sContext.Caches.Service.Add(service)
+	_ = configBuilder.k8sContext.Caches.Ingress.Add(ingress)
+
+	cbCtx := &ConfigBuilderContext{
+		IngressList:           []*v1beta1.Ingress{ingress},
+		ServiceList:           []*v1.Service{service},
+		DefaultAddressPoolID:  to.StringPtr("xx"),
+		DefaultHTTPSettingsID: to.StringPtr("yy"),
+	}
+
+	// Action
+	configBuilder.mem = memoization{}
+	configBuilder.newProbesMap(cbCtx)
+	httpSettings, _, _, _ := configBuilder.getBackendsAndSettingsMap(cbCtx)
+
+	Context("test backend ports for the http settings", func() {
+		expectedhttpSettingsLen := 3
+
+		It("checking http settings backend port", func() {
+			Expect(expectedhttpSettingsLen).To(Equal(len(httpSettings)), "httpSetting count %d should be %d", len(httpSettings), expectedhttpSettingsLen)
+
+			for _, setting := range httpSettings {
+				if *setting.Name == DefaultBackendHTTPSettingsName {
+					Expect(int32(80)).To(Equal(*setting.Port), "default backend port %d should be 80", *setting.Port)
+				} else if strings.Contains(*setting.Name, strconv.Itoa(int(tests.ContainerPort))) {
+					// http setting for ingress with service port as 80
+					Expect(tests.ContainerPort).To(Equal(*setting.Port), "setting %s backend port %d should be 9876", *setting.Name, *setting.Port)
+				} else if strings.Contains(*setting.Name, "75") {
+					// http setting for the ingress with service port as 443. Target port is https-port which resolves to multiple backend port
+					// and the smallest backend port is chosen
+					Expect(int32(75)).To(Equal(*setting.Port), "setting %s backend port %d should be 75", *setting.Name, *setting.Port)
+				} else {
+					// Dummy Failure, This should not happen
+					Expect(23).To(Equal(75), "setting %s is not expected to be created", *setting.Name)
+				}
+			}
+		})
 	})
 })

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -457,27 +457,27 @@ func NewEndpointsFixtureWithSameNameMultiplePorts() *v1.Endpoints {
 				Ports: []v1.EndpointPort{
 					{
 						Protocol: v1.ProtocolTCP,
-						Name:     "--service-https-port--",
+						Name:     ServiceHTTPSPort,
 						Port:     5000,
 					},
 					{
 						Protocol: v1.ProtocolTCP,
-						Name:     "--service-https-port--",
+						Name:     ServiceHTTPSPort,
 						Port:     80,
 					},
 					{
 						Protocol: v1.ProtocolTCP,
-						Name:     "--service-https-port--",
+						Name:     ServiceHTTPSPort,
 						Port:     81,
 					},
 					{
 						Protocol: v1.ProtocolTCP,
-						Name:     "--service-https-port--",
+						Name:     ServiceHTTPSPort,
 						Port:     4999,
 					},
 					{
 						Protocol: v1.ProtocolTCP,
-						Name:     "--service-https-port--",
+						Name:     ServiceHTTPSPort,
 						Port:     75,
 					},
 				},

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -425,6 +425,68 @@ func NewServiceFixture(servicePorts ...v1.ServicePort) *v1.Service {
 }
 
 // NewEndpointsFixture makes a new endpoint for testing
+func NewEndpointsFixtureWithSameNameMultiplePorts() *v1.Endpoints {
+	return &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceName,
+			Namespace: Namespace,
+		},
+		Subsets: []v1.EndpointSubset{
+			{
+				// IP addresses which offer the related ports that are marked as ready. These endpoints
+				// should be considered safe for load balancers and clients to utilize.
+				// +optional
+				Addresses: []v1.EndpointAddress{
+					{
+						IP: "10.9.8.7",
+						// The Hostname of this endpoint
+						// +optional
+						Hostname: "www.contoso.com",
+						// Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.
+						// +optional
+						NodeName: to.StringPtr(NodeName),
+					},
+				},
+				// IP addresses which offer the related ports but are not currently marked as ready
+				// because they have not yet finished starting, have recently failed a readiness check,
+				// or have recently failed a liveness check.
+				// +optional
+				NotReadyAddresses: []v1.EndpointAddress{},
+				// Port numbers available on the related IP addresses.
+				// +optional
+				Ports: []v1.EndpointPort{
+					{
+						Protocol: v1.ProtocolTCP,
+						Name:     "--service-https-port--",
+						Port:     5000,
+					},
+					{
+						Protocol: v1.ProtocolTCP,
+						Name:     "--service-https-port--",
+						Port:     80,
+					},
+					{
+						Protocol: v1.ProtocolTCP,
+						Name:     "--service-https-port--",
+						Port:     81,
+					},
+					{
+						Protocol: v1.ProtocolTCP,
+						Name:     "--service-https-port--",
+						Port:     4999,
+					},
+					{
+						Protocol: v1.ProtocolTCP,
+						Name:     "--service-https-port--",
+						Port:     75,
+					},
+				},
+			},
+		},
+	}
+}
+
+// NewEndpointsFixture makes a new endpoint for testing
 func NewEndpointsFixture() *v1.Endpoints {
 	return &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -424,7 +424,7 @@ func NewServiceFixture(servicePorts ...v1.ServicePort) *v1.Service {
 	}
 }
 
-// NewEndpointsFixture makes a new endpoint for testing
+// NewEndpointsFixtureWithSameNameMultiplePorts makes a new endpoint for testing
 func NewEndpointsFixtureWithSameNameMultiplePorts() *v1.Endpoints {
 	return &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Updating logic to choose single backend port in case backend port name is resolved to multiple backend ports retrieved by endpoints

Currently, if service target endpoint is not provided, endpoints api is called to see what are the backend ports and in case multiple backend ports exists with same name, AGIC stops processing the update and PUT will not be issued to AppGw. Only way to fix this problem is deleting the ingress which lead to this problem.

After this changes, in case there are multiple target backend ports, smallest backend port is chosen to create backend http settings.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

Currently, if service target endpoint is not provided, endpoints api is called to see what are the backend ports and in case multiple backend ports exists with same name, AGIC stops processing the update and PUT will not be issued to AppGw. Only way to fix this problem is deleting the ingress which lead to this problem.

## Fixes

After this changes, in case there are multiple target backend ports, smallest backend port is chosen to create backend http settings.

