### PR TITLE
fix: indentation error in helm values file

### DIFF
--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -44,9 +44,9 @@ kubernetes:
     #  cpu: 100m
     #  memory: 100Mi
 
-# Set this to override the default ingress class value. DEFAULT: azure/application-gateway
-# This can be used to segregate ingress controllers in the same namespace
-# ingressClass: agic-2
+  # Set this to override the default ingress class value. DEFAULT: azure/application-gateway
+  # This can be used to segregate ingress controllers in the same namespace
+  # ingressClass: agic-2
 
 ################################################################################
 # Specify which application gateway the ingress controller will manage

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -48,9 +48,9 @@ kubernetes:
     #  cpu: 100m
     #  memory: 100Mi
 
-# Set this to override the default ingress class value. DEFAULT: azure/application-gateway
-# This can be used to segregate ingress controllers in the same namespace
-# ingressClass: agic-2
+  # Set this to override the default ingress class value. DEFAULT: azure/application-gateway
+  # This can be used to segregate ingress controllers in the same namespace
+  # ingressClass: agic-2
 
 ################################################################################
 # Specify which application gateway the ingress controller will manage


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist

- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

In the helm\ingress-azure folder, where the helm value file resides, we noticed that the indentation for `ingressClass` is a bit off.

In the current master code, it is as if the  `ingressClass` is a standalone key in the value file, but after checking the code at this line of code: https://github.com/Azure/application-gateway-kubernetes-ingress/blob/84e9ae00a2dc2e94f848b38cfee58e1d625c2463/helm/ingress-azure/templates/configmap.yaml#L92 

We figured out `ingressClass` should be the subkey of the `kubernetes`. We spent quite some time figuring this out and we hope it will not be the same trouble for others, thus motivating us to open this PR to fix this indentation error in the helm value files.

## Fixes

No issues found open
