### PR TITLE
enable use of system namespaces using env variable

### DIFF
--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         env:
+        - name: allowSystemNamespaces
+          value: {{ default .Values.appgw.allowSystemNamespaces "false" }}
         - name: AZURE_CLOUD_PROVIDER_LOCATION
           value: /etc/appgw/azure.json
         - name: AGIC_POD_NAME

--- a/pkg/k8scontext/k8scontext_test.go
+++ b/pkg/k8scontext/k8scontext_test.go
@@ -7,6 +7,7 @@ package k8scontext
 
 import (
 	"context"
+	"os"
 	"reflect"
 	"time"
 
@@ -435,6 +436,21 @@ var _ = ginkgo.Describe("K8scontext", func() {
 			}
 			finalList := filterAndSort(ingrList)
 			Expect(finalList).To(ContainElement(ingr))
+		})
+	})
+
+	ginkgo.Context("System namespaces consideration", func() {
+		ginkgo.It("system namespaces should be ignored by default", func() {
+			Expect(namespacesToIgnore).To(HaveLen(2))
+		})
+
+		ginkgo.It("system namespaces should be considered when env var allowSystemNamespaces is set to true", func() {
+			k8sClient = testclient.NewSimpleClientset()
+			crdClient := fake.NewSimpleClientset()
+			istioCrdClient := istioFake.NewSimpleClientset()
+			os.Setenv("allowSystemNamespaces", "true")
+			NewContext(k8sClient, crdClient, istioCrdClient, []string{ingressNS}, 1000*time.Second, metricstore.NewFakeMetricStore())
+			Expect(namespacesToIgnore).To(HaveLen(0))
 		})
 	})
 })


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [X] The title of the PR is clear and informative
- [X] If applicable, the changes made in the PR have proper test coverage
- [X] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

Added an environment variable allowSystemNamespaces which controls whether system namespaces are monitored for secrets and ingress resource definitions. By setting variable allowSystemNamespaces  to "true", secrets and ingresses can be utilized in namespaces kube-system, kube-public for usage by  application gateway ingress controller. Default behaviour is preserved, where secrets and ingresses in namespaces kube-system and kube-public are ignored.

## Fixes

#1060
