### PR TITLE
Bump AKS default version

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -281,7 +281,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.18.14",
+            "defaultValue": "1.21.1",
             "type": "string",
             "metadata": {
                 "description": "The version of Kubernetes."


### PR DESCRIPTION
otherwise it'll throw-out this error:
```
{"error":{"code":"InvalidTemplateDeployment","message":"The template deployment 'ingress-appgw' is not valid according to the validation procedure. The tracking id is 'cc9eaf47-df7a-46f4-975a-c78b0f605e9d'. See inner errors for details.","details":[{"code":"AgentPoolK8sVersionNotSupported","message":"Provisioning of resource(s) for container service aksa294 in resource group Feast-AKS-Ingress failed. Message: {\n  \"code\": \"AgentPoolK8sVersionNotSupported\",\n  \"message\": \"Version 1.18.14 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list\"\n }. Details: "}]}}

```

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [ ] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
