### PR TITLE
networking/v1: add support for ingress path type

### DIFF
--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -217,8 +217,9 @@ func generateListenerID(ingress *networking.Ingress, rule *networking.IngressRul
 	if overridePort != nil {
 		if *overridePort > 0 && *overridePort < 65000 {
 			frontendPort = *overridePort
+			klog.V(5).Infof("Using custom port specified in the override annotation: %d", *overridePort)
 		} else {
-			klog.V(5).Infof("Invalid custom port configuration (%d). Setting listener port to default : %d", *overridePort, frontendPort)
+			klog.V(5).Infof("Derived listener port from ingress: %d", frontendPort)
 		}
 
 	}

--- a/pkg/appgw/ingress_rules.go
+++ b/pkg/appgw/ingress_rules.go
@@ -52,7 +52,7 @@ func (c *appGwConfigBuilder) applyToListener(rule *networking.IngressRule) bool 
 	for pathIdx := range rule.HTTP.Paths {
 		path := &rule.HTTP.Paths[pathIdx]
 		// if there is path that is /, /* , empty string, then apply the waf policy to the listener.
-		if len(path.Path) == 0 || path.Path == "/" || path.Path == "/*" {
+		if isPathCatchAll(path.Path, path.PathType) {
 			return true
 		}
 	}

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -314,7 +314,7 @@ func (c *appGwConfigBuilder) getPathRules(cbCtx *ConfigBuilderContext, listenerI
 			Name: to.StringPtr(pathRuleName),
 			ID:   to.StringPtr(c.appGwIdentifier.pathRuleID(pathMapName, pathRuleName)),
 			ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
-				Paths: &[]string{path.Path},
+				Paths: &[]string{preparePathFromPathType(path.Path, path.PathType)},
 			},
 		}
 
@@ -438,4 +438,20 @@ func printPathRule(pathRule n.ApplicationGatewayPathRule) string {
 	}
 
 	return s
+}
+
+// preparePathFromPathType uses pathType property to modify ingress.Path to append/remove "*"
+// if pathType == Prefix, "*" is appended if not provided by the user
+// if pathType == Exact, "*" is trimmed
+func preparePathFromPathType(path string, pathType *networking.PathType) string {
+	if pathType != nil {
+		if *pathType == networking.PathTypeExact {
+			return strings.TrimSuffix(path, "*")
+		}
+
+		if *pathType == networking.PathTypePrefix && !strings.HasSuffix(path, "*") {
+			return path + "*"
+		}
+	}
+	return path
 }

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -696,6 +696,139 @@ func NewIngressTestFixtureBasic(namespace string, ingressName string, tls bool) 
 	return ingress
 }
 
+// NewIngressTestFixture creates a new Ingress struct for testing.
+func NewIngressTestWithVariousPathTypeFixture(namespace string, ingressName string) networking.Ingress {
+	prefixType := networking.PathTypePrefix
+	exactType := networking.PathTypeExact
+	implementationSpecificType := networking.PathTypeImplementationSpecific
+	return networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ingressName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				annotations.IngressClassKey: IngressClassController,
+			},
+		},
+		Spec: networking.IngressSpec{
+			Rules: []networking.IngressRule{
+				{
+					Host: "hello.com",
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
+								{
+									// type:prefix with *
+									Path:     "/prefix0*",
+									PathType: &prefixType,
+									Backend: networking.IngressBackend{
+										Service: &networking.IngressServiceBackend{
+											Name: ServiceName,
+											Port: networking.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+								{
+									// type:prefix without *
+									Path:     "/prefix1",
+									PathType: &prefixType,
+									Backend: networking.IngressBackend{
+										Service: &networking.IngressServiceBackend{
+											Name: ServiceName,
+											Port: networking.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+								{
+									// type:exact with *
+									Path:     "/exact2*",
+									PathType: &exactType,
+									Backend: networking.IngressBackend{
+										Service: &networking.IngressServiceBackend{
+											Name: ServiceName,
+											Port: networking.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+								{
+									// type:exact without *
+									Path:     "/exact3",
+									PathType: &implementationSpecificType,
+									Backend: networking.IngressBackend{
+										Service: &networking.IngressServiceBackend{
+											Name: ServiceName,
+											Port: networking.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+								{
+									// type:implementationSpecific with *
+									Path:     "/ims4*",
+									PathType: &implementationSpecificType,
+									Backend: networking.IngressBackend{
+										Service: &networking.IngressServiceBackend{
+											Name: ServiceName,
+											Port: networking.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+								{
+									// type:implementationSpecific without *
+									Path:     "/ims5",
+									PathType: &implementationSpecificType,
+									Backend: networking.IngressBackend{
+										Service: &networking.IngressServiceBackend{
+											Name: ServiceName,
+											Port: networking.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+								{
+									// type:nil with *
+									Path:     "/nil6*",
+									PathType: nil,
+									Backend: networking.IngressBackend{
+										Service: &networking.IngressServiceBackend{
+											Name: ServiceName,
+											Port: networking.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+								{
+									// type:nil without *
+									Path:     "/nil7",
+									PathType: nil,
+									Backend: networking.IngressBackend{
+										Service: &networking.IngressServiceBackend{
+											Name: ServiceName,
+											Port: networking.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 // NewPodTestFixture creates a new Pod struct for testing.
 func NewPodTestFixture(namespace string, podName string) v1.Pod {
 	return v1.Pod{

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -820,6 +820,32 @@ func NewIngressTestWithVariousPathTypeFixture(namespace string, ingressName stri
 										},
 									},
 								},
+								{
+									// "/" path with pathType:prefix
+									Path:     "/",
+									PathType: &prefixType,
+									Backend: networking.IngressBackend{
+										Service: &networking.IngressServiceBackend{
+											Name: ServiceName,
+											Port: networking.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+								{
+									// "/*" path with pathType:exact
+									Path:     "/*",
+									PathType: &exactType,
+									Backend: networking.IngressBackend{
+										Service: &networking.IngressServiceBackend{
+											Name: ServiceName,
+											Port: networking.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
 							},
 						},
 					},

--- a/scripts/e2e/cmd/runner/networking-v1-mfu_one_namespace_one_ingress_test.go
+++ b/scripts/e2e/cmd/runner/networking-v1-mfu_one_namespace_one_ingress_test.go
@@ -480,7 +480,7 @@ var _ = Describe("networking-v1-MFU", func() {
 			Expect(err).To(BeNil())
 
 			yamlPath := "testdata/networking-v1/one-namespace-one-ingress/path-type/app.yaml"
-			klog.Info("Applying empty secret yaml: ", yamlPath)
+			klog.Info("Applying yaml: ", yamlPath)
 			err = applyYaml(clientset, namespaceName, yamlPath)
 			Expect(err).To(BeNil())
 			time.Sleep(10 * time.Second)
@@ -494,7 +494,7 @@ var _ = Describe("networking-v1-MFU", func() {
 
 			respondedWithColor := func(path string, body string) {
 				resp, err := makeGetRequest(urlHttps+path, "example.com", 200, true)
-				Expect(readBody(resp)).To(ContainSubstring(body))
+				Expect(readBody(resp)).To(ContainSubstring(body), "path: %s", path)
 				Expect(err).To(BeNil())
 			}
 
@@ -509,6 +509,11 @@ var _ = Describe("networking-v1-MFU", func() {
 			// PathType:ImplementationSpecific
 			respondedWithColor("/ims", "correct-app")
 			respondedWithColor("/imsSuffix", "correct-app")
+
+			// Path / with pathType:exact
+			// AppGW doesn't allow / with pathType:exact
+			respondedWithColor("/", "catch-all")
+			respondedWithColor("/Suffix", "catch-all")
 		})
 
 		AfterEach(func() {

--- a/scripts/e2e/cmd/runner/networking-v1-mfu_one_namespace_one_ingress_test.go
+++ b/scripts/e2e/cmd/runner/networking-v1-mfu_one_namespace_one_ingress_test.go
@@ -405,7 +405,7 @@ var _ = Describe("networking-v1-MFU", func() {
 		})
 
 		It("[ingress-class-resource] ingress class resource should work with ingress v1", func() {
-			namespaceName := "ingress-class-resource"
+			namespaceName := "e2e-ingress-class-resource"
 			ns := &v1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespaceName,
@@ -466,6 +466,49 @@ var _ = Describe("networking-v1-MFU", func() {
 			// check that rewrite rule is adding a response header "test-header: test-value"
 			testHeader := resp.Header.Get("test-header")
 			Expect(testHeader).To(Equal("test-value"))
+		})
+
+		It("[path-type] Path Type should correctly convert path to app gateway and respond correctly", func() {
+			namespaceName := "e2e-path-type"
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceName,
+				},
+			}
+			klog.Info("Creating namespace: ", namespaceName)
+			_, err = clientset.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+
+			yamlPath := "testdata/networking-v1/one-namespace-one-ingress/path-type/app.yaml"
+			klog.Info("Applying empty secret yaml: ", yamlPath)
+			err = applyYaml(clientset, namespaceName, yamlPath)
+			Expect(err).To(BeNil())
+			time.Sleep(10 * time.Second)
+
+			// get ip address for 1 ingress
+			klog.Info("Getting public IP from Ingress...")
+			publicIP, _ := getPublicIP(clientset, namespaceName)
+			Expect(publicIP).ToNot(Equal(""))
+
+			urlHttps := fmt.Sprintf("http://%s", publicIP)
+
+			respondedWithColor := func(path string, body string) {
+				resp, err := makeGetRequest(urlHttps+path, "example.com", 200, true)
+				Expect(readBody(resp)).To(ContainSubstring(body))
+				Expect(err).To(BeNil())
+			}
+
+			// PathType:Prefix
+			respondedWithColor("/prefix", "correct-app")
+			respondedWithColor("/prefixSuffix", "correct-app")
+
+			// PathType:Exact
+			respondedWithColor("/exact", "correct-app")
+			respondedWithColor("/exact/asd", "catch-all")
+
+			// PathType:ImplementationSpecific
+			respondedWithColor("/ims", "correct-app")
+			respondedWithColor("/imsSuffix", "correct-app")
 		})
 
 		AfterEach(func() {

--- a/scripts/e2e/cmd/runner/testdata/networking-v1/one-namespace-one-ingress/path-type/app.yaml
+++ b/scripts/e2e/cmd/runner/testdata/networking-v1/one-namespace-one-ingress/path-type/app.yaml
@@ -1,0 +1,169 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: catch-all
+data:
+  default.conf: |-
+    server {
+        listen 80 default_server;
+        location / {
+          return 200 "catch-all";
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catch-all
+spec:
+  selector:
+    matchLabels:
+      app: catch-all
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: catch-all
+    spec:
+      containers:
+      - name: nginx
+        imagePullPolicy: Always
+        image: nginx:latest
+        ports:
+          - containerPort: 80
+            name: http
+        volumeMounts:
+          - mountPath: /etc/nginx/conf.d
+            name: configmap-volume
+      volumes:
+      - name: configmap-volume
+        configMap:
+          name: catch-all
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: catch-all
+spec:
+  selector:
+    app: catch-all
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: correct-app
+data:
+  default.conf: |-
+    server {
+        listen 80 default_server;
+        location / {
+          return 200 "correct-app";
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: correct-app
+spec:
+  selector:
+    matchLabels:
+      app: correct-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: correct-app
+    spec:
+      containers:
+      - name: nginx
+        imagePullPolicy: Always
+        image: nginx:latest
+        ports:
+          - containerPort: 80
+            name: http
+        volumeMounts:
+          - mountPath: /etc/nginx/conf.d
+            name: configmap-volume
+      volumes:
+      - name: configmap-volume
+        configMap:
+          name: correct-app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: correct-app
+spec:
+  selector:
+    app: correct-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/health-probe-path: /
+spec:
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /
+            backend:
+              service:
+                name: catch-all
+                port:
+                  number: 80
+            pathType: Prefix
+          - path: /prefix
+            backend:
+              service:
+                name: correct-app
+                port:
+                  number: 80
+            pathType: Prefix
+          - path: /prefix*
+            backend:
+              service:
+                name: correct-app
+                port:
+                  number: 80
+            pathType: Prefix
+          - path: /exact
+            backend:
+              service:
+                name: correct-app
+                port:
+                  number: 80
+            pathType: Exact
+          - path: /exact*
+            backend:
+              service:
+                name: correct-app
+                port:
+                  number: 80
+            pathType: Exact
+          - path: /ims
+            backend:
+              service:
+                name: correct-app
+                port:
+                  number: 80
+            pathType: ImplementationSpecific
+          - path: /ims*
+            backend:
+              service:
+                name: correct-app
+                port:
+                  number: 80
+            pathType: ImplementationSpecific


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
Ingress V1 adds a new property called pathType which is not currently by AGIC. This PR adds support for pathType while maintaining compatibility with cases where pathType is not specified.

https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
#1279