### PR TITLE
Change default kubernetesVersion to 1.20.7

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -281,7 +281,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.18.14",
+            "defaultValue": "1.20.7",
             "type": "string",
             "metadata": {
                 "description": "The version of Kubernetes."


### PR DESCRIPTION
Version 1.18.14 is not available in some (maybe all) regions. Using the template throws error:

{"error":{"code":"InvalidTemplateDeployment","message":"The template deployment 'ingress-appgw' is not valid according to the validation procedure. The tracking id is '3a051d9c-7a4e-4b1d-9d7b-44036d438f59'. See inner errors for details.","details":[{"code":"AgentPoolK8sVersionNotSupported","message":"Provisioning of resource(s) for container service aks1ab4 in resource group MyResourceGroup failed. Message: {\n  \"code\": \"AgentPoolK8sVersionNotSupported\",\n  \"message\": \"Version 1.18.14 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list\"\n }. Details: "}]}}

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [ ] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
