### PR TITLE
Support for workload identity in AGIC Helm installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GO_BINARY_NAME ?= appgw-ingress
 GOOS ?= linux
 GARCH ?= arm64
 
-BUILD_BASE_IMAGE ?= golang:1.17.3
+BUILD_BASE_IMAGE ?= golang:1.19.5
 
 REPO ?= appgwreg.azurecr.io
 IMAGE_NAME = public/azure-application-gateway/kubernetes-ingress-staging

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.19
 
 require (
 	github.com/Azure/azure-sdk-for-go v66.0.0+incompatible
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0-beta.2
 	github.com/Azure/go-autorest/autorest v0.11.28
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
 	github.com/Azure/go-autorest/autorest/to v0.4.0
@@ -24,7 +26,7 @@ require (
 )
 
 require (
-	github.com/AlekSi/gocov-xml v1.1.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.21 // indirect
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.6 // indirect
@@ -32,7 +34,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/axw/gocov v1.1.0 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -51,15 +53,14 @@ require (
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/jstemmer/go-junit-report v1.0.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/matm/gocov-html v0.0.0-20200509184451-71874e2e203b // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
@@ -72,7 +73,6 @@ require (
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
-	golang.org/x/tools v0.1.12 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,10 +11,14 @@ cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/AlekSi/gocov-xml v1.1.0 h1:iElWGi7s/MuL8/d8WDtI2fOAsN3ap9x8nK5RrAhaDng=
-github.com/AlekSi/gocov-xml v1.1.0/go.mod h1:g1dRVOCHjKkMtlPfW6BokJ/qxoeZ1uPNAK7A/ii3CUo=
 github.com/Azure/azure-sdk-for-go v66.0.0+incompatible h1:bmmC38SlE8/E81nNADlgmVGurPWMHDX2YNXVQMrBpEE=
 github.com/Azure/azure-sdk-for-go v66.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0-beta.2 h1:NsprcuNHEsCR48QYlLxx/gAi9OcCzcwX8VVTZVK8fdQ=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0-beta.2/go.mod h1:NBanQUfSWiWn3QEpWDTCU0IjBECKOYvl2R8xdRtMtiM=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.1/go.mod h1:JFgpikqFJ/MleTTxwepExTKnFUKKszPS8UavbQYUMuw=
@@ -46,6 +50,8 @@ github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+Z
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 h1:VgSJlZH5u0k2qxSpqyghcFQKmvYckj46uymKK5XzkBM=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0/go.mod h1:BDJ5qMFKx9DugEg3+uQSDCdbYPr5s9vBTrL9P8TpqOU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -56,9 +62,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/axw/gocov v1.0.0/go.mod h1:LvQpEYiwwIb2nYkXY2fDWhg9/AsYqkhmrCshjlUJECE=
-github.com/axw/gocov v1.1.0 h1:y5U1krExoJDlb/kNtzxyZQmNRprFOFCutWbNjcQvmVM=
-github.com/axw/gocov v1.1.0/go.mod h1:H9G4tivgdN3pYSSVrTFBr6kGDCmAkgbJhtxFzAvgcdw=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -80,6 +83,7 @@ github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS3
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/dnaeon/go-vcr v1.1.0 h1:ReYa/UBrRyQdant9B4fNHGoCNKw6qh6P0fsdGmZpR7c=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
@@ -185,8 +189,6 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jstemmer/go-junit-report v1.0.0 h1:8X1gzZpR+nVQLAht+L/foqOeX2l9DTZoaIPbEQHxsds=
-github.com/jstemmer/go-junit-report v1.0.0/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -206,8 +208,6 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/matm/gocov-html v0.0.0-20200509184451-71874e2e203b h1:5Wc/N1FIBnExmX0/SEdKe0A0COvdJc3rCGHQ7s1oBPQ=
-github.com/matm/gocov-html v0.0.0-20200509184451-71874e2e203b/go.mod h1:zha4ZSIA/qviBBKx3j6tJG/Lx6aIdjOXPWuKAcJchQM=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -243,6 +243,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.20.1 h1:PA/3qinGoukvymdIDV8pii6tiZgC8kbmJO6Z5+b002Q=
 github.com/onsi/gomega v1.20.1/go.mod h1:DtrZpjmvpn2mPm4YWQa0/ALMDj9v4YxLgojwPeREyVo=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 h1:Qj1ukM4GlMWXNdMBuXcXfz/Kw9s1qm0CLY32QxuSImI=
+github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -413,7 +415,6 @@ golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -425,8 +426,6 @@ golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
-golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/helm/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/templates/configmap.yaml
@@ -78,7 +78,7 @@ data:
 {{- end }}
 
 {{- if .Values.armAuth -}}
-{{- if eq .Values.armAuth.type "aadPodIdentity"}}
+{{- if or (eq .Values.armAuth.type "aadPodIdentity") (eq .Values.armAuth.type "workloadIdentity") }}
   AZURE_CLIENT_ID: "{{ .Values.armAuth.identityClientID }}"
   USE_MANAGED_IDENTITY_FOR_POD: "true"
 {{- end }}

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -7,11 +7,6 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    {{- if .Values.armAuth }}
-    {{- if eq .Values.armAuth.type "workloadIdentity" }}
-    azure.workload.identity/use: "true"
-    {{- end }}
-    {{- end }}
 spec:
   replicas: 1 # TODO: Make configurable when leader election is supported.
   selector:
@@ -26,6 +21,9 @@ spec:
         {{- if .Values.armAuth }}
         {{- if eq .Values.armAuth.type "aadPodIdentity"}}
         aadpodidbinding: {{ template "application-gateway-kubernetes-ingress.fullname" . }}
+        {{- end }}
+        {{- if eq .Values.armAuth.type "workloadIdentity" }}
+        azure.workload.identity/use: "true"
         {{- end }}
         {{- end }}
       annotations:

--- a/helm/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/templates/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    {{- if .Values.armAuth }}
+    {{- if eq .Values.armAuth.type "workloadIdentity" }}
+    azure.workload.identity/use: "true"
+    {{- end }}
+    {{- end }}
 spec:
   replicas: 1 # TODO: Make configurable when leader election is supported.
   selector:

--- a/helm/ingress-azure/templates/serviceaccount.yaml
+++ b/helm/ingress-azure/templates/serviceaccount.yaml
@@ -6,4 +6,11 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    {{- if .Values.armAuth }}
+    {{- if eq .Values.armAuth.type "workloadIdentity" }}
+    azure.workload.identity/use: "true"
+  annotations:
+    azure.workload.identity/client-id: {{ required "armAuth.identityClientID is required if using Workload Identity" .Values.armAuth.identityClientID }}
+    {{- end }}
+    {{- end }}
   name: {{ template "application-gateway-kubernetes-ingress.serviceaccountname" . }}

--- a/helm/ingress-azure/tests/fixtures/sample-config-workload-identity.json
+++ b/helm/ingress-azure/tests/fixtures/sample-config-workload-identity.json
@@ -1,0 +1,20 @@
+{
+    "verbosityLevel": 3,
+    "appgw": {
+        "subscriptionId": "sub-id",
+        "resourceGroup": "resgp",
+        "name": "gateway",
+        "usePrivateIP": false,
+        "shared": false
+    },
+    "armAuth": {
+        "type": "workloadIdentity",
+        "identityClientID": "client-id"
+    },
+    "rbac": {
+        "enabled": false
+    },
+    "kubernetes": {
+        "resources": {}
+    }
+}

--- a/helm/ingress-azure/tests/snapshots/sample-config-workload-identity/ingress-azure/templates/configmap.yaml
+++ b/helm/ingress-azure/tests/snapshots/sample-config-workload-identity/ingress-azure/templates/configmap.yaml
@@ -1,0 +1,24 @@
+---
+# Source: ingress-azure/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-name-cm-ingress-azure
+  labels:
+    app: ingress-azure
+    chart: ingress-azure-1.6.0
+    heritage: Helm
+    release: release-name
+data:
+  APPGW_VERBOSITY_LEVEL: "3"
+  MULTI_CLUSTER_MODE: "false"
+  HTTP_SERVICE_PORT:     "8123"
+  APPGW_SUBSCRIPTION_ID: "sub-id"
+  APPGW_RESOURCE_GROUP:  "resgp"
+  APPGW_NAME:            "gateway"
+  APPGW_SUBNET_NAME: "gateway-subnet"
+  AZURE_CLIENT_ID: "client-id"
+  USE_MANAGED_IDENTITY_FOR_POD: "true"
+  INGRESS_CLASS_RESOURCE_ENABLED: "true"
+  INGRESS_CLASS_RESOURCE_NAME: "azure-application-gateway"
+  INGRESS_CLASS_RESOURCE_CONTROLLER: "azure/application-gateway"

--- a/helm/ingress-azure/tests/snapshots/sample-config-workload-identity/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/tests/snapshots/sample-config-workload-identity/ingress-azure/templates/deployment.yaml
@@ -9,7 +9,6 @@ metadata:
     chart: ingress-azure-1.6.0
     heritage: Helm
     release: release-name
-    azure.workload.identity/use: "true"
 spec:
   replicas: 1 # TODO: Make configurable when leader election is supported.
   selector:
@@ -21,6 +20,7 @@ spec:
       labels:
         app: ingress-azure
         release: release-name
+        azure.workload.identity/use: "true"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8123"

--- a/helm/ingress-azure/tests/snapshots/sample-config-workload-identity/ingress-azure/templates/deployment.yaml
+++ b/helm/ingress-azure/tests/snapshots/sample-config-workload-identity/ingress-azure/templates/deployment.yaml
@@ -1,0 +1,69 @@
+---
+# Source: ingress-azure/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: release-name-ingress-azure
+  labels:
+    app: ingress-azure
+    chart: ingress-azure-1.6.0
+    heritage: Helm
+    release: release-name
+    azure.workload.identity/use: "true"
+spec:
+  replicas: 1 # TODO: Make configurable when leader election is supported.
+  selector:
+    matchLabels:
+      app: ingress-azure
+      release: release-name
+  template:
+    metadata:
+      labels:
+        app: ingress-azure
+        release: release-name
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8123"
+    spec:
+      serviceAccountName: release-name-sa-ingress-azure
+      securityContext:
+        runAsUser: 0
+      containers:
+      - name: ingress-azure
+        image: mcr.microsoft.com/azure-application-gateway/kubernetes-ingress:1.6.0
+        imagePullPolicy: Always
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8123
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health/alive
+            port: 8123
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        env:
+        - name: AZURE_CLOUD_PROVIDER_LOCATION
+          value: /etc/appgw/azure.json
+        - name: AGIC_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: AGIC_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        envFrom:
+        - configMapRef:
+            name: release-name-cm-ingress-azure
+        volumeMounts:
+        - name: azure
+          mountPath: /etc/appgw/
+          readOnly: true
+      volumes:
+      - name: azure
+        hostPath:
+          path: /etc/kubernetes/
+          type: Directory

--- a/helm/ingress-azure/tests/snapshots/sample-config-workload-identity/ingress-azure/templates/ingressclass.yaml
+++ b/helm/ingress-azure/tests/snapshots/sample-config-workload-identity/ingress-azure/templates/ingressclass.yaml
@@ -1,0 +1,10 @@
+---
+# Source: ingress-azure/templates/ingressclass.yaml
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+  name: azure-application-gateway
+spec:
+  controller: azure/application-gateway

--- a/helm/ingress-azure/tests/snapshots/sample-config-workload-identity/ingress-azure/templates/serviceaccount.yaml
+++ b/helm/ingress-azure/tests/snapshots/sample-config-workload-identity/ingress-azure/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: ingress-azure/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: ingress-azure
+    chart: ingress-azure-1.6.0
+    heritage: Helm
+    release: release-name
+    azure.workload.identity/use: "true"
+  annotations:
+    azure.workload.identity/client-id: client-id
+  name: release-name-sa-ingress-azure

--- a/helm/ingress-azure/values-template.yaml
+++ b/helm/ingress-azure/values-template.yaml
@@ -99,6 +99,11 @@ appgw: {}
 #   # Generate this value with:
 #   #   az ad sp create-for-rbac --subscription <subscription-uuid> --sdk-auth | base64 -w0
 #   secretJSON: <base64-encoded-JSON-blob>
+#
+# - Option 3: Workload Identity (https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview)
+# armAuth:
+#   type: workloadIdentity
+#   identityClientID:  <>
 
 ################################################################################
 # (Legacy: use `kubernetes.nodeSelector` instead) Specify the scheduling options

--- a/helm/ingress-azure/values.yaml
+++ b/helm/ingress-azure/values.yaml
@@ -103,6 +103,11 @@ appgw: {}
 #   # Generate this value with:
 #   #   az ad sp create-for-rbac --subscription <subscription-uuid> --sdk-auth | base64 -w0
 #   secretJSON: <base64-encoded-JSON-blob>
+#
+# - Option 3: Workload Identity (https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview)
+# armAuth:
+#   type: workloadIdentity
+#   identityClientID:  <>
 
 ################################################################################
 # (Legacy: use `kubernetes.nodeSelector` instead) Specify the scheduling options

--- a/pkg/azure/auth.go
+++ b/pkg/azure/auth.go
@@ -35,14 +35,14 @@ func GetAuthorizerWithRetry(authLocation string, useManagedidentity bool, cpConf
 
 func getAuthorizer(authLocation string, useManagedidentity bool, cpConfig *CloudProviderConfig) (autorest.Authorizer, error) {
 	// Authorizer logic:
-	// 1. If User provided authLocation, then use the file.
-	// 2. If User provided a managed identity in ex: helm config, then use Environment
-	// 3. If User provided nothing and CloudProviderConfig has value, then use CloudProviderConfig
-	// 4. Fall back to environment
+	// 1. If a file location is provided, use file for authorizer.
+	// 2. If cloud provider is accessible and user didn't enable managed identity, then use cloud provider client id/secret.
+	// 3. Fallback is Default Azure Credentials which will try multiple credentials providers like MSI and Workload identity.
 	if authLocation != "" {
 		klog.V(1).Infof("Creating authorizer from file referenced by environment variable: %s", authLocation)
 		return auth.NewAuthorizerFromFile(n.DefaultBaseURI)
 	}
+
 	if !useManagedidentity && cpConfig != nil {
 		klog.V(1).Info("Creating authorizer using Cluster Service Principal.")
 		credAuthorizer := auth.NewClientCredentialsConfig(cpConfig.ClientID, cpConfig.ClientSecret, cpConfig.TenantID)

--- a/pkg/azure/auth.go
+++ b/pkg/azure/auth.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"k8s.io/klog/v2"
 
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/azure/defaultazurecredential"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
@@ -54,6 +55,6 @@ func getAuthorizer(authLocation string, useManagedidentity bool, cpConfig *Cloud
 		return credAuthorizer.Authorizer()
 	}
 
-	klog.V(1).Info("Creating authorizer from Azure Managed Service Identity")
-	return auth.NewAuthorizerFromEnvironment()
+	klog.V(1).Info("Creating authorizer using Default Azure Credentials")
+	return defaultazurecredential.NewAuthorizer()
 }

--- a/pkg/azure/defaultazurecredential/authorizer.go
+++ b/pkg/azure/defaultazurecredential/authorizer.go
@@ -36,12 +36,14 @@ type tokenCredentialWrapper struct {
 }
 
 func (w *tokenCredentialWrapper) OAuthToken() string {
+	klog.V(7).Info("Getting Azure token using DefaultAzureCredential")
+
 	token, err := w.cred.GetToken(context.Background(), policy.TokenRequestOptions{
 		Scopes: []string{"https://management.azure.com/.default"},
 	})
 
 	if err != nil {
-		klog.Error("Error getting bearer token: ", err)
+		klog.Error("Error getting Azure token: ", err)
 		return ""
 	}
 

--- a/pkg/azure/defaultazurecredential/authorizer.go
+++ b/pkg/azure/defaultazurecredential/authorizer.go
@@ -1,0 +1,49 @@
+package defaultazurecredential
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/go-autorest/autorest"
+	"k8s.io/klog/v2"
+)
+
+// NewAuthorizer returns an autorest.Authorizer that uses the DefaultAzureCredential
+// from the Azure SDK for Go.
+//
+// DefaultAzureCredential uses the following credential types in order in version 1.3 or higher.
+//   - [EnvironmentCredential]
+//   - [WorkloadIdentityCredential], if environment variable configuration is set by the Azure workload
+//     identity webhook. Use [WorkloadIdentityCredential] directly when not using the webhook or needing
+//     more control over its configuration.
+//   - [ManagedIdentityCredential]
+//   - [AzureCLICredential]
+func NewAuthorizer() (autorest.Authorizer, error) {
+	cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return autorest.NewBearerAuthorizer(&tokenCredentialWrapper{
+		cred: cred,
+	}), nil
+}
+
+type tokenCredentialWrapper struct {
+	cred azcore.TokenCredential
+}
+
+func (w *tokenCredentialWrapper) OAuthToken() string {
+	token, err := w.cred.GetToken(context.Background(), policy.TokenRequestOptions{
+		Scopes: []string{"https://management.azure.com/.default"},
+	})
+
+	if err != nil {
+		klog.Error("Error getting bearer token: ", err)
+		return ""
+	}
+
+	return token.Token
+}


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
This PR adds support for workload identity in AGIC when installed via Helm. AGIC will use to communicate with ARM to update Application Gateway.
Feature Documentation: https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview

* updates the authorization code to use the latest `DefaultAzureCredentials` token provider which supports using workload identity.
* To use workload identity, type `workloadIdentity` will apply the required labels and annotations on Deployment and Service Account.
```yaml
armAuth:
  type: workloadIdentity
  identityClientID:  <>
```

## Testing
* Label and Annotation on Service Account
![image](https://user-images.githubusercontent.com/5294363/215865351-c7634e5f-73d2-4adb-9a87-9ee9fcfcf276.png)
*  Label on Pod
![image](https://user-images.githubusercontent.com/5294363/215865007-e0f983e4-d390-471a-90a3-a39e5f28e82f.png)
* Pod has required environment variables to enable workload identity
![image](https://user-images.githubusercontent.com/5294363/215863924-41db09d5-1faa-4478-b949-d3e2a822e39b.png)
* AGIC successfully updating AppGW
![image](https://user-images.githubusercontent.com/5294363/215863680-31317fca-775f-46c0-9e93-d827c64fcda4.png)


## Fixes

<!-- Please mention #issues that are fixed in this PR -->
Fixes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1492