### PR TITLE
feat: add support for custom annotations

### DIFF
--- a/helm/ingress-azure/Chart.yaml
+++ b/helm/ingress-azure/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: Use Azure Application Gateway as the ingress for an Azure Kubernetes Service cluster.
 name: ingress-azure
-version: 1.2.0
+version: 1.2.1

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         checksum/config: {{ print .Values | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.kubernetes.httpServicePort | quote}}
-        {{- with .Values.podAnnotations }}
+        {{- with .Values.kubernetes.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         checksum/config: {{ print .Values | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.kubernetes.httpServicePort | quote}}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "application-gateway-kubernetes-ingress.serviceaccountname" . }}
       securityContext:        

--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -24,6 +24,9 @@ kubernetes:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  
+  # custom annotations
+  podAnnotations: {}
 
 # Set this to override the default ingress class value. DEFAULT: azure/application-gateway
 # This can be used to segregate ingress controllers in the same namespace
@@ -68,5 +71,3 @@ nodeSelector: {}
 # Specify if the cluster is RBAC enabled or not
 rbac:
   enabled: false # true/false
-
-podAnnotations: {}

--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -68,3 +68,5 @@ nodeSelector: {}
 # Specify if the cluster is RBAC enabled or not
 rbac:
   enabled: false # true/false
+
+podAnnotations: {}

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -29,6 +29,9 @@ kubernetes:
     # disktype: dentro
   tolerations: []
   affinity: {}
+  
+  # Add pod level annotations
+  podAnnotations: {}
 
 
 ################################################################################
@@ -70,6 +73,3 @@ nodeSelector: {}
 # Specify if the cluster is RBAC enabled or not
 rbac:
   enabled: false # true/false
-
-podAnnotations: 
-  zz: zz

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -70,3 +70,6 @@ nodeSelector: {}
 # Specify if the cluster is RBAC enabled or not
 rbac:
   enabled: false # true/false
+
+podAnnotations: 
+  zz: zz


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
I am interested in a use-case where custom annotations are read from the resources. Currently this chart is lacking support for custom annotations fields.
I have updated the templates to allow setting `podAnnotations` field from the values file in order to add pod level annotations for this chart.

Update `values.yaml` to insert your custom annotations:
```
kubernetes:
    podAnnotations: 
        your.domain/cusom-annotations: important-value
```


## Fixes 
This PR is addressing Issue #1083

