### PR TITLE
fix: update AAD and Azure endpoints using Cloud from cpConfig

### DIFF
--- a/pkg/azure/auth.go
+++ b/pkg/azure/auth.go
@@ -10,6 +10,7 @@ import (
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-03-01/network"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"k8s.io/klog/v2"
 
@@ -40,6 +41,11 @@ func getAuthorizer(authLocation string, useManagedidentity bool, cpConfig *Cloud
 	if !useManagedidentity && cpConfig != nil {
 		klog.V(1).Info("Creating authorizer using Cluster Service Principal.")
 		credAuthorizer := auth.NewClientCredentialsConfig(cpConfig.ClientID, cpConfig.ClientSecret, cpConfig.TenantID)
+
+		// Set active directory endpoint using environment
+		azureEnv, _ := azure.EnvironmentFromName(cpConfig.Cloud)
+		credAuthorizer.AADEndpoint = azureEnv.ActiveDirectoryEndpoint
+
 		return credAuthorizer.Authorizer()
 	}
 

--- a/pkg/azure/auth.go
+++ b/pkg/azure/auth.go
@@ -45,6 +45,7 @@ func getAuthorizer(authLocation string, useManagedidentity bool, cpConfig *Cloud
 		// Set active directory endpoint using environment
 		azureEnv, _ := azure.EnvironmentFromName(cpConfig.Cloud)
 		credAuthorizer.AADEndpoint = azureEnv.ActiveDirectoryEndpoint
+		credAuthorizer.Resource = azureEnv.ResourceManagerEndpoint
 
 		return credAuthorizer.Authorizer()
 	}


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

* This issue is affecting AGIC addon in non-public cloud regions like China / US regions
* It affects addon when cluster is deployed in service principal mode.
* In this mode, AGIC uses the `clientId` and `clientSecret` fromm the cloud provider config.
* In this case, AGIC uses the standard `auth.NewClientCredentialsConfig` Auth library call which by default to public endpoints for AAD and ARM.
* This fails in non-public clouds.

In this fix, we use the `Cloud` name provided in the cloud provider config to initialize the correct endpoints.

## Tests
This was tested in the mooncake AKS deployment.
<!-- Please add a brief description of the changes made in this PR -->
Error without the fix:
![image](https://user-images.githubusercontent.com/5294363/134549321-d0baafc8-fb5a-44f7-a86b-6be3ef959a58.png)


After the fix, AGIC is able to successfully get a token and update AppGateway
![image](https://user-images.githubusercontent.com/5294363/134549035-488f4c93-78d2-4ced-9883-ff1acf4681e8.png)


## Fixes

<!-- Please mention #issues that are fixed in this PR -->
