### PR TITLE
fix: update ingressSecretMap even when secret is malformed

### DIFF
--- a/pkg/k8scontext/ingress_handlers.go
+++ b/pkg/k8scontext/ingress_handlers.go
@@ -3,6 +3,7 @@ package k8scontext
 import (
 	"reflect"
 
+	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
@@ -37,7 +38,7 @@ func (h handlers) ingressAdd(obj interface{}) {
 			if secret, exists, err := h.context.Caches.Secret.GetByKey(secKey); exists && err == nil {
 				if !h.context.ingressSecretsMap.ContainsValue(secKey) {
 					if err := h.context.CertificateSecretStore.ConvertSecret(secKey, secret.(*v1.Secret)); err != nil {
-						continue
+						glog.Error(err.Error())
 					}
 				}
 			}

--- a/pkg/k8scontext/ingress_handlers.go
+++ b/pkg/k8scontext/ingress_handlers.go
@@ -115,7 +115,7 @@ func (h handlers) ingressUpdate(oldObj, newObj interface{}) {
 			if secret, exists, err := h.context.Caches.Secret.GetByKey(secKey); exists && err == nil {
 				if !h.context.ingressSecretsMap.ContainsValue(secKey) {
 					if err := h.context.CertificateSecretStore.ConvertSecret(secKey, secret.(*v1.Secret)); err != nil {
-						continue
+						glog.Error(err.Error())
 					}
 				}
 			}

--- a/pkg/k8scontext/secrets_handlers.go
+++ b/pkg/k8scontext/secrets_handlers.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
+	"github.com/golang/glog"
 )
 
 // secret resource handlers
@@ -34,6 +35,8 @@ func (h handlers) secretAdd(obj interface{}) {
 				Value: obj,
 			}
 			h.context.MetricStore.IncK8sAPIEventCounter()
+		} else {
+			glog.Error(err.Error())
 		}
 	}
 }
@@ -59,6 +62,8 @@ func (h handlers) secretUpdate(oldObj, newObj interface{}) {
 				Value: newObj,
 			}
 			h.context.MetricStore.IncK8sAPIEventCounter()
+		} else {
+			glog.Error(err.Error())
 		}
 	}
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
This PR fixes an issue in processing ingress event with TLS secret.
When ingress is processed, the referenced TLS secret is mapped to ingress and saved in a ingress-secret map.

In specific case where secret is malformed,, this step is skipped due to the `continue` statement. So later, when the certificate is fixed, it doesn't cause an event on AGIC and doesn't update the Application Gateway.
Secret is malformed in case customer is using a certificate manager which creates an empty secret initially and then fills the cert crt and key after generating them.

This is the place where secret handler checks if the secret is in the map or not.
https://github.com/Azure/application-gateway-kubernetes-ingress/blob/6bc8764eb2ecff4a0c6ce96b9124ea36c7e4daa5/pkg/k8scontext/secrets_handlers.go#L55
<!-- Please add a brief description of the changes made in this PR -->

## Fixes
Closes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/893
Closes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/728
Closes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/763
<!-- Please mention #issues that are fixed in this PR -->
