### PR TITLE
Fix case on agicIdentity query

### DIFF
--- a/docs/troubleshootings/troubleshooting-agic-addon-identity-not-found.md
+++ b/docs/troubleshootings/troubleshooting-agic-addon-identity-not-found.md
@@ -16,7 +16,7 @@ aksClusterName="YOUR_AKS_CLUSTER_NAME"
 resourceGroup="YOUR_RESOURCEGROUP_NAME"
 nodeResourceGroup=$(az aks show -n $aksClusterName -g $resourceGroup --query "nodeResourceGroup" -o tsv)
 aksVmssId=$(az vmss list -g $nodeResourceGroup --query "[0].id" -o tsv)
-agicIdentity=$(az aks show -n $aksClusterName -g $resourceGroup --query "addonProfiles.IngressApplicationGateway.identity.resourceId" -o tsv)
+agicIdentity=$(az aks show -n $aksClusterName -g $resourceGroup --query "addonProfiles.ingressApplicationGateway.identity.resourceId" -o tsv)
 
 az vmss identity remove --ids $aksVmssId --identities $agicIdentity
 az vmss identity assign --ids $aksVmssId --identities $agicIdentity


### PR DESCRIPTION
## Checklist
- [x] The title of the PR is clear and informative
- [n/a] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

When running through these instructions, I found that the case for the `ingressApplicationGateway` addon profile was wrong.

## Fixes

Fixes the above docs.