### PR TITLE
Optional host mounts with ability to run pod as non-root. 

### DIFF
--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -32,8 +32,10 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "application-gateway-kubernetes-ingress.serviceaccountname" . }}
-      securityContext:        
-        runAsUser: 0
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -51,8 +53,6 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         env:
-        - name: AZURE_CLOUD_PROVIDER_LOCATION
-          value: /etc/appgw/azure.json
         - name: AGIC_POD_NAME
           valueFrom:
             fieldRef:
@@ -66,32 +66,37 @@ spec:
         - name: AZURE_AUTH_LOCATION
           value: /etc/Azure/Networking-AppGW/auth/armAuth.json
         {{- end}}
+        {{- else }}
+        - name: AZURE_CLOUD_PROVIDER_LOCATION
+          value: /etc/appgw/azure.json
         {{- end}}
         envFrom:
         - configMapRef:
             name: {{ template "application-gateway-kubernetes-ingress.configmapname" . }}
         volumeMounts:
-        - name: azure
-          mountPath: /etc/appgw/
-          readOnly: true
         {{- if .Values.armAuth }}
         {{- if eq .Values.armAuth.type "servicePrincipal"}}
         - name: networking-appgw-k8s-azure-service-principal-mount
           mountPath: /etc/Azure/Networking-AppGW/auth
           readOnly: true
         {{- end}}
+        {{- else }}
+        - name: azure
+          mountPath: /etc/appgw/
+          readOnly: true
         {{- end}}
       volumes:
-      - name: azure
-        hostPath:
-          path: /etc/kubernetes/
-          type: Directory
       {{- if .Values.armAuth }}
       {{- if eq .Values.armAuth.type "servicePrincipal"}}
       - name: networking-appgw-k8s-azure-service-principal-mount
         secret:
           secretName: networking-appgw-k8s-azure-service-principal
       {{- end}}
+      {{- else }}
+      - name: azure
+        hostPath:
+          path: /etc/kubernetes/
+          type: Directory
       {{- end}}
       {{- if .Values.kubernetes.nodeSelector }}
       {{- with .Values.kubernetes.nodeSelector }}

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -73,3 +73,6 @@ nodeSelector: {}
 # Specify if the cluster is RBAC enabled or not
 rbac:
   enabled: false # true/false
+
+securityContext:
+  runAsUser: 0


### PR DESCRIPTION
Fixes Azure/application-gateway-kubernetes-ingress#1113

Signed-off-by: Mikhail Advani <mikhail.advani@gmail.com>

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

- Security context of the deployment has been moved to values so that it can be overridden where needed.
- Mount and set the AZURE_CLOUD_PROVIDER_LOCATION if and only if armAuth is not defined, i.e. the pod relies on the node for authentication parameters

## Fixes

#1113 