### PR TITLE
fix(prohibited target): incorrect merge when rules being merged reference the same path map 

### DIFF
--- a/pkg/brownfield/brownfield_suite_test.go
+++ b/pkg/brownfield/brownfield_suite_test.go
@@ -8,13 +8,19 @@
 package brownfield
 
 import (
+	"flag"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/klog/v2"
 )
 
 func TestApplicationGatewayKubernetesIngress(t *testing.T) {
+	klog.InitFlags(nil)
+	_ = flag.Set("v", "5")
+	_ = flag.Lookup("logtostderr").Value.Set("true")
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "ApplicationGatewayKubernetesIngress Suite")
 }

--- a/pkg/brownfield/pathmaps.go
+++ b/pkg/brownfield/pathmaps.go
@@ -109,6 +109,10 @@ func mergePathMapsWithBasicRule(pathMap *n.ApplicationGatewayURLPathMap, rule *n
 func mergePathRules(pathRulesBucket ...*[]n.ApplicationGatewayPathRule) *[]n.ApplicationGatewayPathRule {
 	uniq := make(pathRulesByName)
 	for _, bucket := range pathRulesBucket {
+		if bucket == nil {
+			continue
+		}
+
 		for _, pathRule := range *bucket {
 			uniq[pathRuleName(*pathRule.Name)] = pathRule
 		}

--- a/pkg/brownfield/pathmaps.go
+++ b/pkg/brownfield/pathmaps.go
@@ -119,6 +119,7 @@ func mergePathRules(pathRulesBucket ...*[]n.ApplicationGatewayPathRule) *[]n.App
 	}
 	var merged []n.ApplicationGatewayPathRule
 	for _, pathRule := range uniq {
+		klog.V(5).Infof("[brownfield] Appending %s with paths %v", *pathRule.Name, pathRule.Paths)
 		merged = append(merged, pathRule)
 	}
 	return &merged

--- a/pkg/brownfield/routing_rules.go
+++ b/pkg/brownfield/routing_rules.go
@@ -118,6 +118,7 @@ func mergeRoutingRules(appGw *n.ApplicationGateway, firstRoutingRule *n.Applicat
 
 		if *firstRoutingRule.URLPathMap.ID == *secondRoutingRule.URLPathMap.ID {
 			// No merge needed as both routing rule point to the same URL Path map
+			klog.V(5).Infof("[brownfield] Rule %s and rule %s share the same path map %s; Skipping merge", *firstRoutingRule.Name, *secondRoutingRule.Name, *firstPathMap.Name)
 			return firstRoutingRule
 		}
 

--- a/pkg/brownfield/routing_rules.go
+++ b/pkg/brownfield/routing_rules.go
@@ -116,6 +116,11 @@ func mergeRoutingRules(appGw *n.ApplicationGateway, firstRoutingRule *n.Applicat
 			return firstRoutingRule
 		}
 
+		if *firstRoutingRule.URLPathMap.ID == *secondRoutingRule.URLPathMap.ID {
+			// No merge needed as both routing rule point to the same URL Path map
+			return firstRoutingRule
+		}
+
 		// Get the url path map for the second rule
 		secondPathMap := lookupPathMap(appGw.URLPathMaps, secondRoutingRule.URLPathMap.ID)
 

--- a/pkg/brownfield/routing_rules_test.go
+++ b/pkg/brownfield/routing_rules_test.go
@@ -162,6 +162,7 @@ var _ = Describe("Test blacklist request routing rules", func() {
 
 			Expect(pathBasedRuleCount).To(Equal(3))
 			Expect(basicRuleCount).To(Equal(2))
+			Expect(len(*appGw.URLPathMaps)).To(Equal(4))
 		})
 
 		It("should merge correctly when 2 routing rule use the same http listener but different url paths", func() {
@@ -169,13 +170,15 @@ var _ = Describe("Test blacklist request routing rules", func() {
 			// as AppGw doesn't allow 2 rules using same listener
 
 			// Setup 2 path maps
-			pathMap1 := (*appGw.URLPathMaps)[0]
-			pathMap2 := (*appGw.URLPathMaps)[1]
+			pathMap1 := (*appGw.URLPathMaps)[1]
+			pathMap2 := (*appGw.URLPathMaps)[2]
 			urlPathMap := &[]n.ApplicationGatewayURLPathMap{
 				pathMap1,
 				pathMap2,
 			}
 			appGw.URLPathMaps = urlPathMap
+			Expect(len(*pathMap1.PathRules)).To(Equal(2))
+			Expect(len(*pathMap2.PathRules)).To(Equal(1))
 
 			// Setup first rule to use first path map
 			rulePathBased1.URLPathMap.ID = pathMap1.ID
@@ -199,7 +202,7 @@ var _ = Describe("Test blacklist request routing rules", func() {
 			Expect(len(*appGw.URLPathMaps)).To(Equal(1))
 
 			pathRules := *(*appGw.URLPathMaps)[0].PathRules
-			Expect(len(pathRules)).To(Equal(2))
+			Expect(len(pathRules)).To(Equal(3))
 		})
 	})
 })

--- a/pkg/tests/fixtures/paths.go
+++ b/pkg/tests/fixtures/paths.go
@@ -34,6 +34,7 @@ const (
 func GetURLPathMap1() *n.ApplicationGatewayURLPathMap {
 	return &n.ApplicationGatewayURLPathMap{
 		Name: to.StringPtr(URLPathMapName1),
+		ID:   to.StringPtr("x/y/z/" + URLPathMapName1),
 		ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 			// DefaultBackendAddressPool - Default backend address pool resource of URL path map.
 			DefaultBackendAddressPool: &n.SubResource{
@@ -135,6 +136,7 @@ func GetDefaultURLPathMap() *n.ApplicationGatewayURLPathMap {
 	return &n.ApplicationGatewayURLPathMap{
 		Etag: to.StringPtr("*"),
 		Name: to.StringPtr(DefaultPathMapName),
+		ID:   to.StringPtr("x/y/z/" + DefaultPathMapName),
 		ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 			DefaultBackendAddressPool:  &n.SubResource{ID: to.StringPtr("/" + DefaultBackendPoolName)},
 			DefaultBackendHTTPSettings: &n.SubResource{ID: to.StringPtr("/" + DefaultBackendHTTPSettingsName)},
@@ -146,6 +148,7 @@ func GetDefaultURLPathMap() *n.ApplicationGatewayURLPathMap {
 func GetURLPathMap2() *n.ApplicationGatewayURLPathMap {
 	return &n.ApplicationGatewayURLPathMap{
 		Name: to.StringPtr(URLPathMapName2),
+		ID:   to.StringPtr("x/y/z/" + URLPathMapName2),
 		ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 			// DefaultBackendAddressPool - Default backend address pool resource of URL path map.
 			DefaultBackendAddressPool: &n.SubResource{
@@ -212,6 +215,7 @@ func GetPathRulePathBased2() *n.ApplicationGatewayPathRule {
 func GetURLPathMap3() *n.ApplicationGatewayURLPathMap {
 	return &n.ApplicationGatewayURLPathMap{
 		Name: to.StringPtr(URLPathMapName3),
+		ID:   to.StringPtr("x/y/z/" + URLPathMapName3),
 		ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
 			// DefaultBackendAddressPool - Default backend address pool resource of URL path map.
 			DefaultBackendAddressPool: &n.SubResource{

--- a/pkg/tests/fixtures/paths.go
+++ b/pkg/tests/fixtures/paths.go
@@ -68,7 +68,7 @@ func GetURLPathMap1() *n.ApplicationGatewayURLPathMap {
 // GetPathRulePathBased1 creates a new struct for use in unit tests.
 func GetPathRulePathBased1() *n.ApplicationGatewayPathRule {
 	return &n.ApplicationGatewayPathRule{
-		Name: to.StringPtr(PathRuleName),
+		Name: to.StringPtr(PathRuleName + URLPathMapName1),
 		ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 			// Paths - Path rules of URL path map.
 			Paths: &[]string{
@@ -181,7 +181,7 @@ func GetURLPathMap2() *n.ApplicationGatewayURLPathMap {
 // GetPathRulePathBased2 creates a new struct for use in unit tests.
 func GetPathRulePathBased2() *n.ApplicationGatewayPathRule {
 	return &n.ApplicationGatewayPathRule{
-		Name: to.StringPtr(PathRuleName),
+		Name: to.StringPtr(PathRuleName + URLPathMapName2),
 		ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 			// Paths - Path rules of URL path map.
 			Paths: &[]string{
@@ -248,7 +248,7 @@ func GetURLPathMap3() *n.ApplicationGatewayURLPathMap {
 // GetPathRulePathBased3 creates a new struct for use in unit tests.
 func GetPathRulePathBased3() *n.ApplicationGatewayPathRule {
 	return &n.ApplicationGatewayPathRule{
-		Name: to.StringPtr(PathRuleName),
+		Name: to.StringPtr(PathRuleName + URLPathMapName3),
 		ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
 			// Paths - Path rules of URL path map.
 			Paths: &[]string{

--- a/pkg/tests/fixtures/paths_test.go
+++ b/pkg/tests/fixtures/paths_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Test Fixtures", func() {
 	Context("Testing GetPathRulePathBased1", func() {
 		It("should work as expected", func() {
 			actual := GetPathRulePathBased1()
-			Expect(*actual.Name).To(Equal("PathRule-1"))
+			Expect(*actual.Name).To(Equal("PathRule-1URLPathMap-1"))
 		})
 	})
 
@@ -49,7 +49,7 @@ var _ = Describe("Test Fixtures", func() {
 	Context("Testing GetPathRulePathBased2", func() {
 		It("should work as expected", func() {
 			actual := GetPathRulePathBased2()
-			Expect(*actual.Name).To(Equal("PathRule-1"))
+			Expect(*actual.Name).To(Equal("PathRule-1URLPathMap-2"))
 		})
 	})
 })


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
This PR fixes a bug in prohibited target.

When AGIC merges two routing rule together - existing and generated one - it also merged the attached URL path maps.
After merging AGIC deletes the second path map and only keeps the first one. This causes a bug when both first path map and second path map have the same `name`.

When path maps have the same name, they have already been merged when AGIC processes the path map before processing request routing rule. So, there is no need to merge the path maps again as it is already having the new rules.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
Fixes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1257
