### PR TITLE
Updating apiVersion to eliminate error

### DIFF
--- a/docs/examples/aspnetapp.yaml
+++ b/docs/examples/aspnetapp.yaml
@@ -28,7 +28,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: aspnetapp
@@ -39,6 +39,9 @@ spec:
   - http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: aspnetapp
-          servicePort: 80
+          service:
+            name: aspnetapp
+            port: 
+              number: 80              


### PR DESCRIPTION
Updating  apiVersion from extensions/v1beta1 to networking.k8s.io/v1, otherwise running `kubectl apply` will give an error:
`Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress`

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [X] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

Updating Ingress apiVersion from extensions/v1beta1 to networking.k8s.io/v1, the applying formatting changes as needed for differences between the two versions

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
