### PR TITLE
New Annotation: backend-probe-path for custom Healthprobe paths

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -13,6 +13,7 @@ For an Ingress resource to be observed by AGIC it **must be annotated** with `ku
 | [appgw.ingress.kubernetes.io/backend-path-prefix](#backend-path-prefix) | `string` | `nil` | |
 | [appgw.ingress.kubernetes.io/backend-hostname](#backend-hostname) | `string` | `nil` | |
 | [appgw.ingress.kubernetes.io/backend-protocol](#backend-protocol) | `string` | `http` | `http`, `https` |
+| [appgw.ingress.kubernetes.io/backend-probe-path](#backend-probe-path) | `string` |  | `string` |
 | [appgw.ingress.kubernetes.io/ssl-redirect](#ssl-redirect) | `bool` | `false` | |
 | [appgw.ingress.kubernetes.io/appgw-ssl-certificate](#appgw-ssl-certificate) | `string` | `nil` | |
 | [appgw.ingress.kubernetes.io/appgw-trusted-root-certificate](#appgw-trusted-root-certificate) | `string` | `nil` | |
@@ -116,6 +117,38 @@ spec:
         backend:
           serviceName: go-server-service
           servicePort: 443
+```
+
+## Backend Probe Path
+
+This annotation allows us to specify a custom path that the Application Gateway should use to probe the health of an endpoint.
+
+> **Note**
+The argument has to be a valid path and is checked against the regular expression `^\/[/.a-zA-Z0-9-]+$`. If it does not match, it defaults to the path `/`.
+
+### Usage
+```yaml
+appgw.ingress.kubernetes.io/backend-probe-path: "/path/to/healthcheck"
+```
+
+### Example
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: go-server-ingress-timeout
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/backend-probe-path: "/path/to/healthcheck"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /hello/
+        backend:
+          serviceName: go-server-service
+          servicePort: 80
 ```
 
 ## SSL Redirect
@@ -418,7 +451,7 @@ appgw.ingress.kubernetes.io/waf-policy-for-path: "/subscriptions/abcd/resourceGr
 ```
 
 ### Example
-The example below will apply the WAF policy 
+The example below will apply the WAF policy
 ```yaml
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -436,7 +469,7 @@ spec:
         backend:
           serviceName: ad-server
           servicePort: 80
-          
+
       - path: /auth
         backend:
           serviceName: auth-server

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -27,6 +27,9 @@ const (
 	// Null means Host specified in the request to Application Gateway is used to connect to the backend.
 	BackendHostNameKey = ApplicationGatewayPrefix + "/backend-hostname"
 
+	// BackendProbePathKey defines a custom path that is used in the health check probes.
+	BackendProbePathKey = ApplicationGatewayPrefix + "/backend-probe-path"
+
 	// CookieBasedAffinityKey defines the key to enable/disable cookie based affinity for client connection.
 	CookieBasedAffinityKey = ApplicationGatewayPrefix + "/cookie-based-affinity"
 
@@ -130,6 +133,11 @@ func BackendPathPrefix(ing *v1beta1.Ingress) (string, error) {
 // BackendHostName override hostname
 func BackendHostName(ing *v1beta1.Ingress) (string, error) {
 	return parseString(ing, BackendHostNameKey)
+}
+
+// BackendProbePath override Health Probe path
+func BackendProbePath(ing *v1beta1.Ingress) (string, error) {
+	return parseString(ing, BackendProbePathKey)
 }
 
 // GetAppGwSslCertificate refer to appgw installed certificate

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Test ingress annotation functions", func() {
 		"appgw.ingress.kubernetes.io/connection-draining-timeout":    "3456",
 		"appgw.ingress.kubernetes.io/backend-path-prefix":            "prefix-here",
 		"appgw.ingress.kubernetes.io/backend-hostname":               "www.backend.com",
+		"appgw.ingress.kubernetes.io/backend-probe-path":             "/this/is/a/testpath",
 		"appgw.ingress.kubernetes.io/hostname-extension":             "www.bye.com, www.b*.com",
 		"appgw.ingress.kubernetes.io/appgw-ssl-certificate":          "appgw-cert",
 		"appgw.ingress.kubernetes.io/appgw-trusted-root-certificate": "appgw-root-cert1,appgw-root-cert2",
@@ -171,6 +172,20 @@ var _ = Describe("Test ingress annotation functions", func() {
 			actual, err := BackendHostName(ing)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).To(Equal("www.backend.com"))
+		})
+	})
+
+	Context("test BackendProbePath", func() {
+		It("returns error when ingress has no annotations", func() {
+			ing := &v1beta1.Ingress{}
+			actual, err := BackendProbePath(ing)
+			Expect(err).To(HaveOccurred())
+			Expect(actual).To(Equal(""))
+		})
+		It("returns the hostname", func() {
+			actual, err := BackendProbePath(ing)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal("/this/is/a/testpath"))
 		})
 	})
 

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -162,6 +162,12 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 		probe.Path = to.StringPtr(strings.TrimRight(*probe.Path, "*"))
 	}
 
+	if customPath, err := annotations.BackendProbePath(backendID.Ingress); err == nil {
+		// TODO: validate, that customPath is a path
+		probe.Path = to.StringPtr(customPath)
+		glog.V(5).Infof("Created custom path %s for ingress %s/%s probe", *probe.Path, backendID.Ingress.Namespace, backendID.Ingress.Name)
+	}
+
 	// For V1 gateway, port property is not supported
 	if c.appGw.Sku.Tier == n.ApplicationGatewayTierStandard || c.appGw.Sku.Tier == n.ApplicationGatewayTierWAF {
 		probe.Port = nil

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -164,7 +164,7 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 	}
 
 	if customPath, err := annotations.BackendProbePath(backendID.Ingress); err == nil {
-		if matched, reErr := regexp.MatchString(`^\/[/.a-zA-Z0-9-]+$`, customPath); matched == true && reErr == nil {
+		if matched, reErr := regexp.MatchString(`^\/([.a-zA-Z0-9-_~\?\#\[\]\@\:\$\&\(\)\*\+\,\;\=]+/??)*$`, customPath); matched == true && reErr == nil {
 			probe.Path = to.StringPtr(customPath)
 			glog.V(5).Infof("Created custom path %s for ingress %s/%s probe", *probe.Path, backendID.Ingress.Namespace, backendID.Ingress.Name)
 		} else {

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -164,11 +164,12 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 	}
 
 	if customPath, err := annotations.BackendProbePath(backendID.Ingress); err == nil {
-		if matched, reErr := regexp.MatchString(`^((?:[^/]*/)*)(.*)$`, customPath); matched == true && reErr == nil {
+		if matched, reErr := regexp.MatchString(`^\/[/.a-zA-Z0-9-]+$`, customPath); matched == true && reErr == nil {
 			probe.Path = to.StringPtr(customPath)
 			glog.V(5).Infof("Created custom path %s for ingress %s/%s probe", *probe.Path, backendID.Ingress.Namespace, backendID.Ingress.Name)
 		} else {
-			glog.V(5).Infof("Custom path %s for ingress %s/%s probe is not valid! Using %s instead.", customPath, backendID.Ingress.Namespace, backendID.Ingress.Name, *probe.Path)
+			probe.Path = to.StringPtr("/")
+			glog.V(5).Infof("Custom path %s for ingress %s/%s probe is not valid! Using '/' instead.", customPath, backendID.Ingress.Namespace, backendID.Ingress.Name)
 		}
 	}
 

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -169,7 +169,7 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 			glog.V(5).Infof("Created custom path %s for ingress %s/%s probe", *probe.Path, backendID.Ingress.Namespace, backendID.Ingress.Name)
 		} else {
 			probe.Path = to.StringPtr("/")
-			glog.V(5).Infof("Custom path %s for ingress %s/%s probe is not valid! Using '/' instead.", customPath, backendID.Ingress.Namespace, backendID.Ingress.Name)
+			glog.Warningf("Custom path %s for ingress %s/%s probe is not valid! Using '/' instead.", customPath, backendID.Ingress.Namespace, backendID.Ingress.Name)
 		}
 	}
 

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -198,6 +198,41 @@ func NewIngressFixture() *v1beta1.Ingress {
 	}
 }
 
+// NewAnnotatedIngressFixture makes a new Ingress for testing that supports configurable annotations
+func NewAnnotatedIngressFixture(annotationMap map[string]string) *v1beta1.Ingress {
+	be80 := NewIngressBackendFixture(ServiceName, 80)
+	be443 := NewIngressBackendFixture(ServiceName, 443)
+
+	return &v1beta1.Ingress{
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				NewIngressRuleFixture(Host, URLPath1, *be80),
+				NewIngressRuleFixture(Host, URLPath2, *be443),
+			},
+			TLS: []v1beta1.IngressTLS{
+				{
+					Hosts: []string{
+						"www.contoso.com",
+						"ftp.contoso.com",
+						Host,
+						"",
+					},
+					SecretName: NameOfSecret,
+				},
+				{
+					Hosts:      []string{},
+					SecretName: NameOfSecret,
+				},
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotationMap,
+			Namespace:   Namespace,
+			Name:        Name,
+		},
+	}
+}
+
 // NewIngressFixtureSingleSlashPath makes a new Ingress with "/" and "/*" as ingress rule path for testing
 func NewIngressFixtureSingleSlashPath() *v1beta1.Ingress {
 	be80 := NewIngressBackendFixture(ServiceName, 80)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

This PR adds a new annotion `appgw.ingress.kubernetes.io/backend-probe-path: "/path/to/healthcheck"`. It addresses the Issue #906. If the annotation is set, then the Path of the Healthprobe is overwritten. If no valid path (e.g. containing spaces), then the healthprobe path defaults to `/`.

The PR coverage contains documentation and tests.

## Fixes

#906
