### PR TITLE
Minor clarification to documentation, fixing references to match the actual variables’ casing convention

### DIFF
--- a/docs/setup/install-existing.md
+++ b/docs/setup/install-existing.md
@@ -154,7 +154,7 @@ You can use [Cloud Shell](https://shell.azure.com/) to install the AGIC Helm pac
     nano helm-config.yaml
     ```
 
-    **NOTE:** The `<identity-resource-id>` and `<identity-client-id>` are the properties of the Azure AD Identity you setup in the previous section. You can retrieve this information by running the following command: `az identity show -g <resourcegroup> -n <identity-name>`, where `<resourcegroup>` is the resource group in which the top level AKS cluster object, Application Gateway and Managed Identify are deployed.
+    **NOTE:** The `<identityResourceId>` and `<identityClientId>` are the properties of the Azure AD Identity you setup in the previous section. You can retrieve this information by running the following command: `az identity show -g <resourcegroup> -n <identity-name>`, where `<resourcegroup>` is the resource group in which the top level AKS cluster object, Application Gateway and Managed Identify are deployed.
 
 1. Install Helm chart `application-gateway-kubernetes-ingress` with the `helm-config.yaml` configuration from the previous step
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [X] The title of the PR is clear and informative
- [X] If applicable, the changes made in the PR have proper test coverage
  (not applicable)
- [X] Issues addressed by the PR are mentioned in the description followed by `Fixes`.
  (also not applicable)

## Description

<!-- Please add a brief description of the changes made in this PR -->

The file in question, [`docs/examples/sample-helm-config.yaml`][^1], uses camelCase for these pseudo-variables.

**Alternatively**, the `sample-helm-config.yaml` could be updated to match the kebab-case used in the documentation. I assume the change I made is what's intended, but I absolutely don't have a strong opinion. I just noticed a minor inconsistency while following the docs and figured I could contribute a fix. 🙂

[^1]: https://github.com/Azure/application-gateway-kubernetes-ingress/blob/762b7fd2a1bc9058be55d5dec6159409e98877ff/docs/examples/sample-helm-config.yaml


## Fixes

<!-- Please mention #issues that are fixed in this PR -->

(Not applicable)
