### PR TITLE
Fix dotnet/samples:aspnetapp references

### DIFF
--- a/docs/examples/aspnetapp.yaml
+++ b/docs/examples/aspnetapp.yaml
@@ -6,7 +6,7 @@ metadata:
     app: aspnetapp
 spec:
   containers:
-  - image: "mcr.microsoft.com/dotnet/core/samples:aspnetapp"
+  - image: "mcr.microsoft.com/dotnet/samples:aspnetapp"
     name: aspnetapp-image
     ports:
     - containerPort: 80

--- a/docs/features/appgw-ssl-certificate.md
+++ b/docs/features/appgw-ssl-certificate.md
@@ -116,7 +116,7 @@ metadata:
     app: aspnetapp
 spec:
   containers:
-  - image: "mcr.microsoft.com/dotnet/core/samples:aspnetapp"
+  - image: "mcr.microsoft.com/dotnet/samples:aspnetapp"
     name: aspnetapp-image
     ports:
     - containerPort: 80

--- a/docs/features/probes.md
+++ b/docs/features/probes.md
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: aspnetapp
-        image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
+        image: mcr.microsoft.com/dotnet/samples:aspnetapp
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/docs/setup/install-new.md
+++ b/docs/setup/install-new.md
@@ -277,7 +277,7 @@ metadata:
     app: aspnetapp
 spec:
   containers:
-  - image: "mcr.microsoft.com/dotnet/core/samples:aspnetapp"
+  - image: "mcr.microsoft.com/dotnet/samples:aspnetapp"
     name: aspnetapp-image
     ports:
     - containerPort: 80

--- a/docs/troubleshootings/troubleshooting-installing-a-simple-application.md
+++ b/docs/troubleshootings/troubleshooting-installing-a-simple-application.md
@@ -24,7 +24,7 @@ metadata:
     app: test-agic-app
 spec:
   containers:
-  - image: "mcr.microsoft.com/dotnet/core/samples:aspnetapp"
+  - image: "mcr.microsoft.com/dotnet/samples:aspnetapp"
     name: aspnetapp-image
     ports:
     - containerPort: 80

--- a/scripts/e2e/cmd/runner/testdata/extensions-v1beta1/one-namespace-many-ingresses/three-ingresses-slash-sth/app.yaml
+++ b/scripts/e2e/cmd/runner/testdata/extensions-v1beta1/one-namespace-many-ingresses/three-ingresses-slash-sth/app.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: apsnetapp
           imagePullPolicy: Always
-          image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
+          image: mcr.microsoft.com/dotnet/samples:aspnetapp
           ports:
             - containerPort: 80
 ---

--- a/scripts/e2e/cmd/runner/testdata/networking-v1/one-namespace-many-ingresses/three-ingresses-slash-sth/app.yaml
+++ b/scripts/e2e/cmd/runner/testdata/networking-v1/one-namespace-many-ingresses/three-ingresses-slash-sth/app.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: apsnetapp
           imagePullPolicy: Always
-          image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
+          image: mcr.microsoft.com/dotnet/samples:aspnetapp
           ports:
             - containerPort: 80
 ---


### PR DESCRIPTION
Fix dotnet/samples:aspnetapp references

These files had references to the `mcr.microsoft.com/dotnet/core/samples` tag which is [no longer a supported tag](https://github.com/dotnet/dotnet-docker/blob/9eb203c4890d3d0122d3939614ff25d68fc46d6e/README.samples.md?plain=1#L93), and no longer exists.

This updates it to the supported tag: `mcr.microsoft.com/dotnet/samples:aspnetapp`

Without making these updates, the `aspnetapp` container used in the samples will be stuck in the `Pending` or `Waiting` state with reason `ImagePullBackOff` and an error: `Back-off pulling image "mcr.microsoft.com/dotnet/core/samples:aspnetapp"`

Related:
- https://github.com/dotnet/AspNetCore.Docs/pull/27202
- https://github.com/dotnet/dotnet-docker/discussions/3674
- https://github.com/dotnet/AspNetCore.Docs/pull/27728
- https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1483
