### PR TITLE
e2e: prohibited using helm, use azure.json

### DIFF
--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -29,8 +29,8 @@ data:
 {{- if .Values.appgw.applicationGatewayID }}
   APPGW_RESOURCE_ID: {{ .Values.appgw.applicationGatewayID | quote }}
 {{- else }}
-  APPGW_SUBSCRIPTION_ID: {{ .Values.appgw.subscriptionId | quote }}
-  APPGW_RESOURCE_GROUP:  {{ .Values.appgw.resourceGroup | quote }}
+  APPGW_SUBSCRIPTION_ID: {{ default "" .Values.appgw.subscriptionId | quote }}
+  APPGW_RESOURCE_GROUP:  {{ default "" .Values.appgw.resourceGroup | quote }}
   APPGW_NAME:            {{ .Values.appgw.name | quote }}
 
   {{- if or .Values.appgw.subnetID .Values.appgw.subnetName .Values.appgw.subnetPrefix }}

--- a/scripts/e2e/helm-config-with-prohibited-rules.yaml
+++ b/scripts/e2e/helm-config-with-prohibited-rules.yaml
@@ -1,0 +1,13 @@
+appgw:
+  shared: true
+  prohibitedTargets:
+    - name: prohibit-backend-ns
+      hostname: brownfield-blacklist-ns.host
+      paths:
+        - "/blacklist/*"
+
+armAuth:
+  type: aadPodIdentity
+
+rbac:
+  enabled: true


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
This PR adds e2e for 2 cases:
1. Use the new helm config way of adding prohibited target
2. Make sure that AGIC is able to use azure.json by just providing gateway name and no other information. AGIC should get remaining info from azure.json.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
