### PR TITLE
Add cookie-based-affinity-distinct-name annotation

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -392,6 +392,38 @@ spec:
           serviceName: go-server-service
           servicePort: 80
 ```
+### distinct cookie name
+In addition to cookie-based-affinity, you can set `cookie-based-affinity-distinct-name: "true"` to ensure a different affinity cookie is set per backend.
+###
+
+```yaml
+appgw.ingress.kubernetes.io/cookie-based-affinity-distinct-name: "true"
+```
+### Example
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: go-server-ingress-affinity
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/cookie-based-affinity: "true"
+    appgw.ingress.kubernetes.io/cookie-based-affinity-distinct-name: "true"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /affinity1/
+        backend:
+          serviceName: affinity-service
+          servicePort: 80
+      - path: /affinity2/
+        backend:
+          serviceName: other-affinity-service
+          servicePort: 80          
+```
 
 ## Request Timeout
 

--- a/functional_tests/cookie_name.json
+++ b/functional_tests/cookie_name.json
@@ -63,7 +63,7 @@
                 "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--SlashNothingSlashSomething",
                 "name": "bp---namespace---hello-world-b-80-80---name--SlashNothingSlashSomething",
                 "properties": {
-                    "affinityCookieName": "ef38541db88f854ddb5b951dd04b333d",
+                    "affinityCookieName": "appgw-affinity-ef38541db88f854ddb5b951dd04b333d",
                     "cookieBasedAffinity": "Enabled",
                     "pickHostNameFromBackendAddress": false,
                     "port": 80,

--- a/functional_tests/cookie_name.json
+++ b/functional_tests/cookie_name.json
@@ -1,0 +1,262 @@
+{
+    "properties": {
+        "backendAddressPools": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/defaultaddresspool",
+                "name": "defaultaddresspool",
+                "properties": {
+                    "backendAddresses": []
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-a-80-bp-80",
+                "name": "pool---namespace---hello-world-a-80-bp-80",
+                "properties": {
+                    "backendAddresses": [
+                        {
+                            "ipAddress": "1.1.1.1"
+                        },
+                        {
+                            "ipAddress": "1.1.1.2"
+                        },
+                        {
+                            "ipAddress": "1.1.1.3"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80",
+                "name": "pool---namespace---hello-world-b-80-bp-80",
+                "properties": {
+                    "backendAddresses": [
+                        {
+                            "ipAddress": "1.1.1.1"
+                        },
+                        {
+                            "ipAddress": "1.1.1.2"
+                        },
+                        {
+                            "ipAddress": "1.1.1.3"
+                        }
+                    ]
+                }
+            }
+        ],
+        "backendHttpSettingsCollection": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-a-80-80---name--SlashNothingSlashSomething",
+                "name": "bp---namespace---hello-world-a-80-80---name--SlashNothingSlashSomething",
+                "properties": {
+                    "affinityCookieName": "3362c921cf90d228a7cd586ac3d72008",
+                    "cookieBasedAffinity": "Enabled",
+                    "pickHostNameFromBackendAddress": false,
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-a-80---name--SlashNothingSlashSomething"
+                    },
+                    "protocol": "Http",
+                    "requestTimeout": 30
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--SlashNothingSlashSomething",
+                "name": "bp---namespace---hello-world-b-80-80---name--SlashNothingSlashSomething",
+                "properties": {
+                    "affinityCookieName": "ef38541db88f854ddb5b951dd04b333d",
+                    "cookieBasedAffinity": "Enabled",
+                    "pickHostNameFromBackendAddress": false,
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--SlashNothingSlashSomething"
+                    },
+                    "protocol": "Http",
+                    "requestTimeout": 30
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/defaulthttpsetting",
+                "name": "defaulthttpsetting",
+                "properties": {
+                    "cookieBasedAffinity": "Disabled",
+                    "pickHostNameFromBackendAddress": false,
+                    "port": 80,
+                    "probe": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http"
+                    },
+                    "protocol": "Http",
+                    "requestTimeout": 30
+                }
+            }
+        ],
+        "frontendIPConfigurations": [
+            {
+                "id": "--front-end-ip-id-1--",
+                "name": "xx3",
+                "properties": {
+                    "publicIPAddress": {
+                        "id": "xyz"
+                    }
+                }
+            },
+            {
+                "id": "--front-end-ip-id-2--",
+                "name": "yy3",
+                "properties": {
+                    "privateIPAddress": "abc"
+                }
+            }
+        ],
+        "frontendPorts": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80",
+                "name": "fp-80",
+                "properties": {
+                    "port": 80
+                }
+            }
+        ],
+        "httpListeners": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "properties": {
+                    "firewallPolicy": {
+                        "id": "/some/policy/here"
+                    },                    
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
+                    },
+                    "hostNames": [],
+                    "protocol": "Http",
+                    "requireServerNameIndication": false
+                }
+            }
+        ],
+        "probes": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Http",
+                "name": "defaultprobe-Http",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "match": {},
+                    "minServers": 0,
+                    "path": "/",
+                    "pickHostNameFromBackendHttpSettings": false,
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/defaultprobe-Https",
+                "name": "defaultprobe-Https",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "match": {},
+                    "minServers": 0,
+                    "path": "/",
+                    "pickHostNameFromBackendHttpSettings": false,
+                    "protocol": "Https",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-a-80---name--SlashNothingSlashSomething",
+                "name": "pb---namespace---hello-world-a-80---name--SlashNothingSlashSomething",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "match": {},
+                    "minServers": 0,
+                    "path": "/A",
+                    "pickHostNameFromBackendHttpSettings": false,
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/probes/pb---namespace---hello-world-b-80---name--SlashNothingSlashSomething",
+                "name": "pb---namespace---hello-world-b-80---name--SlashNothingSlashSomething",
+                "properties": {
+                    "host": "localhost",
+                    "interval": 30,
+                    "match": {},
+                    "minServers": 0,
+                    "path": "/",
+                    "pickHostNameFromBackendHttpSettings": false,
+                    "protocol": "Http",
+                    "timeout": 30,
+                    "unhealthyThreshold": 3
+                }
+            }
+        ],
+        "redirectConfigurations": [],
+        "requestRoutingRules": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "properties": {
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                    },
+                    "ruleType": "PathBasedRouting",
+                    "urlPathMap": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                    }
+                }
+            }
+        ],
+        "sku": {
+            "capacity": 3,
+            "name": "Standard_v2",
+            "tier": "Standard_v2"
+        },
+        "sslCertificates": [],
+        "urlPathMaps": [
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "properties": {
+                    "defaultBackendAddressPool": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
+                    },
+                    "defaultBackendHttpSettings": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--SlashNothingSlashSomething"
+                    },
+                    "pathRules": [
+                        {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
+                            "name": "pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
+                            "properties": {
+                                "backendAddressPool": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-a-80-bp-80"
+                                },
+                                "backendHttpSettings": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-a-80-80---name--SlashNothingSlashSomething"
+                                },
+                                "firewallPolicy": {
+                                    "id": "/some/policy/here"
+                                },                                
+                                "paths": [
+                                    "/A"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "tags": {
+        "ingress-for-aks-cluster-id": "/subscriptions/subid/resourcegroups/aksresgp/providers/Microsoft.ContainerService/managedClusters/aksname",
+        "managed-by-k8s-ingress": "a/b/c"
+    }
+}

--- a/functional_tests/cookie_name.json
+++ b/functional_tests/cookie_name.json
@@ -123,7 +123,7 @@
                 "properties": {
                     "firewallPolicy": {
                         "id": "/some/policy/here"
-                    },                    
+                    },
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
                     },
@@ -244,7 +244,7 @@
                                 },
                                 "firewallPolicy": {
                                     "id": "/some/policy/here"
-                                },                                
+                                },
                                 "paths": [
                                     "/A"
                                 ]

--- a/functional_tests/cookie_name.json
+++ b/functional_tests/cookie_name.json
@@ -48,7 +48,7 @@
                 "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-a-80-80---name--SlashNothingSlashSomething",
                 "name": "bp---namespace---hello-world-a-80-80---name--SlashNothingSlashSomething",
                 "properties": {
-                    "affinityCookieName": "3362c921cf90d228a7cd586ac3d72008",
+                    "affinityCookieName": "appgw-affinity-3362c921cf90d228a7cd586ac3d72008",
                     "cookieBasedAffinity": "Enabled",
                     "pickHostNameFromBackendAddress": false,
                     "port": 80,

--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // --------------------------------------------------------------------------------------------
 
+//go:build unittest
 // +build unittest
 
 package functests
@@ -1002,6 +1003,26 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 			check(cbCtx, "waf_annotation.json", stopChannel, ctxt, configBuilder)
+		})
+
+		ginkgo.It("Cookie Name", func() {
+			annotatedIngress := ingressSlashNothingSlashSomething
+			annotatedIngress.Annotations[annotations.CookieBasedAffinityKey] = "true"
+			annotatedIngress.Annotations[annotations.CookieBasedAffinityDistinctNameKey] = "true"
+
+			cbCtx := &ConfigBuilderContext{
+				IngressList: []*networking.Ingress{
+					annotatedIngress,
+				},
+				ServiceList:  serviceList,
+				EnvVariables: environment.GetFakeEnv(),
+				ExistingPortsByNumber: map[Port]n.ApplicationGatewayFrontendPort{
+					Port(80): fixtures.GetDefaultPort(),
+				},
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
+			}
+			check(cbCtx, "cookie_name.json", stopChannel, ctxt, configBuilder)
 		})
 
 		ginkgo.It("Health Probes: same container labels; different namespaces", func() {

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -51,6 +51,9 @@ const (
 	// CookieBasedAffinityKey defines the key to enable/disable cookie based affinity for client connection.
 	CookieBasedAffinityKey = ApplicationGatewayPrefix + "/cookie-based-affinity"
 
+	// CookieBasedAffinityDistinctNameKey defines the key to enable/disable distinct cookie names per backend for client connection.
+	CookieBasedAffinityDistinctNameKey = ApplicationGatewayPrefix + "/cookie-based-affinity-distinct-name"
+
 	// RequestTimeoutKey defines the request timeout to the backend.
 	RequestTimeoutKey = ApplicationGatewayPrefix + "/request-timeout"
 
@@ -228,6 +231,11 @@ func ConnectionDrainingTimeout(ing *networking.Ingress) (int32, error) {
 // IsCookieBasedAffinity provides value to enable/disable cookie based affinity for client connection.
 func IsCookieBasedAffinity(ing *networking.Ingress) (bool, error) {
 	return parseBool(ing, CookieBasedAffinityKey)
+}
+
+// IsCookieBasedAffinityDistinctName provides value to enable/disable distinct cookie name based affinity for client connection.
+func IsCookieBasedAffinityDistinctName(ing *networking.Ingress) (bool, error) {
+	return parseBool(ing, CookieBasedAffinityDistinctNameKey)
 }
 
 // UsePrivateIP determines whether to use private IP with the ingress

--- a/pkg/annotations/ingress_annotations_test.go
+++ b/pkg/annotations/ingress_annotations_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Test ingress annotation functions", func() {
 		"appgw.ingress.kubernetes.io/override-frontend-port":           "444",
 		"appgw.ingress.kubernetes.io/connection-draining":              "true",
 		"appgw.ingress.kubernetes.io/cookie-based-affinity":            "true",
+		"appgw.ingress.kubernetes.io/cookie-based-affinity-distinct-name":            "true",
 		"appgw.ingress.kubernetes.io/ssl-redirect":                     "true",
 		"appgw.ingress.kubernetes.io/request-timeout":                  "123456",
 		"appgw.ingress.kubernetes.io/connection-draining-timeout":      "3456",
@@ -83,6 +84,20 @@ var _ = Describe("Test ingress annotation functions", func() {
 			Expect(actual).To(Equal(true))
 		})
 	})
+
+	Context("test IsCookieBasedAffinityDistinctName", func() {
+		It("returns error when ingress has no annotations", func() {
+			ing := &networking.Ingress{}
+			actual, err := IsCookieBasedAffinityDistinctName(ing)
+			Expect(err).To(HaveOccurred())
+			Expect(actual).To(Equal(false))
+		})
+		It("returns true", func() {
+			actual, err := IsCookieBasedAffinityDistinctName(ing)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(true))
+		})
+	})	
 
 	Context("test appgwSslCertificate", func() {
 		It("returns error when ingress has no annotations", func() {

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -276,7 +276,7 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 	}
 
 	if distinctName, err := annotations.IsCookieBasedAffinityDistinctName(backendID.Ingress); err == nil && distinctName {
-		httpSettings.AffinityCookieName = to.StringPtr(backendID.serviceFullNameHash())
+		httpSettings.AffinityCookieName = to.StringPtr("test")
 	} else if err != nil && !controllererrors.IsErrorCode(err, controllererrors.ErrorMissingAnnotation) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
 	}

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -6,7 +6,6 @@
 package appgw
 
 import (
-	"crypto/md5"
 	"fmt"
 	"sort"
 	"strings"
@@ -277,9 +276,7 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 	}
 
 	if distinctName, err := annotations.IsCookieBasedAffinityDistinctName(backendID.Ingress); err == nil && distinctName {
-		hash := fmt.Sprintf("%x", md5.Sum([]byte(backendID.serviceFullName())))
-		//finalVal := fmt.Sprintf("%s%s%s", hash, "-", "affinity")
-		httpSettings.AffinityCookieName = to.StringPtr(hash)
+		httpSettings.AffinityCookieName = to.StringPtr(backendID.serviceFullNameHash())
 	} else if err != nil && !controllererrors.IsErrorCode(err, controllererrors.ErrorMissingAnnotation) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
 	}

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -276,8 +276,7 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 	}
 
 	if distinctName, err := annotations.IsCookieBasedAffinityDistinctName(backendID.Ingress); err == nil && distinctName {
-		klog.V(5).Infof("Try to set unique cookie name")
-		httpSettings.AffinityCookieName = to.StringPtr("test")
+		httpSettings.AffinityCookieName = to.StringPtr(backendID.serviceFullNameHash())
 	} else if err != nil && !controllererrors.IsErrorCode(err, controllererrors.ErrorMissingAnnotation) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
 	}

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -276,7 +276,7 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 	}
 
 	if distinctName, err := annotations.IsCookieBasedAffinityDistinctName(backendID.Ingress); err == nil && distinctName {
-		httpSettings.AffinityCookieName = to.StringPtr(backendID.serviceFullNameHash())
+		httpSettings.AffinityCookieName = to.StringPtr(fmt.Sprintf("%s%s", "appgw-affinity-", backendID.serviceFullNameHash()))
 	} else if err != nil && !controllererrors.IsErrorCode(err, controllererrors.ErrorMissingAnnotation) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
 	}

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -276,6 +276,7 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 	}
 
 	if distinctName, err := annotations.IsCookieBasedAffinityDistinctName(backendID.Ingress); err == nil && distinctName {
+		klog.V(5).Infof("Try to set unique cookie name")
 		httpSettings.AffinityCookieName = to.StringPtr("test")
 	} else if err != nil && !controllererrors.IsErrorCode(err, controllererrors.ErrorMissingAnnotation) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())

--- a/pkg/appgw/internaltypes.go
+++ b/pkg/appgw/internaltypes.go
@@ -106,6 +106,10 @@ func (s serviceIdentifier) serviceFullName() string {
 	return fmt.Sprintf("%v-%v", s.Namespace, s.Name)
 }
 
+func (s serviceIdentifier) serviceFullNameHash() string {
+	return fmt.Sprintf("%x", md5.Sum([]byte(s.serviceFullName())))
+}
+
 func (s serviceIdentifier) serviceKey() string {
 	return fmt.Sprintf("%v/%v", s.Namespace, s.Name)
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [X] The title of the PR is clear and informative
- [X] If applicable, the changes made in the PR have proper test coverage
- [X] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

Generate a unique affinity cookie name when the annotation `cookie-based-affinity-distinct-name` is set to `true` in an ingress. This maintains affinity when using path based routing for different backends..

Adding the following annotations will ensure every backend has a different affinity cookie:
```yaml
    appgw.ingress.kubernetes.io/cookie-based-affinity: "true"
    appgw.ingress.kubernetes.io/cookie-based-affinity-distinct-name: "true"
```

## Fixes

#772 Enhance annotation list of AGIC
