### PR TITLE
Adds other ingress class to ingres-class-resource e2e test

### DIFF
--- a/scripts/e2e/cmd/runner/testdata/networking-v1/one-namespace-one-ingress/ingress-class-resource/app.yaml
+++ b/scripts/e2e/cmd/runner/testdata/networking-v1/one-namespace-one-ingress/ingress-class-resource/app.yaml
@@ -64,6 +64,18 @@ spec:
             pathType: Exact
 
 ---
+# A second ingress class
+# no controller will be running for this class but the resource will exist in kubernetes
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  annotations:
+    app.kubernetes.io/component: controller
+  name: other-gateway
+spec:
+  controller: azure/application-gateway
+
+---
 
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
This should trigger the previously fixed bug that caused two controllers
to apply each other's ingress rules.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [ ] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
