### PR TITLE
Update azuredeploy.json

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -281,7 +281,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.18.8",
+            "defaultValue": "1.18.14",
             "type": "string",
             "metadata": {
                 "description": "The version of Kubernetes."


### PR DESCRIPTION
update the latest default k8s version
1.18.8 is not supported anymore
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
