### PR TITLE
helm: Moved RBAC from  v1beta1 to v1 (#1074)

### DIFF
--- a/helm/ingress-azure/templates/clusterrole.yaml
+++ b/helm/ingress-azure/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.enabled -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/helm/ingress-azure/templates/clusterrolebinding.yaml
+++ b/helm/ingress-azure/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.enabled -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -205,7 +205,6 @@ k8s.io/api/auditregistration/v1alpha1
 k8s.io/api/authentication/v1
 k8s.io/api/authentication/v1beta1
 k8s.io/api/authorization/v1
-k8s.io/api/authorization/v1beta1
 k8s.io/api/autoscaling/v1
 k8s.io/api/autoscaling/v2beta1
 k8s.io/api/autoscaling/v2beta2


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
rbac.authorization.k8s.io/v1alpha1 and rbac.authorization.k8s.io/v1beta1 API groups are deprecated in favor of rbac.authorization.k8s.io/v1, and will no longer be served in v1.20.
https://v1-17.docs.kubernetes.io/docs/setup/release/notes/
kubernetes/kubernetes#84758

This PR fix the usage of deprecated API groups

## Fixes
Closes #1074
<!-- Please mention #issues that are fixed in this PR -->
