### PR TITLE
Add container securityContext and additional volumes to Helm chart

### DIFF
--- a/docs/helm-values-documenation.md
+++ b/docs/helm-values-documenation.md
@@ -83,10 +83,10 @@ kubernetes:
     volumes:
         extraVolumes:
         - name: tmp
-        emptyDir: {}
+          emptyDir: {}
         extraVolumeMounts:
         - name: tmp
-        mountPath: /tmp
+          mountPath: /tmp
 ```
 
 > **Note:** AGIC needs to be able to write to the `/tmp` directory.

--- a/docs/helm-values-documenation.md
+++ b/docs/helm-values-documenation.md
@@ -14,11 +14,15 @@
 | `appgw.shared` | false | This boolean flag should be defaulted to `false`. Set to `true` should you need a [Shared App Gateway](setup/install-existing.md#multi-cluster--shared-app-gateway). |
 | `appgw.subResourceNamePrefix` | No prefix if empty | Prefix that should be used in the naming of the Application Gateway's sub-resources|
 | `kubernetes.watchNamespace` | Watches all if empty | Specify the name space, which AGIC should watch. This could be a single string value, or a comma-separated list of namespaces. |
-| `kubernetes.securityContext` | `runAsUser: 0` | Specify security context to use with AGIC deployment. By default, AGIC will assume `root` permission. Jump to [Security Context](#security-context) for more information. |
+| `kubernetes.securityContext` | `runAsUser: 0` | Specify the pod security context to use with AGIC deployment. By default, AGIC will assume `root` permission. Jump to [Run without root](#run-without-root) for more information. |
+| `kubernetes.containerSecurityContext` | `{}` | Specify the [container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) to use with AGIC deployment. |
 | `kubernetes.podAnnotations` | `{}` | Specify custom annotations for AGIC pod |
+| `kubernetes.resources` | `{}` | Specify [resource quota](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for AGIC pod |
 | `kubernetes.nodeSelector` | `{}` | Scheduling node selector |
 | `kubernetes.tolerations` | `[]` | Scheduling tolerations |
 | `kubernetes.affinity` | `{}` | Scheduling affinity |
+| `kubernetes.volumes.extraVolumes` | `{}` | Specify additional volumes for the AGIC pod. This can be useful when [running on a `readOnlyRootFilesystem`](#run-with-read-only-root-filesystem), as AGIC requires a writeable `/tmp` directory. |
+| `kubernetes.volumes.extraVolumeMounts` | `{}` | Specify additional volume mounts for the AGIC pod. This can be useful when [running on a `readOnlyRootFilesystem`](#run-with-read-only-root-filesystem), as AGIC requires a writeable `/tmp` directory. |
 | `kubernetes.ingressClass` | `azure/application-gateway` | Specify a [custom ingress class](features\custom-ingress-class.md) which will be used to match `kubernetes.io/ingress.class` in ingress manifest |
 | `rbac.enabled` | false | Specify true if kubernetes cluster is rbac enabled |
 | `armAuth.type` | | could be `aadPodIdentity` or `servicePrincipal` |
@@ -48,13 +52,41 @@ rbac:
     enabled: false
 ```
 
----
-### Security Context
+### Run without root
+
 By default, AGIC will assume `root` permission which allows it to read `cloud-provider` config and get meta-data information about the cluster.
-If you want AGIC to run without `root` access, then make sure that AGIC is installed with atleast the following information to run successfully:
-* `appgw.subscriptionId`, `appgw.resourceGroup` and `appgw.name`  
-or
-* `appgw.applicationGatewayID`
+If you want AGIC to run without `root` access, then make sure that AGIC is installed with at least the following information to run successfully:
 
-AGIC also uses `cloud-provider` config to get Node's Virtual Network Name / Subscription and Route table name. If AGIC is not able to reach this information,  It will skip assigning the Node's route table to Application Gateway's subnet which is required when using `kubenet` network plugin. To workaround, this assignment can be performed manually.
+```yaml
+appgw:
+    applicationGatewayID: <application-gateway-resource-id>
+    # OR
+    subscriptionId: <subscription-id>
+    resourceGroup: <resource-group-name>
+    name: <application-gateway-name>
 
+kubernetes:
+    securityContext:
+        runAsUser: 1000 # appgw-ingress-user
+```
+
+> **Note:** AGIC also uses `cloud-provider` config to get Node's Virtual Network Name / Subscription and Route table name. If AGIC is not able to reach this information,  It will skip assigning the Node's route table to Application Gateway's subnet which is required when using `kubenet` network plugin. To workaround, this assignment can be performed manually.
+
+### Run with read-only root filesystem
+
+To run AGIC with `readOnlyRootFilesystem`, the following additional configuration items are required:
+
+```yaml
+kubernetes:
+    containerSecurityContext:
+        readOnlyRootFilesystem: true
+    volumes:
+        extraVolumes:
+        - name: tmp
+        emptyDir: {}
+        extraVolumeMounts:
+        - name: tmp
+        mountPath: /tmp
+```
+
+> **Note:** AGIC needs to be able to write to the `/tmp` directory.

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -61,6 +61,10 @@ spec:
         resources:
 {{ toYaml . | indent 10 }}
         {{- end }}
+        {{- with .Values.kubernetes.containerSecurityContext }}
+        securityContext:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         env:
         - name: AZURE_CLOUD_PROVIDER_LOCATION
           value: /etc/appgw/azure.json
@@ -92,6 +96,9 @@ spec:
           readOnly: true
         {{- end}}
         {{- end}}
+        {{- if .Values.kubernetes.volumes.extraVolumeMounts }}
+        {{- toYaml .Values.kubernetes.volumes.extraVolumeMounts | nindent 8 }}
+        {{- end }}
       volumes:
       - name: azure
         hostPath:
@@ -104,6 +111,9 @@ spec:
           secretName: networking-appgw-k8s-azure-service-principal
       {{- end}}
       {{- end}}
+      {{- if .Values.kubernetes.volumes.extraVolumes }}
+      {{- toYaml .Values.kubernetes.volumes.extraVolumes | nindent 6 }}
+      {{- end }}
       {{- if .Values.kubernetes.nodeSelector }}
       {{- with .Values.kubernetes.nodeSelector }}
       nodeSelector:

--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -29,8 +29,13 @@ kubernetes:
   tolerations: []
   affinity: {}
 
+  # Pod security context
   securityContext:
     runAsUser: 0
+
+  # Container security context
+  containerSecurityContext: {}
+    #readOnlyRootFilesystem: true
 
   # Add pod level annotations
   podAnnotations: {}
@@ -43,6 +48,15 @@ kubernetes:
     #requests:
     #  cpu: 100m
     #  memory: 100Mi
+
+  # Add additional volumes and volume mounts to the pod
+  volumes: {}
+    #extraVolumes:
+    #- name: tmp
+    #  emptyDir: {}
+    #extraVolumeMounts:
+    #- name: tmp
+    #  mountPath: /tmp
 
   # Set this to override the default ingress class value. DEFAULT: azure/application-gateway
   # This can be used to segregate ingress controllers in the same namespace

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -33,8 +33,13 @@ kubernetes:
   tolerations: []
   affinity: {}
 
+  # Pod security context
   securityContext:
     runAsUser: 0
+
+  # Container security context
+  containerSecurityContext: {}
+    #readOnlyRootFilesystem: true
 
   # Add pod level annotations
   podAnnotations: {}
@@ -47,6 +52,15 @@ kubernetes:
     #requests:
     #  cpu: 100m
     #  memory: 100Mi
+
+  # Add additional volumes and volume mounts to the pod
+  volumes: {}
+    #extraVolumes:
+    #- name: tmp
+    #  emptyDir: {}
+    #extraVolumeMounts:
+    #- name: tmp
+    #  mountPath: /tmp
 
   # Set this to override the default ingress class value. DEFAULT: azure/application-gateway
   # This can be used to segregate ingress controllers in the same namespace


### PR DESCRIPTION
## Checklist
- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
This surfaces some kubernetes configuration options through Helm to be able to run AGIC with `readOnlyRootFilesystem`. To make this work, the following new configuration options are exposed:

- Container `securityContext`
- Container `volumeMounts`
- Pod `volumes`

To run this now, one needs to add the following to the Helm `values.yaml`:

```yaml
# values.yaml
kubernetes:
  # ...
  containerSecurityContext:
    readOnlyRootFilesystem: true
  volumes:
    extraVolumes:
    - name: tmp
      emptyDir: {}
    extraVolumeMounts:
    - name: tmp
      mountPath: /tmp
```

## Fixes

Fixes #1376 
