### PR TITLE
Update default k8s version: 1.20.9 -> 1.23.3

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -281,7 +281,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.20.9",
+            "defaultValue": "1.23.3",
             "type": "string",
             "metadata": {
                 "description": "The version of Kubernetes."


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->

https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-install-new#deploy-components says as bellow.

> 1. Download the Azure Resource Manager template and modify the template as needed.
> ```bash
> wget https://raw.githubusercontent.com/Azure/application-gateway-kubernetes-ingress/master/deploy/azuredeploy.json -O template.json
> ```

However, users who try the above example encounter the following error because version `1.20.9` is outdated.

```console
{'code': 'InvalidTemplateDeployment', 'message': "The template deployment 'ingress-appgw' is not valid according to the validation procedure. The tracking id is 'ccf8480c-e53b-4d50-aa2f-41d83408018a'. See inner errors for details."}

Inner Errors: 
{'code': 'AgentPoolK8sVersionNotSupported', 'message': 'Provisioning of resource(s) for container service aks242d in resource group MyResourceGroup failed. Message: {\n  "code": "AgentPoolK8sVersionNotSupported",\n  "message": "Version 1.20.9 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list"\n }. Details: '}
```

## Fixes

<!-- Please mention #issues that are fixed in this PR -->

fixes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1367