### PR TITLE
Helm Chart - Give the ability for custom annotations on agic pod

### DIFF
--- a/helm/ingress-azure/Chart.yaml
+++ b/helm/ingress-azure/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: Use Azure Application Gateway as the ingress for an Azure Kubernetes Service cluster.
 name: ingress-azure
-version: 1.2.0
+version: 1.2.1

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         checksum/config: {{ print .Values | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.kubernetes.httpServicePort | quote}}
+        {{- if .Values.appgw.annotations }}
+{{ toYaml .Values.appgw.annotations | indent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "application-gateway-kubernetes-ingress.serviceaccountname" . }}
       containers:

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -37,6 +37,9 @@ appgw: {}
 #   # Whether to force private IP for all the listeners on Application Gateway
 #   usePrivateIP: false
 #   subResourceNamePrefix: "myPrefix"
+#   # Any extra annotations needed for the ingress controller pod
+#   annotations: 
+#     example.io/myAnnotation: annotation
 
 ################################################################################
 # Specify the authentication with Azure Resource Manager


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

Many services e.g. datadog use custom annotations on pods to provide
extra functionality. This change to the helm chart allows you to specify
such annotations.

If it is not set you get the default annotations and if it is set you
get the default annotations plus the extras you specified

## Fixes

 - #1021

