### PR TITLE
updating image location

### DIFF
--- a/docs/examples/aspnetapp.yaml
+++ b/docs/examples/aspnetapp.yaml
@@ -6,7 +6,7 @@ metadata:
     app: aspnetapp
 spec:
   containers:
-  - image: "mcr.microsoft.com/dotnet/core/samples:aspnetapp"
+  - image: "mcr.microsoft.com/dotnet/samples:aspnetapp"
     name: aspnetapp-image
     ports:
     - containerPort: 80


### PR DESCRIPTION
the image location has changed. the old location no longer exists. I found this issue when referring to instructions on how to deploy a sample application here: https://learn.microsoft.com/en-us/azure/application-gateway/tutorial-ingress-controller-add-on-existing#deploy-a-sample-application-using-agic

the results can be verified using the following commands:

non-working location - 
docker pull mcr.microsoft.com/dotnet/core/samples:aspnetapp

working location - 
docker pull mcr.microsoft.com/dotnet/samples:aspnetapp

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [ ] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
