### PR TITLE
e2e: validate subResourceNamePrefix is used to name appgw sub-resources

### DIFF
--- a/scripts/e2e/cmd/runner/environment.go
+++ b/scripts/e2e/cmd/runner/environment.go
@@ -31,6 +31,9 @@ const (
 
 	// AzureAuthLocationVarName is the name of the AZURE_AUTH_LOCATION
 	AzureAuthLocationVarName = "AZURE_AUTH_LOCATION"
+
+	// SubResourceNamePrefixVarName is the name of the subResourceNamePrefix
+	SubResourceNamePrefixVarName = "subResourceNamePrefix"
 )
 
 // EnvVariables is a struct storing values for environment variables.
@@ -47,12 +50,13 @@ type EnvVariables struct {
 // GetEnv returns values for defined environment variables for Ingress Controller.
 func GetEnv() *EnvVariables {
 	return &EnvVariables{
-		SubscriptionID:     os.Getenv(SubscriptionIDVarName),
-		ResourceGroupName:  os.Getenv(ResourceGroupNameVarName),
-		AppGwName:          os.Getenv(AppGwNameVarName),
-		KubeConfigFilePath: GetEnvironmentVariable(KubeConfigVarName, "~/.kube/config", nil),
-		ObjectID:           os.Getenv(ObjectIDVarName),
-		AzureAuthLocation:  os.Getenv(AzureAuthLocationVarName),
+		SubscriptionID:        os.Getenv(SubscriptionIDVarName),
+		ResourceGroupName:     os.Getenv(ResourceGroupNameVarName),
+		AppGwName:             os.Getenv(AppGwNameVarName),
+		SubResourceNamePrefix: os.Getenv(SubResourceNamePrefixVarName),
+		KubeConfigFilePath:    GetEnvironmentVariable(KubeConfigVarName, "~/.kube/config", nil),
+		ObjectID:              os.Getenv(ObjectIDVarName),
+		AzureAuthLocation:     os.Getenv(AzureAuthLocationVarName),
 	}
 }
 

--- a/scripts/e2e/cmd/runner/helper.go
+++ b/scripts/e2e/cmd/runner/helper.go
@@ -255,8 +255,7 @@ func applyYaml(clientset *kubernetes.Clientset, namespaceName string, fileName s
 			} else {
 				return errors.New("namespace is not defined for secrets")
 			}
-		}
-		if ingress, ok := objs.(*v1beta1.Ingress); ok {
+		} else if ingress, ok := objs.(*v1beta1.Ingress); ok {
 			nm := ingress.Namespace
 			if len(nm) == 0 && len(namespaceName) != 0 {
 				if _, err := clientset.ExtensionsV1beta1().Ingresses(namespaceName).Create(ingress); err != nil {
@@ -269,8 +268,7 @@ func applyYaml(clientset *kubernetes.Clientset, namespaceName string, fileName s
 			} else {
 				return errors.New("namespace is not defined for ingress")
 			}
-		}
-		if service, ok := objs.(*v1.Service); ok {
+		} else if service, ok := objs.(*v1.Service); ok {
 			nm := service.Namespace
 			if len(nm) == 0 && len(namespaceName) != 0 {
 				if _, err := clientset.CoreV1().Services(namespaceName).Create(service); err != nil {
@@ -283,8 +281,7 @@ func applyYaml(clientset *kubernetes.Clientset, namespaceName string, fileName s
 			} else {
 				return errors.New("namespace is not defined for service")
 			}
-		}
-		if deployment, ok := objs.(*appsv1.Deployment); ok {
+		} else if deployment, ok := objs.(*appsv1.Deployment); ok {
 			nm := deployment.Namespace
 			if len(nm) == 0 && len(namespaceName) != 0 {
 				if _, err := clientset.AppsV1().Deployments(namespaceName).Create(deployment); err != nil {
@@ -297,8 +294,7 @@ func applyYaml(clientset *kubernetes.Clientset, namespaceName string, fileName s
 			} else {
 				return errors.New("namespace is not defined for deployment")
 			}
-		}
-		if cm, ok := objs.(*v1.ConfigMap); ok {
+		} else if cm, ok := objs.(*v1.ConfigMap); ok {
 			nm := cm.Namespace
 			if len(nm) == 0 && len(namespaceName) != 0 {
 				if _, err := clientset.CoreV1().ConfigMaps(namespaceName).Create(cm); err != nil {
@@ -311,8 +307,8 @@ func applyYaml(clientset *kubernetes.Clientset, namespaceName string, fileName s
 			} else {
 				return errors.New("namespace is not defined for configmaps")
 			}
-		}
-		if pod, ok := objs.(*v1.Pod); ok {
+			continue
+		} else if pod, ok := objs.(*v1.Pod); ok {
 			nm := pod.Namespace
 			if len(nm) == 0 && len(namespaceName) != 0 {
 				if _, err := clientset.CoreV1().Pods(namespaceName).Create(pod); err != nil {
@@ -325,9 +321,10 @@ func applyYaml(clientset *kubernetes.Clientset, namespaceName string, fileName s
 			} else {
 				return errors.New("namespace is not defined for pods")
 			}
+			continue
+		} else {
+			return fmt.Errorf("unable to apply YAML. Unknown object type: %v", objs)
 		}
-
-		return fmt.Errorf("unable to apply YAML. Unknown object type: %v", objs)
 	}
 	return nil
 }
@@ -463,4 +460,26 @@ func readBody(resp *http.Response) (string, error) {
 	}
 
 	return "", nil
+}
+
+func getGateway() (*n.ApplicationGateway, error) {
+	env := GetEnv()
+
+	klog.Info("preparing app gateway client")
+	client, err := getApplicationGatewaysClient()
+	if err != nil {
+		return nil, err
+	}
+
+	gateway, err := client.Get(
+		context.TODO(),
+		env.ResourceGroupName,
+		env.AppGwName,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &gateway, nil
 }

--- a/scripts/e2e/cmd/runner/helper.go
+++ b/scripts/e2e/cmd/runner/helper.go
@@ -307,7 +307,6 @@ func applyYaml(clientset *kubernetes.Clientset, namespaceName string, fileName s
 			} else {
 				return errors.New("namespace is not defined for configmaps")
 			}
-			continue
 		} else if pod, ok := objs.(*v1.Pod); ok {
 			nm := pod.Namespace
 			if len(nm) == 0 && len(namespaceName) != 0 {
@@ -321,7 +320,6 @@ func applyYaml(clientset *kubernetes.Clientset, namespaceName string, fileName s
 			} else {
 				return errors.New("namespace is not defined for pods")
 			}
-			continue
 		} else {
 			return fmt.Errorf("unable to apply YAML. Unknown object type: %v", objs)
 		}

--- a/scripts/e2e/cmd/runner/lfu_one_namespace_one_ingress_test.go
+++ b/scripts/e2e/cmd/runner/lfu_one_namespace_one_ingress_test.go
@@ -9,11 +9,14 @@ package runner
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
@@ -52,6 +55,47 @@ var _ = Describe("LFU", func() {
 			err = clientset.CoreV1().Namespaces().Delete("test-brownfield-ns", deleteOptions)
 			Expect(err).To(BeNil())
 		})
-	})
 
+		It("[sub-resource-prefix] should be use the sub-resource-prefix to prefix sub-resources", func() {
+			env := GetEnv()
+			klog.Infof("'subResourceNamePrefix': %s", env.SubResourceNamePrefix)
+			Expect(env.SubResourceNamePrefix).ToNot(Equal(""), "Please make sure that environment variable 'subResourceNamePrefix' is set")
+
+			namespaceName := "e2e-sub-resource-prefix"
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceName,
+				},
+			}
+			klog.Info("Creating namespace: ", namespaceName)
+			_, err = clientset.CoreV1().Namespaces().Create(ns)
+			Expect(err).To(BeNil())
+
+			SSLE2ERedirectYamlPath := "testdata/one-namespace-one-ingress/ssl-e2e-redirect/app.yaml"
+			klog.Info("Applying yaml: ", SSLE2ERedirectYamlPath)
+			err = applyYaml(clientset, namespaceName, SSLE2ERedirectYamlPath)
+			Expect(err).To(BeNil())
+			time.Sleep(30 * time.Second)
+
+			gateway, err := getGateway()
+			Expect(err).To(BeNil())
+
+			prefixUsed := false
+			for _, listener := range *gateway.HTTPListeners {
+				klog.Infof("checking listener %s for %s", *listener.Name, env.SubResourceNamePrefix)
+				if strings.HasPrefix(*listener.Name, env.SubResourceNamePrefix) {
+					klog.Infof("found %s that uses the prefix", *listener.Name)
+					prefixUsed = true
+					break
+				}
+			}
+
+			Expect(prefixUsed).To(BeTrue(), "%s wasn't used for naming the sub-resource of app gateway. Currently, this check looks at HTTP listener only", env.SubResourceNamePrefix)
+		})
+
+		AfterEach(func() {
+			// clear all namespaces
+			cleanUp(clientset)
+		})
+	})
 })

--- a/scripts/e2e/helper.sh
+++ b/scripts/e2e/helper.sh
@@ -51,6 +51,7 @@ function InstallAGIC() {
     helm upgrade --install agic-${version} staging/ingress-azure \
         --set appgw.name=${applicationGatewayName} \
         --set appgw.subnetPrefix=${applicationGatewaySubnetPrefix} \
+        --set appgw.subResourceNamePrefix=${subResourceNamePrefix} \
         --set armAuth.type=aadPodIdentity \
         --set armAuth.identityResourceID=${identityResourceId} \
         --set armAuth.identityClientID=${identityClientId} \
@@ -87,6 +88,7 @@ function SetupSharedBackend() {
     helm upgrade --install agic-${version} staging/ingress-azure \
         -f ./helm-config-with-prohibited-rules.yaml \
         --set appgw.applicationGatewayID=${applicationGatewayId} \
+        --set appgw.subResourceNamePrefix=${subResourceNamePrefix} \
         --set armAuth.type=aadPodIdentity \
         --set armAuth.identityResourceID=${identityResourceId} \
         --set armAuth.identityClientID=${identityClientId} \


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
This PR adds
1. fixes a bug in the placement of subResourceNamePrefix in the helm config.
2. an e2e that uses subResourceNamePrefix in the helm and validates that app gateway sub-resources are named apt-ly.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
