### PR TITLE
Update aspnetappwin.yaml

### DIFF
--- a/docs/examples/aspnetappwin.yaml
+++ b/docs/examples/aspnetappwin.yaml
@@ -30,7 +30,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: aspnetapp
@@ -40,7 +40,10 @@ spec:
   rules:
   - http:
       paths:
-      - path: /
+      - path: /aspnet
+        pathType: Prefix
         backend:
-          serviceName: aspnetapp
-          servicePort: 80
+          service:
+            name: aspnetapp
+            port:
+              number: 80

--- a/docs/examples/aspnetappwin.yaml
+++ b/docs/examples/aspnetappwin.yaml
@@ -40,7 +40,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /aspnet
+      - path: /
         pathType: Prefix
         backend:
           service:


### PR DESCRIPTION
updated to use the new api version networking.k8s.io/v1 instead of  depcreated api extensions/v1beta1 which is getting removed in 1.22

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
