### PR TITLE
fix: panic when processing duplicate paths in urlpathmap

### DIFF
--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -6,6 +6,7 @@
 package appgw
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -383,7 +384,7 @@ func (c *appGwConfigBuilder) mergePathMap(existingPathMap *n.ApplicationGatewayU
 		addRuleToMergeList := true
 		for _, path := range *pathRule.Paths {
 			if _, exists := pathMap[path]; exists {
-				klog.Errorf("A path-rule with path '%s' already exists in config for BackendPool '%s'. Duplicate path-rule with BackendPool '%s' will not be applied.", path, *pathMap[path].BackendAddressPool.ID, *pathRule.BackendAddressPool.ID)
+				klog.Errorf("A path-rule with path '%s' already exists'. Existing path rule {%s} and new path rule {%s}.", path, printPathRule(pathMap[path]), printPathRule(pathRule))
 				addRuleToMergeList = false
 			} else {
 				pathMap[path] = pathRule
@@ -397,4 +398,22 @@ func (c *appGwConfigBuilder) mergePathMap(existingPathMap *n.ApplicationGatewayU
 	existingPathMap.PathRules = &mergedPathRules
 
 	return existingPathMap
+}
+
+func printPathRule(pathRule n.ApplicationGatewayPathRule) string {
+	s := fmt.Sprintf("pathMapName=%s", *pathRule.Name)
+
+	if pathRule.BackendAddressPool != nil && pathRule.BackendAddressPool.ID != nil {
+		s = fmt.Sprintf("%s poolID=%s", s, *pathRule.BackendAddressPool.ID)
+	}
+
+	if pathRule.RedirectConfiguration != nil && pathRule.RedirectConfiguration.ID != nil {
+		s = fmt.Sprintf("%s redirectID=%s", s, *pathRule.RedirectConfiguration.ID)
+	}
+
+	if pathRule.LoadDistributionPolicy != nil && pathRule.LoadDistributionPolicy.ID != nil {
+		s = fmt.Sprintf("%s ldpID=%s", s, *pathRule.LoadDistributionPolicy.ID)
+	}
+
+	return s
 }

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -549,7 +549,7 @@ var _ = Describe("Test routing rules generations", func() {
 
 		// 2 path based rules with path - /api1, /api2
 		ingressPathBased := tests.NewIngressFixture()
-		ingressPathBased.Annotations[annotations.SslRedirectKey] = "false"
+		ingressPathBased.Annotations[annotations.SslRedirectKey] = "true"
 		backendBasic := tests.NewIngressBackendFixture(service2.Name, 80)
 
 		// Adding duplicate path /api for a different service in same ingress
@@ -628,7 +628,7 @@ var _ = Describe("Test routing rules generations", func() {
 
 		// 2 path based rules with path - /api1, /api2
 		ingressPathBased := tests.NewIngressFixture()
-		ingressPathBased.Annotations[annotations.SslRedirectKey] = "false"
+		ingressPathBased.Annotations[annotations.SslRedirectKey] = "true"
 		backendBasic := tests.NewIngressBackendFixture(tests.ServiceName, 80)
 		// Adding duplicate path /api3 for a same service in same ingress
 		duplicatePathRule := tests.NewIngressRuleWithPathsFixture(tests.Host, []string{"/api3", "/api3"}, *backendBasic)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
AGIC is hitting panic when processing url path maps with duplicate paths and ssl redirect annotation is true.

AGIC tries to print an error message using `BackendAddressPool.ID` which panics since path rule with redirect configuration doesn't have a backend pool.
```go
klog.Errorf("A path-rule with path '%s' already exists in config for BackendPool '%s'. Duplicate path-rule with BackendPool '%s' will not be applied.", path, *pathMap[path].BackendAddressPool.ID, *pathRule.BackendAddressPool.ID)
```

PANIC:
```
panic: runtime error: invalid memory address or nil pointer dereference                                                                                                                                                                                                                                                                             
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1477e98]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
goroutine 142 [running]:                                                                                                                                                                                                                                                                                                                            
github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw.(*appGwConfigBuilder).mergePathMap(0xc0010aefc0, 0xc001228b40, 0xc0013df440, 0xc0006201e0, 0x17)                                                                                                                                                                                          
/home/vsts/work/1/s/gopath/src/github.com/Azure/application-gateway-kubernetes-ingress/pkg/appgw/requestroutingrules.go:386 +0x5b8   
```

## Tests
When duplicate paths test was updated with "ssl-redirect" annotation, the test started to panic. Test is passing now with the fix.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
Fixes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1269