### PR TITLE
helm: add networking.k8s.io to cluster role

### DIFF
--- a/helm/ingress-azure/templates/clusterrole.yaml
+++ b/helm/ingress-azure/templates/clusterrole.yaml
@@ -35,6 +35,7 @@ rules:
     - watch
 - apiGroups:
     - extensions
+    - networking.k8s.io
   resources:
     - ingresses
   verbs:
@@ -43,6 +44,7 @@ rules:
     - watch
 - apiGroups:
     - extensions
+    - networking.k8s.io
   resources:
     - ingresses/status
   verbs:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
With V1 change, AGIC's `clusterrole` needs access to `networking.k8s.io`. Caught through E2E.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
