### PR TITLE
annotations: Expands list of health-probe related ingress annotations 

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -29,7 +29,7 @@ For an Ingress resource to be observed by AGIC it **must be annotated** with `ku
 | [appgw.ingress.kubernetes.io/health-probe-status-codes](#health-probe-status-codes) | `[]string` | `nil`  |   |
 | [appgw.ingress.kubernetes.io/health-probe-interval](#health-probe-interval) | `int32` | `nil`  |   |
 | [appgw.ingress.kubernetes.io/health-probe-timeout](#health-probe-timeout) | `int32` | `nil`  |   |
-| [appgw.ingress.kubernetes.io/health-probe-unhealthy-treshold](#health-probe-unhealthy-treshold) | `int32` | `nil`  |   |
+| [appgw.ingress.kubernetes.io/health-probe-unhealthy-threshold](#health-probe-unhealthy-threshold) | `int32` | `nil`  |   |
 
 ## Override Frontend Port
 
@@ -594,7 +594,7 @@ This annotation defines healthy status codes returned by the health probe. The v
 ### Usage
 
 ```yaml
-appgw.ingress.kubernetes.io/health-probe-path: <URI path>
+appgw.ingress.kubernetes.io/health-probe-status-codes: <status codes>
 ```
 
 ### Example
@@ -625,7 +625,7 @@ This annotation sets AGW health probe interval. By default, if backend container
 ### Usage
 
 ```yaml
-appgw.ingress.kubernetes.io/health-probe-path: <URI path>
+appgw.ingress.kubernetes.io/health-probe-interval: <interval seconds>
 ```
 
 ### Example
@@ -656,7 +656,7 @@ This annotation allows specifically define timeout for AGW health probe. By defa
 ### Usage
 
 ```yaml
-appgw.ingress.kubernetes.io/health-probe-path: <URI path>
+appgw.ingress.kubernetes.io/health-probe-timeout: <timeout seconds>
 ```
 
 ### Example
@@ -680,14 +680,14 @@ spec:
           servicePort: 8080
 ```
 
-## Health Probe Unhealthy Treshold
+## Health Probe Unhealthy Threshold
 
-This annotation allows specifically define target unhealthy thresold for AGW health probe. By default, if backend container running service with liveliness probe of type `HTTP GET` defined , threshold defined in liveliness probe definition is also used for health probe. However annotation `appgw.ingress.kubernetes.io/health-probe-unhealthy-treshold` overrides it with its value.
+This annotation allows specifically define target unhealthy thresold for AGW health probe. By default, if backend container running service with liveliness probe of type `HTTP GET` defined , threshold defined in liveliness probe definition is also used for health probe. However annotation `appgw.ingress.kubernetes.io/health-probe-unhealthy-threshold` overrides it with its value.
 
 ### Usage
 
 ```yaml
-appgw.ingress.kubernetes.io/health-probe-path: <URI path>
+appgw.ingress.kubernetes.io/health-probe-unhealthy-threshold: <unhealthy threshold>
 ```
 
 ### Example
@@ -700,7 +700,7 @@ metadata:
   namespace: test-ag
   annotations:
     kubernetes.io/ingress.class: azure/application-gateway
-    appgw.ingress.kubernetes.io/health-probe-unhealthy-treshold: "5"
+    appgw.ingress.kubernetes.io/health-probe-unhealthy-threshold: "5"
 spec:
   rules:
   - http:

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -22,6 +22,9 @@ For an Ingress resource to be observed by AGIC it **must be annotated** with `ku
 | [appgw.ingress.kubernetes.io/request-timeout](#request-timeout) | `int32` (seconds) | `30` | |
 | [appgw.ingress.kubernetes.io/use-private-ip](#use-private-ip) | `bool` | `false` | |
 | [appgw.ingress.kubernetes.io/waf-policy-for-path](#azure-waf-policy-for-path) | `string` |   |   |
+| [appgw.ingress.kubernetes.io/health-probe-hostname](#health-probe-hostname) | `string` |  `nil` |   |
+| [appgw.ingress.kubernetes.io/health-probe-port](#health-probe-port) | `int32` | `nil`  |   |
+| [appgw.ingress.kubernetes.io/health-probe-path](#health-probe-path) | `string` | `nil`  |   |
 
 ## Backend Path Prefix
 
@@ -443,3 +446,106 @@ spec:
           servicePort: 80
 ```
 Note that the WAF policy will be applied to both `/ad-server` and `/auth` URLs.
+
+## Health Probe Hostname
+
+This annotation allows specifically define a target host to be used for AGW health probe. By default, if backend container running service with liveliness probe of type `HTTP GET` defined, host used in liveliness probe definition is also used as a target host for health probe. However if annotation `appgw.ingress.kubernetes.io/health-probe-hostname` is defined it overrides it with its own value.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/health-probe-hostname: <hostname>
+```
+
+### Example
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: go-server-ingress-bkprefix
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/health-probe-hostname: "my-backend-host.custom.app"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /hello/
+        backend:
+          serviceName: go-server-service
+          servicePort: 80
+```
+
+## Health Probe Port
+
+Health probe port annotation allows specifically define target TCP port to be used for AGW health probe. By default, if backend container running service has liveliness probe of type `HTTP GET` defined, port used in liveliness probe definition is also used as a port for health probe. Annotation `appgw.ingress.kubernetes.io/health-probe-port` has precedence over such default value.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/health-probe-port: <port number>
+```
+
+### Example
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: go-server-ingress-bkprefix
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/health-probe-hostname: "my-backend-host.custom.app"
+    appgw.ingress.kubernetes.io/health-probe-port: "443"
+    appgw.ingress.kubernetes.io/health-probe-path: "/healthz"
+    appgw.ingress.kubernetes.io/backend-protocol: https
+spec:
+  tls:
+    - secretName: "my-backend-host.custom.app-ssl-certificate"
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: go-server-service
+          servicePort: 443
+```
+
+## Health Probe Path
+
+This annotation allows specifically define target URI path to be used for AGW health probe. By default, if backend container running service with liveliness probe of type `HTTP GET` defined , path defined in liveliness probe definition is also used as a parh for health probe. However annotation `appgw.ingress.kubernetes.io/health-probe-path` overrides it with its own value.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/health-probe-path: <URI path>
+```
+
+### Example
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: go-server-ingress-bkprefix
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/health-probe-hostname: "my-backend-host.custom.app"
+    appgw.ingress.kubernetes.io/health-probe-port: "8080"
+    appgw.ingress.kubernetes.io/health-probe-path: "/healthz"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: go-server-service
+          servicePort: 8080
+```
+
+
+

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -26,6 +26,10 @@ For an Ingress resource to be observed by AGIC it **must be annotated** with `ku
 | [appgw.ingress.kubernetes.io/health-probe-hostname](#health-probe-hostname) | `string` |  `nil` |   |
 | [appgw.ingress.kubernetes.io/health-probe-port](#health-probe-port) | `int32` | `nil`  |   |
 | [appgw.ingress.kubernetes.io/health-probe-path](#health-probe-path) | `string` | `nil`  |   |
+| [appgw.ingress.kubernetes.io/health-probe-status-codes](#health-probe-status-codes) | `[]string` | `nil`  |   |
+| [appgw.ingress.kubernetes.io/health-probe-interval](#health-probe-interval) | `int32` | `nil`  |   |
+| [appgw.ingress.kubernetes.io/health-probe-timeout](#health-probe-timeout) | `int32` | `nil`  |   |
+| [appgw.ingress.kubernetes.io/health-probe-unhealthy-treshold](#health-probe-unhealthy-treshold) | `int32` | `nil`  |   |
 
 ## Override Frontend Port
 
@@ -552,7 +556,7 @@ spec:
 
 ## Health Probe Path
 
-This annotation allows specifically define target URI path to be used for AGW health probe. By default, if backend container running service with liveliness probe of type `HTTP GET` defined , path defined in liveliness probe definition is also used as a parh for health probe. However annotation `appgw.ingress.kubernetes.io/health-probe-path` overrides it with its own value.
+This annotation allows specifically define target URI path to be used for AGW health probe. By default, if backend container running service with liveliness probe of type `HTTP GET` defined , path defined in liveliness probe definition is also used as a path for health probe. However annotation `appgw.ingress.kubernetes.io/health-probe-path` overrides it with its own value.
 
 ### Usage
 
@@ -583,5 +587,126 @@ spec:
           servicePort: 8080
 ```
 
+## Health Probe Status Codes
 
+This annotation defines healthy status codes returned by the health probe. The values are comma seperated list of individual status codes or ranges defined as `<start of the range>-<end of the range>`.
 
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/health-probe-path: <URI path>
+```
+
+### Example
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: go-server-ingress-bkprefix
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/health-probe-status-codes: "200-399, 401"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: go-server-service
+          servicePort: 8080
+```
+
+## Health Probe Interval
+
+This annotation sets AGW health probe interval. By default, if backend container running service with liveliness probe of type `HTTP GET` defined, interval in liveliness probe definition is also used as a interval for health probe. However annotation `appgw.ingress.kubernetes.io/health-probe-interval` overrides it with its value.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/health-probe-path: <URI path>
+```
+
+### Example
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: go-server-ingress-bkprefix
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/health-probe-interval: "20"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: go-server-service
+          servicePort: 8080
+```
+
+## Health Probe Timeout
+
+This annotation allows specifically define timeout for AGW health probe. By default, if backend container running service with liveliness probe of type `HTTP GET` defined, timeout defined in liveliness probe definition is also used for health probe. However annotation `appgw.ingress.kubernetes.io/health-probe-timeout` overrides it with its value.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/health-probe-path: <URI path>
+```
+
+### Example
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: go-server-ingress-bkprefix
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/health-probe-timeout: "15"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: go-server-service
+          servicePort: 8080
+```
+
+## Health Probe Unhealthy Treshold
+
+This annotation allows specifically define target unhealthy thresold for AGW health probe. By default, if backend container running service with liveliness probe of type `HTTP GET` defined , threshold defined in liveliness probe definition is also used for health probe. However annotation `appgw.ingress.kubernetes.io/health-probe-unhealthy-treshold` overrides it with its value.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/health-probe-path: <URI path>
+```
+
+### Example
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: go-server-ingress-bkprefix
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/health-probe-unhealthy-treshold: "5"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: go-server-service
+          servicePort: 8080
+```

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -45,8 +45,8 @@ const (
 	// HealthProbeTimeoutKey defines the probe timeout in seconds
 	HealthProbeTimeoutKey = ApplicationGatewayPrefix + "/health-probe-timeout"
 
-	// HealthProbeUnhealthyTresholdKey defines threshold for marking backend server as unhealthy
-	HealthProbeUnhealthyTresholdKey = ApplicationGatewayPrefix + "/health-probe-unhealthy-treshold"
+	// HealthProbeUnhealthyThresholdKey defines threshold for marking backend server as unhealthy
+	HealthProbeUnhealthyThresholdKey = ApplicationGatewayPrefix + "/health-probe-unhealthy-threshold"
 
 	// CookieBasedAffinityKey defines the key to enable/disable cookie based affinity for client connection.
 	CookieBasedAffinityKey = ApplicationGatewayPrefix + "/cookie-based-affinity"
@@ -195,9 +195,9 @@ func HealthProbeTimeout(ing *v1beta1.Ingress) (int32, error) {
 	return parseInt32(ing, HealthProbeTimeoutKey)
 }
 
-// HealthProbeUnhealthyTreshold probe threshold
-func HealthProbeUnhealthyTreshold(ing *v1beta1.Ingress) (int32, error) {
-	return parseInt32(ing, HealthProbeUnhealthyTresholdKey)
+// HealthProbeUnhealthyThreshold probe threshold
+func HealthProbeUnhealthyThreshold(ing *v1beta1.Ingress) (int32, error) {
+	return parseInt32(ing, HealthProbeUnhealthyThresholdKey)
 }
 
 // GetAppGwSslCertificate refer to appgw installed certificate

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -27,14 +27,14 @@ const (
 	// Null means Host specified in the request to Application Gateway is used to connect to the backend.
 	BackendHostNameKey = ApplicationGatewayPrefix + "/backend-hostname"
 
-  // HealthProbeHostKey defines the key for Host which should be used as a target for health probe.
-  HealthProbeHostKey = ApplicationGatewayPrefix + "/health-probe-hostname"
+	// HealthProbeHostKey defines the key for Host which should be used as a target for health probe.
+	HealthProbeHostKey = ApplicationGatewayPrefix + "/health-probe-hostname"
 
-  // HealthProbePortKey defines the key for port that should be used as a target for health probe.
-  HealthProbePortKey = ApplicationGatewayPrefix + "/health-probe-port"
+	// HealthProbePortKey defines the key for port that should be used as a target for health probe.
+	HealthProbePortKey = ApplicationGatewayPrefix + "/health-probe-port"
 
-  // HealthProbePathKey defines the key for URL path which should be used as a target for health probe.
-  HealthProbePathKey = ApplicationGatewayPrefix + "/health-probe-path"
+	// HealthProbePathKey defines the key for URL path which should be used as a target for health probe.
+	HealthProbePathKey = ApplicationGatewayPrefix + "/health-probe-path"
 
 	// CookieBasedAffinityKey defines the key to enable/disable cookie based affinity for client connection.
 	CookieBasedAffinityKey = ApplicationGatewayPrefix + "/cookie-based-affinity"
@@ -146,19 +146,18 @@ func BackendHostName(ing *v1beta1.Ingress) (string, error) {
 
 // HealthProbeHostName probe hostname override
 func HealthProbeHostName(ing *v1beta1.Ingress) (string, error) {
- return parseString(ing, HealthProbeHostKey)
+	return parseString(ing, HealthProbeHostKey)
 }
 
 // HealthProbePort probe port override
 func HealthProbePort(ing *v1beta1.Ingress) (int32, error) {
- return parseInt32(ing, HealthProbePortKey)
+	return parseInt32(ing, HealthProbePortKey)
 }
 
 // HealthProbePath probe path override
 func HealthProbePath(ing *v1beta1.Ingress) (string, error) {
- return parseString(ing, HealthProbePathKey)
+	return parseString(ing, HealthProbePathKey)
 }
-
 
 // GetAppGwSslCertificate refer to appgw installed certificate
 func GetAppGwSslCertificate(ing *v1beta1.Ingress) (string, error) {

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -27,6 +27,15 @@ const (
 	// Null means Host specified in the request to Application Gateway is used to connect to the backend.
 	BackendHostNameKey = ApplicationGatewayPrefix + "/backend-hostname"
 
+  // HealthProbeHostKey defines the key for Host which should be used as a target for health probe.
+  HealthProbeHostKey = ApplicationGatewayPrefix + "/health-probe-hostname"
+
+  // HealthProbePortKey defines the key for port that should be used as a target for health probe.
+  HealthProbePortKey = ApplicationGatewayPrefix + "/health-probe-port"
+
+  // HealthProbePathKey defines the key for URL path which should be used as a target for health probe.
+  HealthProbePathKey = ApplicationGatewayPrefix + "/health-probe-path"
+
 	// CookieBasedAffinityKey defines the key to enable/disable cookie based affinity for client connection.
 	CookieBasedAffinityKey = ApplicationGatewayPrefix + "/cookie-based-affinity"
 
@@ -134,6 +143,22 @@ func BackendPathPrefix(ing *v1beta1.Ingress) (string, error) {
 func BackendHostName(ing *v1beta1.Ingress) (string, error) {
 	return parseString(ing, BackendHostNameKey)
 }
+
+// HealthProbeHostName probe hostname override
+func HealthProbeHostName(ing *v1beta1.Ingress) (string, error) {
+ return parseString(ing, HealthProbeHostKey)
+}
+
+// HealthProbePort probe port override
+func HealthProbePort(ing *v1beta1.Ingress) (int32, error) {
+ return parseInt32(ing, HealthProbePortKey)
+}
+
+// HealthProbePath probe path override
+func HealthProbePath(ing *v1beta1.Ingress) (string, error) {
+ return parseString(ing, HealthProbePathKey)
+}
+
 
 // GetAppGwSslCertificate refer to appgw installed certificate
 func GetAppGwSslCertificate(ing *v1beta1.Ingress) (string, error) {

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -36,6 +36,18 @@ const (
 	// HealthProbePathKey defines the key for URL path which should be used as a target for health probe.
 	HealthProbePathKey = ApplicationGatewayPrefix + "/health-probe-path"
 
+	// HealthProbeStatusCodesKey defines status codes returned by the probe to be interpreted as healty service
+	HealthProbeStatusCodesKey = ApplicationGatewayPrefix + "/health-probe-status-codes"
+
+	// HealthProbeIntervalKey defines the probe interval in seconds
+	HealthProbeIntervalKey = ApplicationGatewayPrefix + "/health-probe-interval"
+
+	// HealthProbeTimeoutKey defines the probe timeout in seconds
+	HealthProbeTimeoutKey = ApplicationGatewayPrefix + "/health-probe-timeout"
+
+	// HealthProbeUnhealthyTresholdKey defines threshold for marking backend server as unhealthy
+	HealthProbeUnhealthyTresholdKey = ApplicationGatewayPrefix + "/health-probe-unhealthy-treshold"
+
 	// CookieBasedAffinityKey defines the key to enable/disable cookie based affinity for client connection.
 	CookieBasedAffinityKey = ApplicationGatewayPrefix + "/cookie-based-affinity"
 
@@ -157,6 +169,35 @@ func HealthProbePort(ing *v1beta1.Ingress) (int32, error) {
 // HealthProbePath probe path override
 func HealthProbePath(ing *v1beta1.Ingress) (string, error) {
 	return parseString(ing, HealthProbePathKey)
+}
+
+// HealthProbeStatusCodes probe status codes
+func HealthProbeStatusCodes(ing *v1beta1.Ingress) ([]string, error) {
+	value, err := parseString(ing, HealthProbeStatusCodesKey)
+	if value != "" {
+		codesArray := strings.Split(value, ",")
+		for index, element := range codesArray {
+			codesArray[index] = strings.TrimSpace(element)
+		}
+		return codesArray, err
+	}
+
+	return nil, err
+}
+
+// HealthProbeInterval probe interval
+func HealthProbeInterval(ing *v1beta1.Ingress) (int32, error) {
+	return parseInt32(ing, HealthProbeIntervalKey)
+}
+
+// HealthProbeTimeout probe timeout
+func HealthProbeTimeout(ing *v1beta1.Ingress) (int32, error) {
+	return parseInt32(ing, HealthProbeTimeoutKey)
+}
+
+// HealthProbeUnhealthyTreshold probe threshold
+func HealthProbeUnhealthyTreshold(ing *v1beta1.Ingress) (int32, error) {
+	return parseInt32(ing, HealthProbeUnhealthyTresholdKey)
 }
 
 // GetAppGwSslCertificate refer to appgw installed certificate

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -39,29 +39,29 @@ func TestIt(t *testing.T) {
 
 var _ = Describe("Test ingress annotation functions", func() {
 	annotations := map[string]string{
-		"appgw.ingress.kubernetes.io/use-private-ip":                  "true",
-		"appgw.ingress.kubernetes.io/override-frontend-port":          "444",
-		"appgw.ingress.kubernetes.io/connection-draining":             "true",
-		"appgw.ingress.kubernetes.io/cookie-based-affinity":           "true",
-		"appgw.ingress.kubernetes.io/ssl-redirect":                    "true",
-		"appgw.ingress.kubernetes.io/request-timeout":                 "123456",
-		"appgw.ingress.kubernetes.io/connection-draining-timeout":     "3456",
-		"appgw.ingress.kubernetes.io/backend-path-prefix":             "prefix-here",
-		"appgw.ingress.kubernetes.io/backend-hostname":                "www.backend.com",
-		"appgw.ingress.kubernetes.io/hostname-extension":              "www.bye.com, www.b*.com",
-		"appgw.ingress.kubernetes.io/appgw-ssl-certificate":           "appgw-cert",
-		"appgw.ingress.kubernetes.io/appgw-trusted-root-certificate":  "appgw-root-cert1,appgw-root-cert2",
-		"appgw.ingress.kubernetes.io/health-probe-hostname":           "myhost.mydomain.com",
-		"appgw.ingress.kubernetes.io/health-probe-port":               "8080",
-		"appgw.ingress.kubernetes.io/health-probe-path":               "/healthz",
-		"appgw.ingress.kubernetes.io/health-probe-status-codes":       "200-399, 401",
-		"appgw.ingress.kubernetes.io/health-probe-interval":           "15",
-		"appgw.ingress.kubernetes.io/health-probe-timeout":            "10",
-		"appgw.ingress.kubernetes.io/health-probe-unhealthy-treshold": "3",
-		"kubernetes.io/ingress.class":                                 "azure/application-gateway",
-		"appgw.ingress.istio.io/v1alpha3":                             "azure/application-gateway",
-		"falseKey":                                                    "false",
-		"errorKey":                                                    "234error!!",
+		"appgw.ingress.kubernetes.io/use-private-ip":                   "true",
+		"appgw.ingress.kubernetes.io/override-frontend-port":           "444",
+		"appgw.ingress.kubernetes.io/connection-draining":              "true",
+		"appgw.ingress.kubernetes.io/cookie-based-affinity":            "true",
+		"appgw.ingress.kubernetes.io/ssl-redirect":                     "true",
+		"appgw.ingress.kubernetes.io/request-timeout":                  "123456",
+		"appgw.ingress.kubernetes.io/connection-draining-timeout":      "3456",
+		"appgw.ingress.kubernetes.io/backend-path-prefix":              "prefix-here",
+		"appgw.ingress.kubernetes.io/backend-hostname":                 "www.backend.com",
+		"appgw.ingress.kubernetes.io/hostname-extension":               "www.bye.com, www.b*.com",
+		"appgw.ingress.kubernetes.io/appgw-ssl-certificate":            "appgw-cert",
+		"appgw.ingress.kubernetes.io/appgw-trusted-root-certificate":   "appgw-root-cert1,appgw-root-cert2",
+		"appgw.ingress.kubernetes.io/health-probe-hostname":            "myhost.mydomain.com",
+		"appgw.ingress.kubernetes.io/health-probe-port":                "8080",
+		"appgw.ingress.kubernetes.io/health-probe-path":                "/healthz",
+		"appgw.ingress.kubernetes.io/health-probe-status-codes":        "200-399, 401",
+		"appgw.ingress.kubernetes.io/health-probe-interval":            "15",
+		"appgw.ingress.kubernetes.io/health-probe-timeout":             "10",
+		"appgw.ingress.kubernetes.io/health-probe-unhealthy-threshold": "3",
+		"kubernetes.io/ingress.class":                                  "azure/application-gateway",
+		"appgw.ingress.istio.io/v1alpha3":                              "azure/application-gateway",
+		"falseKey":                                                     "false",
+		"errorKey":                                                     "234error!!",
 	}
 
 	ing := &v1beta1.Ingress{
@@ -161,7 +161,7 @@ var _ = Describe("Test ingress annotation functions", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(actual).Should(BeEmpty())
 		})
-		It("returns hostname", func() {
+		It("returns expected status codes", func() {
 			actual, err := HealthProbeStatusCodes(ing)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).Should(HaveLen(2))
@@ -197,15 +197,15 @@ var _ = Describe("Test ingress annotation functions", func() {
 		})
 	})
 
-	Context("test health-probe-unhealthy-treshold", func() {
+	Context("test health-probe-unhealthy-threshold", func() {
 		It("returns error when ingress has no annotations", func() {
 			ing := &v1beta1.Ingress{}
-			actual, err := HealthProbeUnhealthyTreshold(ing)
+			actual, err := HealthProbeUnhealthyThreshold(ing)
 			Expect(err).To(HaveOccurred())
 			Expect(actual).To(Equal(int32(0)))
 		})
 		It("returns hostname", func() {
-			actual, err := HealthProbeUnhealthyTreshold(ing)
+			actual, err := HealthProbeUnhealthyThreshold(ing)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).To(Equal(int32(3)))
 		})

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -39,25 +39,29 @@ func TestIt(t *testing.T) {
 
 var _ = Describe("Test ingress annotation functions", func() {
 	annotations := map[string]string{
-		"appgw.ingress.kubernetes.io/use-private-ip":                 "true",
-		"appgw.ingress.kubernetes.io/override-frontend-port":         "444",
-		"appgw.ingress.kubernetes.io/connection-draining":            "true",
-		"appgw.ingress.kubernetes.io/cookie-based-affinity":          "true",
-		"appgw.ingress.kubernetes.io/ssl-redirect":                   "true",
-		"appgw.ingress.kubernetes.io/request-timeout":                "123456",
-		"appgw.ingress.kubernetes.io/connection-draining-timeout":    "3456",
-		"appgw.ingress.kubernetes.io/backend-path-prefix":            "prefix-here",
-		"appgw.ingress.kubernetes.io/backend-hostname":               "www.backend.com",
-		"appgw.ingress.kubernetes.io/hostname-extension":             "www.bye.com, www.b*.com",
-		"appgw.ingress.kubernetes.io/appgw-ssl-certificate":          "appgw-cert",
-		"appgw.ingress.kubernetes.io/appgw-trusted-root-certificate": "appgw-root-cert1,appgw-root-cert2",
-		"appgw.ingress.kubernetes.io/health-probe-hostname":          "myhost.mydomain.com",
-		"appgw.ingress.kubernetes.io/health-probe-port":              "8080",
-		"appgw.ingress.kubernetes.io/health-probe-path":              "/healthz",
-		"kubernetes.io/ingress.class":                                "azure/application-gateway",
-		"appgw.ingress.istio.io/v1alpha3":                            "azure/application-gateway",
-		"falseKey":                                                   "false",
-		"errorKey":                                                   "234error!!",
+		"appgw.ingress.kubernetes.io/use-private-ip":                  "true",
+		"appgw.ingress.kubernetes.io/override-frontend-port":          "444",
+		"appgw.ingress.kubernetes.io/connection-draining":             "true",
+		"appgw.ingress.kubernetes.io/cookie-based-affinity":           "true",
+		"appgw.ingress.kubernetes.io/ssl-redirect":                    "true",
+		"appgw.ingress.kubernetes.io/request-timeout":                 "123456",
+		"appgw.ingress.kubernetes.io/connection-draining-timeout":     "3456",
+		"appgw.ingress.kubernetes.io/backend-path-prefix":             "prefix-here",
+		"appgw.ingress.kubernetes.io/backend-hostname":                "www.backend.com",
+		"appgw.ingress.kubernetes.io/hostname-extension":              "www.bye.com, www.b*.com",
+		"appgw.ingress.kubernetes.io/appgw-ssl-certificate":           "appgw-cert",
+		"appgw.ingress.kubernetes.io/appgw-trusted-root-certificate":  "appgw-root-cert1,appgw-root-cert2",
+		"appgw.ingress.kubernetes.io/health-probe-hostname":           "myhost.mydomain.com",
+		"appgw.ingress.kubernetes.io/health-probe-port":               "8080",
+		"appgw.ingress.kubernetes.io/health-probe-path":               "/healthz",
+		"appgw.ingress.kubernetes.io/health-probe-status-codes":       "200-399, 401",
+		"appgw.ingress.kubernetes.io/health-probe-interval":           "15",
+		"appgw.ingress.kubernetes.io/health-probe-timeout":            "10",
+		"appgw.ingress.kubernetes.io/health-probe-unhealthy-treshold": "3",
+		"kubernetes.io/ingress.class":                                 "azure/application-gateway",
+		"appgw.ingress.istio.io/v1alpha3":                             "azure/application-gateway",
+		"falseKey":                                                    "false",
+		"errorKey":                                                    "234error!!",
 	}
 
 	ing := &v1beta1.Ingress{
@@ -147,6 +151,63 @@ var _ = Describe("Test ingress annotation functions", func() {
 			actual, err := HealthProbePath(ing)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).To(Equal("/healthz"))
+		})
+	})
+
+	Context("test health-probe-status-codes", func() {
+		It("returns error when ingress has no annotations", func() {
+			ing := &v1beta1.Ingress{}
+			actual, err := HealthProbeStatusCodes(ing)
+			Expect(err).To(HaveOccurred())
+			Expect(actual).Should(BeEmpty())
+		})
+		It("returns hostname", func() {
+			actual, err := HealthProbeStatusCodes(ing)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).Should(HaveLen(2))
+			Expect(actual).Should(ConsistOf("200-399", "401"))
+		})
+	})
+
+	Context("test health-probe-interval", func() {
+		It("returns error when ingress has no annotations", func() {
+			ing := &v1beta1.Ingress{}
+			actual, err := HealthProbeInterval(ing)
+			Expect(err).To(HaveOccurred())
+			Expect(actual).To(Equal(int32(0)))
+		})
+		It("returns hostname", func() {
+			actual, err := HealthProbeInterval(ing)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(int32(15)))
+		})
+	})
+
+	Context("test health-probe-timeout", func() {
+		It("returns error when ingress has no annotations", func() {
+			ing := &v1beta1.Ingress{}
+			actual, err := HealthProbeTimeout(ing)
+			Expect(err).To(HaveOccurred())
+			Expect(actual).To(Equal(int32(0)))
+		})
+		It("returns hostname", func() {
+			actual, err := HealthProbeTimeout(ing)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(int32(10)))
+		})
+	})
+
+	Context("test health-probe-unhealthy-treshold", func() {
+		It("returns error when ingress has no annotations", func() {
+			ing := &v1beta1.Ingress{}
+			actual, err := HealthProbeUnhealthyTreshold(ing)
+			Expect(err).To(HaveOccurred())
+			Expect(actual).To(Equal(int32(0)))
+		})
+		It("returns hostname", func() {
+			actual, err := HealthProbeUnhealthyTreshold(ing)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(int32(3)))
 		})
 	})
 

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -51,6 +51,9 @@ var _ = Describe("Test ingress annotation functions", func() {
 		"appgw.ingress.kubernetes.io/hostname-extension":             "www.bye.com, www.b*.com",
 		"appgw.ingress.kubernetes.io/appgw-ssl-certificate":          "appgw-cert",
 		"appgw.ingress.kubernetes.io/appgw-trusted-root-certificate": "appgw-root-cert1,appgw-root-cert2",
+		"appgw.ingress.kubernetes.io/health-probe-hostname":          "myhost.mydomain.com",
+		"appgw.ingress.kubernetes.io/health-probe-port":              "8080",
+		"appgw.ingress.kubernetes.io/health-probe-path":              "/healthz",
 		"kubernetes.io/ingress.class":                                "azure/application-gateway",
 		"appgw.ingress.istio.io/v1alpha3":                            "azure/application-gateway",
 		"falseKey":                                                   "false",
@@ -102,6 +105,48 @@ var _ = Describe("Test ingress annotation functions", func() {
 			actual, err := GetAppGwTrustedRootCertificate(ing)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actual).To(Equal("appgw-root-cert1,appgw-root-cert2"))
+		})
+	})
+
+	Context("test health-probe-hostname", func() {
+		It("returns error when ingress has no annotations", func() {
+			ing := &v1beta1.Ingress{}
+			actual, err := HealthProbeHostName(ing)
+			Expect(err).To(HaveOccurred())
+			Expect(actual).To(Equal(""))
+		})
+		It("returns hostname", func() {
+			actual, err := HealthProbeHostName(ing)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal("myhost.mydomain.com"))
+		})
+	})
+
+	Context("test health-probe-port", func() {
+		It("returns error when ingress has no annotations", func() {
+			ing := &v1beta1.Ingress{}
+			actual, err := HealthProbePort(ing)
+			Expect(err).To(HaveOccurred())
+			Expect(actual).To(Equal(int32(0)))
+		})
+		It("returns probe port", func() {
+			actual, err := HealthProbePort(ing)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(int32(8080)))
+		})
+	})
+
+	Context("test health-probe-path", func() {
+		It("returns error when ingress has no annotations", func() {
+			ing := &v1beta1.Ingress{}
+			actual, err := HealthProbePath(ing)
+			Expect(err).To(HaveOccurred())
+			Expect(actual).To(Equal(""))
+		})
+		It("returns probe path", func() {
+			actual, err := HealthProbePath(ing)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal("/healthz"))
 		})
 	})
 

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -158,6 +158,29 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 		}
 	}
 
+	// backend protocol must match http settings protocol
+	backendProtocol, err = annotations.BackendProtocol(backendID.Ingress)
+	if err == nil && backendProtocol == annotations.HTTPS {
+		probe.Protocol = n.HTTPS
+	}
+
+	// override healthcheck probe host with host defined in annotation if exists
+	probeHost, err := annotations.HealthProbeHostName(backendID.Ingress)
+	if err == nil && probeHost != "" {
+		probe.Host = to.StringPtr(probeHost)
+	}
+
+	// override healthcheck probe target port with port defined in annotation if exists
+	probePort, err := annotations.HealthProbePort(backendID.Ingress)
+	if err == nil && probePort > 0 && probePort < 65536 {
+		probe.Port = to.Int32Ptr(probePort)
+	}
+
+	// override healthcheck probe host with host defined in annotation if exists
+	probePath, err := annotations.HealthProbePath(backendID.Ingress)
+	if err == nil && probePath != "" {
+		probe.Path = to.StringPtr(probePath)
+	}
 	if probe.Path != nil {
 		probe.Path = to.StringPtr(strings.TrimRight(*probe.Path, "*"))
 	}

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -111,14 +111,6 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 		probe.Protocol = n.HTTPS
 	}
 
-	// backend protocol take precedence over port
-	backendProtocol, err := annotations.BackendProtocol(backendID.Ingress)
-	if err == nil && backendProtocol == annotations.HTTPS {
-		probe.Protocol = n.HTTPS
-	} else if err == nil && backendProtocol == annotations.HTTP {
-		probe.Protocol = n.HTTP
-	}
-
 	k8sProbeForServiceContainer := c.getProbeForServiceContainer(service, backendID)
 	if k8sProbeForServiceContainer != nil {
 		if len(k8sProbeForServiceContainer.Handler.HTTPGet.Host) != 0 {
@@ -159,9 +151,11 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 	}
 
 	// backend protocol must match http settings protocol
-	backendProtocol, err = annotations.BackendProtocol(backendID.Ingress)
+	backendProtocol, err := annotations.BackendProtocol(backendID.Ingress)
 	if err == nil && backendProtocol == annotations.HTTPS {
 		probe.Protocol = n.HTTPS
+	} else if err == nil && backendProtocol == annotations.HTTP {
+		probe.Protocol = n.HTTP
 	}
 
 	// override healthcheck probe host with host defined in annotation if exists
@@ -205,7 +199,7 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 	}
 
 	// override healthcheck probe threshold with value defined in annotation if exists
-	probeThreshold, err := annotations.HealthProbeUnhealthyTreshold(backendID.Ingress)
+	probeThreshold, err := annotations.HealthProbeUnhealthyThreshold(backendID.Ingress)
 	if err == nil && probeThreshold > 0 {
 		probe.UnhealthyThreshold = to.Int32Ptr(probeThreshold)
 	}

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -176,13 +176,38 @@ func (c *appGwConfigBuilder) generateHealthProbe(backendID backendIdentifier) *n
 		probe.Port = to.Int32Ptr(probePort)
 	}
 
-	// override healthcheck probe host with host defined in annotation if exists
+	// override healthcheck probe path with path defined in annotation if exists
 	probePath, err := annotations.HealthProbePath(backendID.Ingress)
 	if err == nil && probePath != "" {
 		probe.Path = to.StringPtr(probePath)
 	}
+
 	if probe.Path != nil {
 		probe.Path = to.StringPtr(strings.TrimRight(*probe.Path, "*"))
+	}
+
+	// override healthcheck probe match status codes with ones defined in annotation if exists
+	probeStatuses, err := annotations.HealthProbeStatusCodes(backendID.Ingress)
+	if err == nil && len(probeStatuses) > 0 {
+		probe.Match.StatusCodes = &probeStatuses
+	}
+
+	// override healthcheck probe interval with value defined in annotation if exists
+	probeInterval, err := annotations.HealthProbeInterval(backendID.Ingress)
+	if err == nil && probeInterval > 0 {
+		probe.Interval = to.Int32Ptr(probeInterval)
+	}
+
+	// override healthcheck probe timeout with value defined in annotation if exists
+	probeTimeout, err := annotations.HealthProbeTimeout(backendID.Ingress)
+	if err == nil && probeTimeout > 0 {
+		probe.Timeout = to.Int32Ptr(probeTimeout)
+	}
+
+	// override healthcheck probe threshold with value defined in annotation if exists
+	probeThreshold, err := annotations.HealthProbeUnhealthyTreshold(backendID.Ingress)
+	if err == nil && probeThreshold > 0 {
+		probe.UnhealthyThreshold = to.Int32Ptr(probeThreshold)
 	}
 
 	// For V1 gateway, port property is not supported

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -8,6 +8,7 @@ package appgw
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -189,12 +190,21 @@ var _ = Describe("configure App Gateway health probes", func() {
 		annotationHpHostname := "myhost.mydomain.com"
 		annotationHpPort := int32(8080)
 		annotationHpPath := "/healthz"
+		annotationHpCodes := "200-399,401"
+		annotationHpInterval := int32(15)
+		annotationHpTimeout := int32(10)
+		annotationHpTreshold := int32(3)
+		StatusCodes := strings.Split(annotationHpCodes, ",")
 
 		annotations := map[string]string{
-			"kubernetes.io/ingress.class":                       "azure/application-gateway",
-			"appgw.ingress.kubernetes.io/health-probe-hostname": annotationHpHostname,
-			"appgw.ingress.kubernetes.io/health-probe-port":     strconv.Itoa(int(annotationHpPort)),
-			"appgw.ingress.kubernetes.io/health-probe-path":     annotationHpPath,
+			"kubernetes.io/ingress.class":                                 "azure/application-gateway",
+			"appgw.ingress.kubernetes.io/health-probe-hostname":           annotationHpHostname,
+			"appgw.ingress.kubernetes.io/health-probe-port":               strconv.Itoa(int(annotationHpPort)),
+			"appgw.ingress.kubernetes.io/health-probe-path":               annotationHpPath,
+			"appgw.ingress.kubernetes.io/health-probe-status-codes":       annotationHpCodes,
+			"appgw.ingress.kubernetes.io/health-probe-interval":           strconv.Itoa(int(annotationHpInterval)),
+			"appgw.ingress.kubernetes.io/health-probe-timeout":            strconv.Itoa(int(annotationHpTimeout)),
+			"appgw.ingress.kubernetes.io/health-probe-unhealthy-treshold": strconv.Itoa(int(annotationHpTreshold)),
 		}
 
 		ingress := fixtures.GetIngress()
@@ -229,6 +239,18 @@ var _ = Describe("configure App Gateway health probes", func() {
 		})
 		It("probe path must match annotation", func() {
 			Expect(pb.ApplicationGatewayProbePropertiesFormat.Path).Should(Equal(&annotationHpPath))
+		})
+		It("probe status codes must match annotation", func() {
+			Expect(pb.ApplicationGatewayProbePropertiesFormat.Match.StatusCodes).Should(Equal(&StatusCodes))
+		})
+		It("probe interval must match annotation", func() {
+			Expect(pb.ApplicationGatewayProbePropertiesFormat.Interval).Should(Equal(&annotationHpInterval))
+		})
+		It("probe timeout must match annotation", func() {
+			Expect(pb.ApplicationGatewayProbePropertiesFormat.Timeout).Should(Equal(&annotationHpTimeout))
+		})
+		It("probe threshold must match annotation", func() {
+			Expect(pb.ApplicationGatewayProbePropertiesFormat.UnhealthyThreshold).Should(Equal(&annotationHpTreshold))
 		})
 	})
 

--- a/pkg/appgw/health_probes_test.go
+++ b/pkg/appgw/health_probes_test.go
@@ -193,18 +193,18 @@ var _ = Describe("configure App Gateway health probes", func() {
 		annotationHpCodes := "200-399,401"
 		annotationHpInterval := int32(15)
 		annotationHpTimeout := int32(10)
-		annotationHpTreshold := int32(3)
-		StatusCodes := strings.Split(annotationHpCodes, ",")
+		annotationHpThreshold := int32(3)
+		statusCodes := strings.Split(annotationHpCodes, ",")
 
 		annotations := map[string]string{
-			"kubernetes.io/ingress.class":                                 "azure/application-gateway",
-			"appgw.ingress.kubernetes.io/health-probe-hostname":           annotationHpHostname,
-			"appgw.ingress.kubernetes.io/health-probe-port":               strconv.Itoa(int(annotationHpPort)),
-			"appgw.ingress.kubernetes.io/health-probe-path":               annotationHpPath,
-			"appgw.ingress.kubernetes.io/health-probe-status-codes":       annotationHpCodes,
-			"appgw.ingress.kubernetes.io/health-probe-interval":           strconv.Itoa(int(annotationHpInterval)),
-			"appgw.ingress.kubernetes.io/health-probe-timeout":            strconv.Itoa(int(annotationHpTimeout)),
-			"appgw.ingress.kubernetes.io/health-probe-unhealthy-treshold": strconv.Itoa(int(annotationHpTreshold)),
+			"kubernetes.io/ingress.class":                                  "azure/application-gateway",
+			"appgw.ingress.kubernetes.io/health-probe-hostname":            annotationHpHostname,
+			"appgw.ingress.kubernetes.io/health-probe-port":                strconv.Itoa(int(annotationHpPort)),
+			"appgw.ingress.kubernetes.io/health-probe-path":                annotationHpPath,
+			"appgw.ingress.kubernetes.io/health-probe-status-codes":        annotationHpCodes,
+			"appgw.ingress.kubernetes.io/health-probe-interval":            strconv.Itoa(int(annotationHpInterval)),
+			"appgw.ingress.kubernetes.io/health-probe-timeout":             strconv.Itoa(int(annotationHpTimeout)),
+			"appgw.ingress.kubernetes.io/health-probe-unhealthy-threshold": strconv.Itoa(int(annotationHpThreshold)),
 		}
 
 		ingress := fixtures.GetIngress()
@@ -241,7 +241,7 @@ var _ = Describe("configure App Gateway health probes", func() {
 			Expect(pb.ApplicationGatewayProbePropertiesFormat.Path).Should(Equal(&annotationHpPath))
 		})
 		It("probe status codes must match annotation", func() {
-			Expect(pb.ApplicationGatewayProbePropertiesFormat.Match.StatusCodes).Should(Equal(&StatusCodes))
+			Expect(pb.ApplicationGatewayProbePropertiesFormat.Match.StatusCodes).Should(Equal(&statusCodes))
 		})
 		It("probe interval must match annotation", func() {
 			Expect(pb.ApplicationGatewayProbePropertiesFormat.Interval).Should(Equal(&annotationHpInterval))
@@ -250,7 +250,7 @@ var _ = Describe("configure App Gateway health probes", func() {
 			Expect(pb.ApplicationGatewayProbePropertiesFormat.Timeout).Should(Equal(&annotationHpTimeout))
 		})
 		It("probe threshold must match annotation", func() {
-			Expect(pb.ApplicationGatewayProbePropertiesFormat.UnhealthyThreshold).Should(Equal(&annotationHpTreshold))
+			Expect(pb.ApplicationGatewayProbePropertiesFormat.UnhealthyThreshold).Should(Equal(&annotationHpThreshold))
 		})
 	})
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [X] The title of the PR is clear and informative
- [X] If applicable, the changes made in the PR have proper test coverage
- [X] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
It expands list of recognized ingress annotations with following additions:
- appgw.ingress.kubernetes.io/health-probe-hostname
- appgw.ingress.kubernetes.io/health-probe-port
- appgw.ingress.kubernetes.io/health-probe-path
Those annotations allow user override health probe settings with values from annotations.

## Fixes
https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1048
