### PR TITLE
Drop duplicate hostnames from ingress hostname annotation

### DIFF
--- a/pkg/annotations/ingress_annotations.go
+++ b/pkg/annotations/ingress_annotations.go
@@ -276,10 +276,12 @@ func GetHostNameExtensions(ing *networking.Ingress) ([]string, error) {
 	if err == nil {
 		var hostnames []string
 		for _, hostname := range strings.Split(val, ",") {
-			if len(hostname) > 0 {
-				hostnames = append(hostnames, strings.TrimSpace(hostname))
+			trimmed := strings.TrimSpace(hostname)
+			if len(trimmed) > 0 {
+				hostnames = append(hostnames, trimmed)
 			}
 		}
+
 		return hostnames, nil
 	}
 

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/controllererrors"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/k8scontext"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 )
 
@@ -247,12 +248,16 @@ func generateListenerID(ingress *networking.Ingress, rule *networking.IngressRul
 		hostNames = append(hostNames, rule.Host)
 	}
 
-	if extendedHostNames, err := annotations.GetHostNameExtensions(ingress); err == nil {
+	extendedHostNames, err := annotations.GetHostNameExtensions(ingress)
+	if err != nil {
+		klog.V(5).Infof("Error while parsing hostname extension: %s", err)
+	} else {
 		if extendedHostNames != nil {
 			hostNames = append(hostNames, extendedHostNames...)
 		}
 	}
 
+	hostNames = utils.RemoveDuplicateStrings(hostNames)
 	listenerID.setHostNames(hostNames)
 	return listenerID
 }

--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -962,4 +962,24 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 
 		})
 	})
+
+	Context("hostname extension includes hostname from config rule", func() {
+		ingressAnnotations := make(map[string]string)
+		ingressAnnotations[annotations.HostNameExtensionKey] = "foo.baz, foo.bar, foo.bar"
+		ingress := &networking.Ingress{
+			Spec: networking.IngressSpec{
+				Rules: []networking.IngressRule{
+					{
+						Host: "foo.baz",
+					},
+				},
+			},
+			ObjectMeta: metav1.ObjectMeta{Annotations: ingressAnnotations},
+		}
+
+		It("should not include the duplicate host in the listener", func() {
+			listener := generateListenerID(ingress, &ingress.Spec.Rules[0], n.ApplicationGatewayProtocolHTTP, nil, false)
+			Expect(listener.getHostNames()).To(Equal([]string{"foo.baz", "foo.bar"}))
+		})
+	})
 })

--- a/pkg/utils/retry_test.go
+++ b/pkg/utils/retry_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/utils/threadsafemultimap_test.go
+++ b/pkg/utils/threadsafemultimap_test.go
@@ -6,7 +6,7 @@
 package utils
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -78,3 +78,22 @@ func RandStringRunes(n int) string {
 	}
 	return string(b)
 }
+
+// RemoveDuplicates returns a copy of a slice with duplicates removed
+func RemoveDuplicateStrings(list []string) []string {
+	if list == nil {
+		return list
+	}
+
+	result := []string{}
+	// use a map to enforce uniqueness
+	dupeChecker := make(map[string]interface{})
+	for _, val := range list {
+		if _, ok := dupeChecker[val]; !ok {
+			result = append(result, val)
+			dupeChecker[val] = nil
+		}
+	}
+
+	return result
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -10,7 +10,7 @@ package utils
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
@@ -72,5 +72,31 @@ var _ = Describe("Utils", func() {
 				Expect(len(RandStringRunes(0))).To(Equal(0))
 			})
 		})
+
+		DescribeTable("Test RemoveDuplicateStrings",
+			func(input []string, expected []string) {
+				Expect(RemoveDuplicateStrings(input)).To(Equal(expected))
+			},
+			Entry(
+				"Should remove duplicate strings",
+				[]string{"1", "1", "2", "3", "4", "3", "5", "1"},
+				[]string{"1", "2", "3", "4", "5"},
+			),
+			Entry(
+				"Should handle slices with no duplicates",
+				[]string{"1", "1", "2", "3", "4", "3", "5", "1"},
+				[]string{"1", "2", "3", "4", "5"},
+			),
+			Entry(
+				"Should return empty slice if input is empty",
+				[]string{},
+				[]string{},
+			),
+			Entry(
+				"Should return nil if input is nil",
+				[]string(nil),
+				[]string(nil),
+			),
+		)
 	})
 })


### PR DESCRIPTION
This will prevent Application Gateway from rejecting a rule change
where a user has accidentally provided the same hostname twice in
an ingress hostname annotation.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
This PR makes the AGIC ignore duplicate entries in an ingress hostnames annotation extension;
which would otherwise cause an error in the Application Gateway.

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
