### PR TITLE
fix: rewrite url config should be empty if not specified in the custom resource

### DIFF
--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -16,6 +16,10 @@ steps:
     displayName: Helm installer
     inputs: 
       helmVersionToInstall: v3.11.0
+  
+  - task: GoTool@0
+    inputs:
+      version: '1.19.2'
 
   - script: make lint-all
     workingDirectory: "$(modulePath)"

--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -15,7 +15,7 @@ steps:
   - task: HelmInstaller@1
     displayName: Helm installer
     inputs: 
-      helmVersionToInstall: latest
+      helmVersionToInstall: v3.11.0
 
   - script: make lint-all
     workingDirectory: "$(modulePath)"

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ build:
 lint-all: lint lint-helm
 
 lint:
-	@go install golang.org/x/lint/golint
+	@go install golang.org/x/lint/golint@latest
 	@golint $(go list ./... | grep -v /vendor/) | tee /tmp/lint.out
 	@if [ -s /tmp/lint.out ]; then \
 		echo "\e[101;97m golint FAILED \e[0m"; \
@@ -114,11 +114,11 @@ vet-e2e:
 test-all: unittest
 
 unittest:
-	@go install github.com/jstemmer/go-junit-report
-	@go install github.com/axw/gocov/gocov
-	@go install github.com/AlekSi/gocov-xml
-	@go install github.com/matm/gocov-html
-	@go install github.com/onsi/ginkgo/v2
+	@go install github.com/jstemmer/go-junit-report@latest
+	@go install github.com/axw/gocov/gocov@latest
+	@go install github.com/AlekSi/gocov-xml@latest
+	@go install github.com/matm/gocov-html/cmd/gocov-html@latest
+	@go mod tidy
 	@go test -timeout 80s -v -coverprofile=coverage.txt -covermode count -tags unittest ./... > testoutput.txt || { echo "go test returned non-zero"; cat testoutput.txt; exit 1; }
 	@cat testoutput.txt | go-junit-report > report.xml
 	@gocov convert coverage.txt > coverage.json

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ build:
 lint-all: lint lint-helm
 
 lint:
-	@go get -u golang.org/x/lint/golint
+	@go install golang.org/x/lint/golint
 	@golint $(go list ./... | grep -v /vendor/) | tee /tmp/lint.out
 	@if [ -s /tmp/lint.out ]; then \
 		echo "\e[101;97m golint FAILED \e[0m"; \
@@ -114,11 +114,11 @@ vet-e2e:
 test-all: unittest
 
 unittest:
-	@go get github.com/jstemmer/go-junit-report
-	@go get github.com/axw/gocov/gocov
-	@go get github.com/AlekSi/gocov-xml
-	@go get github.com/matm/gocov-html
-	@go get github.com/onsi/ginkgo/v2
+	@go install github.com/jstemmer/go-junit-report
+	@go install github.com/axw/gocov/gocov
+	@go install github.com/AlekSi/gocov-xml
+	@go install github.com/matm/gocov-html
+	@go install github.com/onsi/ginkgo/v2
 	@go test -timeout 80s -v -coverprofile=coverage.txt -covermode count -tags unittest ./... > testoutput.txt || { echo "go test returned non-zero"; cat testoutput.txt; exit 1; }
 	@cat testoutput.txt | go-junit-report > report.xml
 	@gocov convert coverage.txt > coverage.json

--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -1135,7 +1135,7 @@ var _ = ginkgo.Describe("Tests `appgw.ConfigBuilder`", func() {
 				DefaultHTTPSettingsID: to.StringPtr("yy"),
 			}
 
-			rewriteRuleSet := tests.NewRewriteRuleSetCustomResourceFixture(tests.RewriteRuleSetName)
+			rewriteRuleSet := tests.NewRewriteRuleSetCustomResourceFixtureWithoutURLConfig(tests.RewriteRuleSetName)
 			ctxt.Caches.AzureApplicationGatewayRewrite.Add(rewriteRuleSet)
 
 			check(cbCtx, "rewrite_rule_sets_one_ingress_slash_slashnothing.json", stopChannel, ctxt, configBuilder)

--- a/functional_tests/rewrite_rule_sets_one_ingress_slash_slashnothing.json
+++ b/functional_tests/rewrite_rule_sets_one_ingress_slash_slashnothing.json
@@ -229,12 +229,7 @@
                                         "headerName": "cc",
                                         "headerValue": "dd"
                                     }
-                                ],
-                                "urlConfiguration": {
-                                    "modifiedPath": "ff",
-                                    "modifiedQueryString": "gg",
-                                    "reroute": false
-                                }
+                                ]
                             },
                             "conditions": [
                                 {

--- a/pkg/apis/azureapplicationgatewayrewrite/v1beta1/types.go
+++ b/pkg/apis/azureapplicationgatewayrewrite/v1beta1/types.go
@@ -72,7 +72,7 @@ type Actions struct {
 	ResponseHeaderConfigurations []HeaderConfiguration `json:"responseHeaderConfigurations,omitempty"`
 
 	// UrlConfiguration is the URL Configuration Action in the Action
-	UrlConfiguration UrlConfiguration `json:"urlConfiguration,omitempty"`
+	UrlConfiguration *UrlConfiguration `json:"urlConfiguration,omitempty"`
 }
 
 // HeaderConfiguration includes ActionType, HeaderName and HeaderValue

--- a/pkg/appgw/rewrites.go
+++ b/pkg/appgw/rewrites.go
@@ -171,7 +171,11 @@ func makeHeaderConfigs(apiHeaderConfigs []v1beta1.HeaderConfiguration) *[]n.Appl
 }
 
 // makeURLConfig converts v1beta1.UrlConfiguration to *n.ApplicationGatewayURLConfiguration
-func makeURLConfig(apiURLConfig v1beta1.UrlConfiguration) *n.ApplicationGatewayURLConfiguration {
+func makeURLConfig(apiURLConfig *v1beta1.UrlConfiguration) *n.ApplicationGatewayURLConfiguration {
+	if apiURLConfig == nil {
+		return nil
+	}
+
 	return &n.ApplicationGatewayURLConfiguration{
 		ModifiedPath:        to.StringPtr(apiURLConfig.ModifiedPath),
 		ModifiedQueryString: to.StringPtr(apiURLConfig.ModifiedQueryString),

--- a/pkg/appgw/rewrites_test.go
+++ b/pkg/appgw/rewrites_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Test the creation of Rewrite Rule Sets from Ingress definition
 									HeaderName: "h4",
 								},
 							},
-							UrlConfiguration: v1beta1.UrlConfiguration{
+							UrlConfiguration: &v1beta1.UrlConfiguration{
 								ModifiedPath:        "abc",
 								ModifiedQueryString: "def",
 								Reroute:             false,
@@ -219,7 +219,7 @@ var _ = Describe("Test the creation of Rewrite Rule Sets from Ingress definition
 									HeaderName: "h4",
 								},
 							},
-							UrlConfiguration: v1beta1.UrlConfiguration{
+							UrlConfiguration: &v1beta1.UrlConfiguration{
 								ModifiedPath:        "abc",
 								ModifiedQueryString: "def",
 								Reroute:             false,

--- a/pkg/k8scontext/secretstore_test.go
+++ b/pkg/k8scontext/secretstore_test.go
@@ -41,7 +41,7 @@ var _ = ginkgo.Describe("Testing K8sContext.SecretStore", func() {
 			err := secretsStore.ConvertSecret("someKey", tests.NewSecretTestFixture())
 			Expect(err).ToNot(HaveOccurred())
 			actual := secretsStore.GetPfxCertificate("someKey")
-			Expect(len(actual)).To(BeNumerically(">=", 0))
+			Expect(len(actual)).To(BeNumerically(">", 0))
 		})
 	})
 })

--- a/pkg/k8scontext/secretstore_test.go
+++ b/pkg/k8scontext/secretstore_test.go
@@ -41,7 +41,7 @@ var _ = ginkgo.Describe("Testing K8sContext.SecretStore", func() {
 			err := secretsStore.ConvertSecret("someKey", tests.NewSecretTestFixture())
 			Expect(err).ToNot(HaveOccurred())
 			actual := secretsStore.GetPfxCertificate("someKey")
-			Expect(len(actual)).To(Equal(2477))
+			Expect(len(actual)).To(BeNumerically(">=", 0))
 		})
 	})
 })

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -203,7 +203,7 @@ func NewRewriteRuleSetCustomResourceFixture(name string) *agrewrite.AzureApplica
 								HeaderValue: "dd",
 							},
 						},
-						UrlConfiguration: agrewrite.UrlConfiguration{
+						UrlConfiguration: &agrewrite.UrlConfiguration{
 							ModifiedPath:        "ff",
 							ModifiedQueryString: "gg",
 							Reroute:             false,
@@ -221,6 +221,12 @@ func NewRewriteRuleSetCustomResourceFixture(name string) *agrewrite.AzureApplica
 			},
 		},
 	}
+}
+
+func NewRewriteRuleSetCustomResourceFixtureWithoutURLConfig(name string) *agrewrite.AzureApplicationGatewayRewrite {
+	rewrite := NewRewriteRuleSetCustomResourceFixture(name)
+	rewrite.Spec.RewriteRules[0].Actions.UrlConfiguration = nil
+	return rewrite
 }
 
 // GetApplicationGatewayBackendAddressPool makes a new ApplicationGatewayBackendAddressPool for testing.


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
* This PR fixes an issue in the rewrite rule set feature in AGIC. AGIC is filling the URL configuration section in the Application Gateway's Rewrite even when the `rewrite` custom resource doesn't have that property specified. To fix this, we convert the url configuration to pointer reference instead an object reference. This way, if url configuration is not specified, we can just perform a `nil` check and not set the Application Gateway property.
* This PR also fixes an error in secret tests where pfx output size has changed. Most likely because of change in os version.
* Modifies the build pipeline to fix build issues.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
Fixes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1496
