### PR TITLE
config: remove tag LastUpdatedByK8sIngress as this causes diff in generated config

### DIFF
--- a/functional_tests/duplicate_ports.json
+++ b/functional_tests/duplicate_ports.json
@@ -240,7 +240,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/health_probes_same_labels_different_namespaces.json
+++ b/functional_tests/health_probes_same_labels_different_namespaces.json
@@ -313,7 +313,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/one_ingress_https_backend.json
+++ b/functional_tests/one_ingress_https_backend.json
@@ -282,7 +282,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/one_ingress_https_backend_without_backend_protocol.json
+++ b/functional_tests/one_ingress_https_backend_without_backend_protocol.json
@@ -206,7 +206,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/one_ingress_slash_nothing.json
+++ b/functional_tests/one_ingress_slash_nothing.json
@@ -176,7 +176,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/one_ingress_slash_slashnothing.json
+++ b/functional_tests/one_ingress_slash_slashnothing.json
@@ -249,7 +249,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/one_ingress_with_multiple_path_rules.json
+++ b/functional_tests/one_ingress_with_multiple_path_rules.json
@@ -325,7 +325,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/three_ingresses.json
+++ b/functional_tests/three_ingresses.json
@@ -405,7 +405,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/two_ingresses_same_domain_tls_notls.json
+++ b/functional_tests/two_ingresses_same_domain_tls_notls.json
@@ -313,7 +313,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/two_ingresses_same_hostname_value_different_locations.json
+++ b/functional_tests/two_ingresses_same_hostname_value_different_locations.json
@@ -234,7 +234,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/two_ingresses_slash_slashsomething.json
+++ b/functional_tests/two_ingresses_slash_slashsomething.json
@@ -249,7 +249,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/two_ingresses_with_and_without_extended_hostname.json
+++ b/functional_tests/two_ingresses_with_and_without_extended_hostname.json
@@ -309,7 +309,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/functional_tests/waf_annotation.json
+++ b/functional_tests/waf_annotation.json
@@ -255,7 +255,6 @@
     },
     "tags": {
         "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
-        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
         "managed-by-k8s-ingress": "a/b/c"
     }
 }

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -386,11 +386,10 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 		}
 
 		// Check tags
-		Expect(len(appGW.Tags)).To(Equal(3))
+		Expect(len(appGW.Tags)).To(Equal(2))
 		expected := map[string]*string{
-			tags.ManagedByK8sIngress:     to.StringPtr("a/b/c"),
-			tags.IngressForAKSClusterID:  to.StringPtr("/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname"),
-			tags.LastUpdatedByK8sIngress: to.StringPtr("2009-11-17 20:34:58.651387237 +0000 UTC"),
+			tags.ManagedByK8sIngress:    to.StringPtr("a/b/c"),
+			tags.IngressForAKSClusterID: to.StringPtr("/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname"),
 		}
 		Expect(appGW.Tags).To(Equal(expected))
 	}

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -11,10 +11,10 @@ import (
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
-	"k8s.io/klog/v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/azure"
@@ -255,7 +255,6 @@ func (c *appGwConfigBuilder) addTags() {
 	} else {
 		klog.V(5).Infof("Error while parsing cluster resource ID for tagging: %s", err)
 	}
-	c.appGw.Tags[tags.LastUpdatedByK8sIngress] = to.StringPtr(c.clock.Now().String())
 }
 
 // GetVersion returns a string representing the version of AGIC.

--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -422,7 +422,6 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --    },
 --    "tags": {
 --        "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
---        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
 --        "managed-by-k8s-ingress": "a/b/c"
 --    }
 --}`
@@ -655,7 +654,6 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --    },
 --    "tags": {
 --        "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
---        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
 --        "managed-by-k8s-ingress": "a/b/c"
 --    }
 --}`
@@ -935,7 +933,6 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --    },
 --    "tags": {
 --        "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
---        "last-updated-by-k8s-ingress": "2009-11-17 20:34:58.651387237 +0000 UTC",
 --        "managed-by-k8s-ingress": "a/b/c"
 --    }
 --}`


### PR DESCRIPTION


<!-- DO NOT DELETE THIS TEMPLATE -->
This PR removes the LastUpdatedByK8sIngress as this causes unnecessary in AppGW config and leads to longer to operation times.

## Checklist
- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
