### PR TITLE
k8s: Add retry logic to get server version

### DIFF
--- a/pkg/k8scontext/supported_apiversion.go
+++ b/pkg/k8scontext/supported_apiversion.go
@@ -67,6 +67,6 @@ func SupportsNetworkingPackage(client clientset.Interface) bool {
 		klog.Errorf("unexpected error parsing running Kubernetes version: %v", err)
 		return false
 	}
-
+	klog.V(1).Infof("server version is: %s", runningVersion.String())
 	return runningVersion.AtLeast(version119)
 }

--- a/pkg/k8scontext/supported_apiversion.go
+++ b/pkg/k8scontext/supported_apiversion.go
@@ -6,12 +6,23 @@
 package k8scontext
 
 import (
+	"time"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
+
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+
+	serverversion "k8s.io/apimachinery/pkg/version"
+)
+
+const (
+	maxRetryCount = 10
+	retryPause    = 1 * time.Second
 )
 
 var (
@@ -36,9 +47,19 @@ func SupportsNetworkingPackage(client clientset.Interface) bool {
 	// check kubernetes version to use new ingress package or not
 	version119, _ := version.ParseGeneric("v1.19.0")
 
-	serverVersion, err := client.Discovery().ServerVersion()
+	var serverVersion *serverversion.Info
+	var err error
+	utils.Retry(maxRetryCount, retryPause, func() (utils.Retriable, error) {
+		serverVersion, err = client.Discovery().ServerVersion()
+		if err != nil {
+			klog.Warningf("Failed to get server version of the cluster: %s", err)
+			return utils.Retriable(true), err
+		} else {
+			return false, err
+		}
+	})
 	if err != nil {
-		return false
+		klog.Fatalf("Failed to get server version of the cluster: %s", err)
 	}
 
 	runningVersion, err := version.ParseGeneric(serverVersion.String())


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

Add retry logic and raise exception when there is issue getting server version of the cluster

## Fixes

#1342 
