### PR TITLE
fix: adjust security context to maintain access to azure.json

### DIFF
--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
         prometheus.io/port: {{ .Values.kubernetes.httpServicePort | quote}}
     spec:
       serviceAccountName: {{ template "application-gateway-kubernetes-ingress.serviceaccountname" . }}
+      securityContext:        
+        runAsUser: 0
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -66,8 +68,9 @@ spec:
         - configMapRef:
             name: {{ template "application-gateway-kubernetes-ingress.configmapname" . }}
         volumeMounts:
-        - mountPath: /etc/appgw/azure.json
-          name: azure
+        - name: azure
+          mountPath: /etc/appgw/
+          readOnly: true
         {{- if .Values.armAuth }}
         {{- if eq .Values.armAuth.type "servicePrincipal"}}
         - name: networking-appgw-k8s-azure-service-principal-mount
@@ -78,8 +81,8 @@ spec:
       volumes:
       - name: azure
         hostPath:
-          path: /etc/kubernetes/azure.json
-          type: File
+          path: /etc/kubernetes/
+          type: Directory
       {{- if .Values.armAuth }}
       {{- if eq .Values.armAuth.type "servicePrincipal"}}
       - name: networking-appgw-k8s-azure-service-principal-mount


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
This PR adjusts the security context so that AGIC pod has access to azure.json.
Since, azure.json is used get vnet/route table/service principal information.
Figure out a better way to find this information without being root user.

[E2E run](https://dev.azure.com/azure/application-gateway-kubernetes-ingress/_releaseProgress?_a=release-environment-extension&releaseId=417&environmentId=911&extensionId=ms.vss-test-web.test-result-in-release-environment-editor-tab)
![image](https://user-images.githubusercontent.com/5294363/96931436-2d135100-1472-11eb-9b05-5e552fa8908f.png):

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
