### PR TITLE
Fixed the second script

### DIFF
--- a/docs/features/appgw-ssl-certificate.md
+++ b/docs/features/appgw-ssl-certificate.md
@@ -57,7 +57,7 @@ nrg=$(az aks show --name SallyAks --resource-group SallyRG --query nodeResourceG
 
 # get principalId of the AGIC managed identity
 identityName="ingressapplicationgateway-$aksClusterName"
-agicIdentityPrincipalId=$(az identity show --name ingressapplicationgateway-sallyaks --resource-group $nrg --query principalId --output tsv)
+agicIdentityPrincipalId=$(az identity show --name $identityName --resource-group $nrg --query principalId --output tsv)
 
 # One time operation, create Azure key vault and certificate (can done through portal as well)
 az keyvault create -n $vaultName -g $resgp --enable-soft-delete -l $location

--- a/docs/features/appgw-ssl-certificate.md
+++ b/docs/features/appgw-ssl-certificate.md
@@ -53,7 +53,7 @@ aksResourceGroupName=""
 appgwName=""
 
 # get the resource group name of the AKS cluster
-nrg=$(az aks show --name SallyAks --resource-group SallyRG --query nodeResourceGroup --output tsv)
+nrg=$(az aks show --name $aksClusterName --resource-group $aksResourceGroupName --query nodeResourceGroup --output tsv)
 
 # get principalId of the AGIC managed identity
 identityName="ingressapplicationgateway-$aksClusterName"

--- a/docs/features/appgw-ssl-certificate.md
+++ b/docs/features/appgw-ssl-certificate.md
@@ -52,6 +52,9 @@ aksClusterName=""
 aksResourceGroupName=""
 appgwName=""
 
+# IMPORTANT: the following way to retrieve the object id of the AGIC managed identity
+# only applies when AGIC is deployed via the AGIC addon for AKS
+
 # get the resource group name of the AKS cluster
 nrg=$(az aks show --name $aksClusterName --resource-group $aksResourceGroupName --query nodeResourceGroup --output tsv)
 

--- a/docs/features/appgw-ssl-certificate.md
+++ b/docs/features/appgw-ssl-certificate.md
@@ -57,7 +57,7 @@ nrg=$(az aks show --name SallyAks --resource-group SallyRG --query nodeResourceG
 
 # get principalId of the AGIC managed identity
 identityName="ingressapplicationgateway-$aksClusterName"
-agicIdentityPrincipalId=$(az identity show --name ingressapplicationgateway-sallyaks --resource-group $nrg)
+agicIdentityPrincipalId=$(az identity show --name ingressapplicationgateway-sallyaks --resource-group $nrg --query principalId --output tsv)
 
 # One time operation, create Azure key vault and certificate (can done through portal as well)
 az keyvault create -n $vaultName -g $resgp --enable-soft-delete -l $location

--- a/docs/features/appgw-ssl-certificate.md
+++ b/docs/features/appgw-ssl-certificate.md
@@ -48,7 +48,16 @@ appgwName=""
 resgp=""
 vaultName=""
 location=""
-agicIdentityPrincipalId=""
+aksClusterName=""
+aksResourceGroupName=""
+appgwName=""
+
+# get the resource group name of the AKS cluster
+nrg=$(az aks show --name SallyAks --resource-group SallyRG --query nodeResourceGroup --output tsv)
+
+# get principalId of the AGIC managed identity
+identityName="ingressapplicationgateway-$aksClusterName"
+agicIdentityPrincipalId=$(az identity show --name ingressapplicationgateway-sallyaks --resource-group $nrg)
 
 # One time operation, create Azure key vault and certificate (can done through portal as well)
 az keyvault create -n $vaultName -g $resgp --enable-soft-delete -l $location


### PR DESCRIPTION
I fixed the second script to get the principal id of the AGIC manage identity in the node resource group starting from the name and resource group of the AKS cluster.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [ ] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
