### PR TITLE
rewrite: Add support for rewrite rule set assignment

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -30,6 +30,7 @@ For an Ingress resource to be observed by AGIC it **must be annotated** with `ku
 | [appgw.ingress.kubernetes.io/health-probe-interval](#health-probe-interval) | `int32` | `nil`  |   | `1.4.0-rc1` |
 | [appgw.ingress.kubernetes.io/health-probe-timeout](#health-probe-timeout) | `int32` | `nil`  |   | `1.4.0-rc1` |
 | [appgw.ingress.kubernetes.io/health-probe-unhealthy-threshold](#health-probe-unhealthy-threshold) | `int32` | `nil`  |   | `1.4.0-rc1` |
+| [appgw.ingress.kubernetes.io/rewrite-rule-set](#rewrite-rule-set) | `string` | `nil`  |   | `1.5.0-rc1` |
 
 ## Override Frontend Port
 
@@ -785,4 +786,35 @@ spec:
             port:
               number: 8080
         pathType: Exact
+```
+
+## Rewrite Rule Set
+
+This annotation allows to assign an existing rewrite rule set to the corresponding request routing rule.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/rewrite-rule-set: <rewrite rule set>
+```
+
+### Example
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: go-server-ingress-bkprefix
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/rewrite-rule-set: add-custom-response-header
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: go-server-service
+          servicePort: 8080
 ```

--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -99,6 +99,9 @@ const (
 	// AppGwTrustedRootCertificate indicates the names of trusted root certificates
 	// Multiple root certificates separated by comma, e.g. "cert1,cert2"
 	AppGwTrustedRootCertificate = ApplicationGatewayPrefix + "/appgw-trusted-root-certificate"
+
+	// RewriteRuleSetKey indicates the name of the rule set to overwrite HTTP headers.
+	RewriteRuleSetKey = ApplicationGatewayPrefix + "/rewrite-rule-set"
 )
 
 var (
@@ -275,6 +278,11 @@ func GetHostNameExtensions(ing *networking.Ingress) ([]string, error) {
 // WAFPolicy override path
 func WAFPolicy(ing *networking.Ingress) (string, error) {
 	return parseString(ing, FirewallPolicy)
+}
+
+// RewriteRuleSet name
+func RewriteRuleSet(ing *networking.Ingress) (string, error) {
+	return parseString(ing, RewriteRuleSetKey)
 }
 
 func parseBool(ing *networking.Ingress, name string) (bool, error) {

--- a/pkg/appgw/identifier.go
+++ b/pkg/appgw/identifier.go
@@ -93,6 +93,10 @@ func (agw Identifier) requestRoutingRuleID(settingsName string) string {
 	return agw.gatewayResourceID("requestRoutingRules", settingsName)
 }
 
+func (agw Identifier) rewriteRuleSetID(rewriteName string) string {
+	return agw.gatewayResourceID("rewriteRuleSets", rewriteName)
+}
+
 func resourceRef(id string) *n.SubResource {
 	return &n.SubResource{ID: to.StringPtr(id)}
 }

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -68,7 +68,8 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 	httpListenersMap := c.groupListenersByListenerIdentifier(cbCtx)
 	pathMap := []n.ApplicationGatewayURLPathMap{}
 	var requestRoutingRules []n.ApplicationGatewayRequestRoutingRule
-	for listenerID, urlPathMap := range c.getPathMaps(cbCtx) {
+	urlPathMaps := c.getPathMaps(cbCtx)
+	for listenerID, urlPathMap := range urlPathMaps {
 		routingRuleName := generateRequestRoutingRuleName(listenerID)
 		httpListener, exists := httpListenersMap[listenerID]
 		if !exists {
@@ -97,6 +98,7 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 				rule.BackendAddressPool = nil
 				rule.BackendHTTPSettings = nil
 			}
+			rule.RewriteRuleSet = urlPathMap.DefaultRewriteRuleSet
 		} else {
 			// Path-based Rule
 			rule.RuleType = n.ApplicationGatewayRequestRoutingRuleTypePathBasedRouting
@@ -120,7 +122,7 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 	return requestRoutingRules, pathMap
 }
 
-func (c *appGwConfigBuilder) noRulesIngress(cbCtx *ConfigBuilderContext, ingress *networking.Ingress, urlPathMaps *map[listenerIdentifier]*n.ApplicationGatewayURLPathMap) {
+func (c *appGwConfigBuilder) noRulesIngress(cbCtx *ConfigBuilderContext, ingress *networking.Ingress, urlPathMaps *map[listenerIdentifier]*n.ApplicationGatewayURLPathMap, listenerIngress *map[listenerIdentifier]*networking.Ingress) {
 	// There are no Rules. We are dealing with some very rudimentary Ingress definition.
 	if ingress.Spec.DefaultBackend == nil {
 		return
@@ -146,16 +148,18 @@ func (c *appGwConfigBuilder) noRulesIngress(cbCtx *ConfigBuilderContext, ingress
 				PathRules:                  &[]n.ApplicationGatewayPathRule{},
 			},
 		}
+		(*listenerIngress)[listenerID] = ingress
 	}
 }
 
 func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listenerIdentifier]*n.ApplicationGatewayURLPathMap {
 	urlPathMaps := make(map[listenerIdentifier]*n.ApplicationGatewayURLPathMap)
+	listenerIngress := make(map[listenerIdentifier]*networking.Ingress)
 	for ingressIdx := range cbCtx.IngressList {
 		ingress := cbCtx.IngressList[ingressIdx]
 
 		if len(ingress.Spec.Rules) == 0 {
-			c.noRulesIngress(cbCtx, ingress, &urlPathMaps)
+			c.noRulesIngress(cbCtx, ingress, &urlPathMaps, &listenerIngress)
 		}
 
 		for ruleIdx := range ingress.Spec.Rules {
@@ -166,6 +170,7 @@ func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listen
 			}
 
 			_, azListenerConfig := c.processIngressRuleWithTLS(rule, ingress, cbCtx.EnvVariables)
+
 			for listenerID, listenerAzConfig := range azListenerConfig {
 				if _, exists := urlPathMaps[listenerID]; !exists {
 					pathMapName := generateURLPathMapName(listenerID)
@@ -227,7 +232,7 @@ func (c *appGwConfigBuilder) getPathMap(cbCtx *ConfigBuilderContext, listenerID 
 	}
 
 	// get defaults provided by the rules if any
-	defaultAddressPoolID, defaultHTTPSettingsID, defaultRedirectConfigurationID := c.getDefaultFromRule(cbCtx, listenerID, listenerAzConfig, ingress, rule)
+	defaultAddressPoolID, defaultHTTPSettingsID, defaultRedirectConfigurationID, defaultRewriteRuleSetID := c.getDefaultFromRule(cbCtx, listenerID, listenerAzConfig, ingress, rule)
 	if defaultRedirectConfigurationID != nil {
 		pathMap.DefaultRedirectConfiguration = resourceRef(*defaultRedirectConfigurationID)
 		pathMap.DefaultBackendAddressPool = nil
@@ -236,13 +241,16 @@ func (c *appGwConfigBuilder) getPathMap(cbCtx *ConfigBuilderContext, listenerID 
 		pathMap.DefaultBackendAddressPool = resourceRef(*defaultAddressPoolID)
 		pathMap.DefaultBackendHTTPSettings = resourceRef(*defaultHTTPSettingsID)
 	}
+	if defaultRewriteRuleSetID != nil {
+		pathMap.DefaultRewriteRuleSet = resourceRef(*defaultRewriteRuleSetID)
+	}
 
 	pathMap.PathRules = c.getPathRules(cbCtx, listenerID, listenerAzConfig, ingress, rule, ruleIdx)
 
 	return &pathMap
 }
 
-func (c *appGwConfigBuilder) getDefaultFromRule(cbCtx *ConfigBuilderContext, listenerID listenerIdentifier, listenerAzConfig listenerAzConfig, ingress *networking.Ingress, rule *networking.IngressRule) (*string, *string, *string) {
+func (c *appGwConfigBuilder) getDefaultFromRule(cbCtx *ConfigBuilderContext, listenerID listenerIdentifier, listenerAzConfig listenerAzConfig, ingress *networking.Ingress, rule *networking.IngressRule) (*string, *string, *string, *string) {
 	if sslRedirect, _ := annotations.IsSslRedirect(ingress); sslRedirect && listenerAzConfig.Protocol == n.ApplicationGatewayProtocolHTTP {
 		targetListener := listenerID
 		targetListener.FrontendPort = 443
@@ -253,7 +261,7 @@ func (c *appGwConfigBuilder) getDefaultFromRule(cbCtx *ConfigBuilderContext, lis
 
 		if _, exists := redirectsSet[*redirectRef.ID]; exists {
 			klog.V(5).Infof("Attached default redirection %s to rule %+v", *redirectRef.ID, *rule)
-			return nil, nil, redirectRef.ID
+			return nil, nil, redirectRef.ID, nil
 		}
 		klog.Errorf("Will not attach default redirect to rule; SSL Redirect does not exist: %s", *redirectRef.ID)
 	}
@@ -272,19 +280,23 @@ func (c *appGwConfigBuilder) getDefaultFromRule(cbCtx *ConfigBuilderContext, lis
 
 	backendPools := c.newBackendPoolMap(cbCtx)
 	_, backendHTTPSettingsMap, _, _ := c.getBackendsAndSettingsMap(cbCtx)
+	var defaultRewriteRuleSet *string
 	if defBackend != nil {
 		// has default backend
 		defaultBackendID := generateBackendID(ingress, defRule, defPath, defBackend)
 		defaultHTTPSettings := backendHTTPSettingsMap[defaultBackendID]
 		defaultAddressPool := backendPools[defaultBackendID]
+		if rewriteRuleSet, err := annotations.RewriteRuleSet(ingress); err == nil && rewriteRuleSet != "" {
+			defaultRewriteRuleSet = to.StringPtr(c.appGwIdentifier.rewriteRuleSetID(rewriteRuleSet))
+		}
 		if defaultAddressPool != nil && defaultHTTPSettings != nil {
 			poolID := to.StringPtr(c.appGwIdentifier.AddressPoolID(*defaultAddressPool.Name))
 			settID := to.StringPtr(c.appGwIdentifier.HTTPSettingsID(*defaultHTTPSettings.Name))
-			return poolID, settID, nil
+			return poolID, settID, nil, defaultRewriteRuleSet
 		}
 	}
 
-	return cbCtx.DefaultAddressPoolID, cbCtx.DefaultHTTPSettingsID, nil
+	return cbCtx.DefaultAddressPoolID, cbCtx.DefaultHTTPSettingsID, nil, defaultRewriteRuleSet
 }
 
 func (c *appGwConfigBuilder) getPathRules(cbCtx *ConfigBuilderContext, listenerID listenerIdentifier, listenerAzConfig listenerAzConfig, ingress *networking.Ingress, rule *networking.IngressRule, ruleIdx int) *[]n.ApplicationGatewayPathRule {
@@ -315,6 +327,15 @@ func (c *appGwConfigBuilder) getPathRules(cbCtx *ConfigBuilderContext, listenerI
 				paths = strings.Join(*pathRule.Paths, ",")
 			}
 			klog.V(5).Infof("Attach Firewall Policy %s to Path Rule %s", wafPolicy, paths)
+		}
+
+		if rewriteRule, err := annotations.RewriteRuleSet(ingress); err == nil {
+			pathRule.RewriteRuleSet = resourceRef(c.appGwIdentifier.rewriteRuleSetID(rewriteRule))
+			var paths string
+			if pathRule.Paths != nil {
+				paths = strings.Join(*pathRule.Paths, ",")
+			}
+			klog.V(5).Infof("Attach Rewrite Rule Set %s to Path Rule %s", rewriteRule, paths)
 		}
 
 		if sslRedirect, _ := annotations.IsSslRedirect(ingress); sslRedirect && listenerAzConfig.Protocol == n.ApplicationGatewayProtocolHTTP {
@@ -365,6 +386,9 @@ func (c *appGwConfigBuilder) mergePathMap(existingPathMap *n.ApplicationGatewayU
 		existingPathMap.DefaultRedirectConfiguration = pathMapToMerge.DefaultRedirectConfiguration
 		existingPathMap.DefaultBackendAddressPool = nil
 		existingPathMap.DefaultBackendHTTPSettings = nil
+	}
+	if pathMapToMerge.DefaultRewriteRuleSet != nil {
+		existingPathMap.DefaultRewriteRuleSet = pathMapToMerge.DefaultRewriteRuleSet
 	}
 
 	if pathMapToMerge.PathRules == nil || len(*pathMapToMerge.PathRules) == 0 {

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -122,7 +122,7 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 	return requestRoutingRules, pathMap
 }
 
-func (c *appGwConfigBuilder) noRulesIngress(cbCtx *ConfigBuilderContext, ingress *networking.Ingress, urlPathMaps *map[listenerIdentifier]*n.ApplicationGatewayURLPathMap, listenerIngress *map[listenerIdentifier]*networking.Ingress) {
+func (c *appGwConfigBuilder) noRulesIngress(cbCtx *ConfigBuilderContext, ingress *networking.Ingress, urlPathMaps *map[listenerIdentifier]*n.ApplicationGatewayURLPathMap) {
 	// There are no Rules. We are dealing with some very rudimentary Ingress definition.
 	if ingress.Spec.DefaultBackend == nil {
 		return
@@ -148,18 +148,16 @@ func (c *appGwConfigBuilder) noRulesIngress(cbCtx *ConfigBuilderContext, ingress
 				PathRules:                  &[]n.ApplicationGatewayPathRule{},
 			},
 		}
-		(*listenerIngress)[listenerID] = ingress
 	}
 }
 
 func (c *appGwConfigBuilder) getPathMaps(cbCtx *ConfigBuilderContext) map[listenerIdentifier]*n.ApplicationGatewayURLPathMap {
 	urlPathMaps := make(map[listenerIdentifier]*n.ApplicationGatewayURLPathMap)
-	listenerIngress := make(map[listenerIdentifier]*networking.Ingress)
 	for ingressIdx := range cbCtx.IngressList {
 		ingress := cbCtx.IngressList[ingressIdx]
 
 		if len(ingress.Spec.Rules) == 0 {
-			c.noRulesIngress(cbCtx, ingress, &urlPathMaps, &listenerIngress)
+			c.noRulesIngress(cbCtx, ingress, &urlPathMaps)
 		}
 
 		for ruleIdx := range ingress.Spec.Rules {


### PR DESCRIPTION
So that rewrite rule sets predefined in the app gateway can be assigned
to routing rules by adding an annotation in the corresponding Ingress.

Fixes #1003.
Related to #462.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
