### PR TITLE
fix: correct position of subResourceNamePrefix in configmap

### DIFF
--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -33,10 +33,6 @@ data:
   APPGW_RESOURCE_GROUP:  {{ .Values.appgw.resourceGroup | quote }}
   APPGW_NAME:            {{ .Values.appgw.name | quote }}
 
-  {{- if .Values.appgw.subResourceNamePrefix }}
-  APPGW_CONFIG_NAME_PREFIX: {{ .Values.appgw.subResourceNamePrefix | quote }}
-  {{- end }}
-
   {{- if or .Values.appgw.subnetID .Values.appgw.subnetName .Values.appgw.subnetPrefix }}
   #if subnet is provided, we treat it as a create case
   APPGW_ENABLE_DEPLOY:   "true"
@@ -62,6 +58,10 @@ data:
 
   {{- end }}
 
+{{- end }}
+
+{{- if .Values.appgw.subResourceNamePrefix }}
+  APPGW_CONFIG_NAME_PREFIX: {{ .Values.appgw.subResourceNamePrefix | quote }}
 {{- end }}
 
 {{- if .Values.appgw.shared }}


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [ ] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
This PR moves subResourceNamePrefix out of the `if/else` block for `appgw resource ID` vs `appgw name`. It was found when the e2e failed.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
