### PR TITLE
Fix bug in determining frontend to use when no ingress is present on cluster

### DIFF
--- a/functional_tests/cookie_name.json
+++ b/functional_tests/cookie_name.json
@@ -118,8 +118,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -198,16 +198,16 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19500,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e"
                     }
                 }
             }
@@ -221,8 +221,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "url-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
@@ -232,7 +232,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
                             "name": "pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/duplicate_ports.json
+++ b/functional_tests/duplicate_ports.json
@@ -92,25 +92,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "fl-08ba2bb7da9df5927d900fca8ce96ba5",
-                "properties": {
-                    "frontendIPConfiguration": {
-                        "id": "--front-end-ip-id-1--"
-                    },
-                    "frontendPort": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
-                    },
-                    "hostNames": [
-                        "foo.baz"
-                    ],
-                    "protocol": "Http",
-                    "requireServerNameIndication": false
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-175bc9385b96d7116527143f35cdfdea",
-                "name": "fl-175bc9385b96d7116527143f35cdfdea",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-43577dd217dfc020e151430368b4c910",
+                "name": "fl-43577dd217dfc020e151430368b4c910",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -126,6 +109,23 @@
                     "sslCertificate": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/cert---namespace-----the-name-of-the-secret--"
                     }
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-460bda00727325679d31c1f44e618448",
+                "name": "fl-460bda00727325679d31c1f44e618448",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
+                    },
+                    "hostNames": [
+                        "foo.baz"
+                    ],
+                    "protocol": "Http",
+                    "requireServerNameIndication": false
                 }
             }
         ],
@@ -178,36 +178,22 @@
         ],
         "redirectConfigurations": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-175bc9385b96d7116527143f35cdfdea",
-                "name": "sslr-fl-175bc9385b96d7116527143f35cdfdea",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-43577dd217dfc020e151430368b4c910",
+                "name": "sslr-fl-43577dd217dfc020e151430368b4c910",
                 "properties": {
                     "includePath": true,
                     "includeQueryString": true,
                     "redirectType": "Permanent",
                     "targetListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-175bc9385b96d7116527143f35cdfdea"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-43577dd217dfc020e151430368b4c910"
                     }
                 }
             }
         ],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "rr-08ba2bb7da9df5927d900fca8ce96ba5",
-                "properties": {
-                    "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-08ba2bb7da9df5927d900fca8ce96ba5"
-                    },
-                    "priority": 19000,
-                    "redirectConfiguration": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-175bc9385b96d7116527143f35cdfdea"
-                    },
-                    "ruleType": "Basic"
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-175bc9385b96d7116527143f35cdfdea",
-                "name": "rr-175bc9385b96d7116527143f35cdfdea",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-43577dd217dfc020e151430368b4c910",
+                "name": "rr-43577dd217dfc020e151430368b4c910",
                 "properties": {
                     "backendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80"
@@ -216,9 +202,23 @@
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--"
                     },
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-175bc9385b96d7116527143f35cdfdea"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-43577dd217dfc020e151430368b4c910"
+                    },
+                    "priority": 19000,
+                    "ruleType": "Basic"
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-460bda00727325679d31c1f44e618448",
+                "name": "rr-460bda00727325679d31c1f44e618448",
+                "properties": {
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-460bda00727325679d31c1f44e618448"
                     },
                     "priority": 19005,
+                    "redirectConfiguration": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-43577dd217dfc020e151430368b4c910"
+                    },
                     "ruleType": "Basic"
                 }
             }

--- a/functional_tests/empty_cluster_with_private_ip.json
+++ b/functional_tests/empty_cluster_with_private_ip.json
@@ -54,8 +54,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-ac133916d522c571f2d9ef8f3b8a25d3",
-                "name": "fl-ac133916d522c571f2d9ef8f3b8a25d3",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-22ee2b2b23866544c9beb9eab8459a2b",
+                "name": "fl-22ee2b2b23866544c9beb9eab8459a2b",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-2--"
@@ -104,8 +104,8 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-ac133916d522c571f2d9ef8f3b8a25d3",
-                "name": "rr-ac133916d522c571f2d9ef8f3b8a25d3",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-22ee2b2b23866544c9beb9eab8459a2b",
+                "name": "rr-22ee2b2b23866544c9beb9eab8459a2b",
                 "properties": {
                     "backendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/defaultaddresspool"
@@ -114,7 +114,7 @@
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/defaulthttpsetting"
                     },
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-ac133916d522c571f2d9ef8f3b8a25d3"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-22ee2b2b23866544c9beb9eab8459a2b"
                     },
                     "priority": 19500,
                     "ruleType": "Basic"

--- a/functional_tests/health_probes_same_labels_different_namespaces.json
+++ b/functional_tests/health_probes_same_labels_different_namespaces.json
@@ -123,25 +123,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "fl-08ba2bb7da9df5927d900fca8ce96ba5",
-                "properties": {
-                    "frontendIPConfiguration": {
-                        "id": "--front-end-ip-id-1--"
-                    },
-                    "frontendPort": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
-                    },
-                    "hostNames": [
-                        "foo.baz"
-                    ],
-                    "protocol": "Http",
-                    "requireServerNameIndication": false
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-175bc9385b96d7116527143f35cdfdea",
-                "name": "fl-175bc9385b96d7116527143f35cdfdea",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-43577dd217dfc020e151430368b4c910",
+                "name": "fl-43577dd217dfc020e151430368b4c910",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -157,6 +140,23 @@
                     "sslCertificate": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/cert---namespace-----the-name-of-the-secret--"
                     }
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-460bda00727325679d31c1f44e618448",
+                "name": "fl-460bda00727325679d31c1f44e618448",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
+                    },
+                    "hostNames": [
+                        "foo.baz"
+                    ],
+                    "protocol": "Http",
+                    "requireServerNameIndication": false
                 }
             }
         ],
@@ -224,36 +224,22 @@
         ],
         "redirectConfigurations": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-175bc9385b96d7116527143f35cdfdea",
-                "name": "sslr-fl-175bc9385b96d7116527143f35cdfdea",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-43577dd217dfc020e151430368b4c910",
+                "name": "sslr-fl-43577dd217dfc020e151430368b4c910",
                 "properties": {
                     "includePath": true,
                     "includeQueryString": true,
                     "redirectType": "Permanent",
                     "targetListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-175bc9385b96d7116527143f35cdfdea"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-43577dd217dfc020e151430368b4c910"
                     }
                 }
             }
         ],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "rr-08ba2bb7da9df5927d900fca8ce96ba5",
-                "properties": {
-                    "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-08ba2bb7da9df5927d900fca8ce96ba5"
-                    },
-                    "priority": 19000,
-                    "ruleType": "PathBasedRouting",
-                    "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-08ba2bb7da9df5927d900fca8ce96ba5"
-                    }
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-175bc9385b96d7116527143f35cdfdea",
-                "name": "rr-175bc9385b96d7116527143f35cdfdea",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-43577dd217dfc020e151430368b4c910",
+                "name": "rr-43577dd217dfc020e151430368b4c910",
                 "properties": {
                     "backendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80"
@@ -262,10 +248,24 @@
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--"
                     },
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-175bc9385b96d7116527143f35cdfdea"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-43577dd217dfc020e151430368b4c910"
+                    },
+                    "priority": 19000,
+                    "ruleType": "Basic"
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-460bda00727325679d31c1f44e618448",
+                "name": "rr-460bda00727325679d31c1f44e618448",
+                "properties": {
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-460bda00727325679d31c1f44e618448"
                     },
                     "priority": 19005,
-                    "ruleType": "Basic"
+                    "ruleType": "PathBasedRouting",
+                    "urlPathMap": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-460bda00727325679d31c1f44e618448"
+                    }
                 }
             }
         ],
@@ -287,15 +287,15 @@
         ],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "url-08ba2bb7da9df5927d900fca8ce96ba5",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-460bda00727325679d31c1f44e618448",
+                "name": "url-460bda00727325679d31c1f44e618448",
                 "properties": {
                     "defaultRedirectConfiguration": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-175bc9385b96d7116527143f35cdfdea"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-43577dd217dfc020e151430368b4c910"
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-08ba2bb7da9df5927d900fca8ce96ba5/pathRules/pr---other-namespace-----name--OtherNamespace-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-460bda00727325679d31c1f44e618448/pathRules/pr---other-namespace-----name--OtherNamespace-rule-0-path-0",
                             "name": "pr---other-namespace-----name--OtherNamespace-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/one_ingress_https_backend.json
+++ b/functional_tests/one_ingress_https_backend.json
@@ -97,8 +97,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-c61dda7ff9748ec5f51989767db5afd0",
-                "name": "fl-c61dda7ff9748ec5f51989767db5afd0",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-1c526ee8ba68b3db940684e9093980ad",
+                "name": "fl-1c526ee8ba68b3db940684e9093980ad",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -115,8 +115,8 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -179,44 +179,44 @@
         ],
         "redirectConfigurations": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-c61dda7ff9748ec5f51989767db5afd0",
-                "name": "sslr-fl-c61dda7ff9748ec5f51989767db5afd0",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-1c526ee8ba68b3db940684e9093980ad",
+                "name": "sslr-fl-1c526ee8ba68b3db940684e9093980ad",
                 "properties": {
                     "includePath": true,
                     "includeQueryString": true,
                     "redirectType": "Permanent",
                     "targetListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-c61dda7ff9748ec5f51989767db5afd0"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-1c526ee8ba68b3db940684e9093980ad"
                     }
                 }
             }
         ],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-c61dda7ff9748ec5f51989767db5afd0",
-                "name": "rr-c61dda7ff9748ec5f51989767db5afd0",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-1c526ee8ba68b3db940684e9093980ad",
+                "name": "rr-1c526ee8ba68b3db940684e9093980ad",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-c61dda7ff9748ec5f51989767db5afd0"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-1c526ee8ba68b3db940684e9093980ad"
                     },
                     "priority": 19500,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-c61dda7ff9748ec5f51989767db5afd0"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-1c526ee8ba68b3db940684e9093980ad"
                     }
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19505,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e"
                     }
                 }
             }
@@ -230,8 +230,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-c61dda7ff9748ec5f51989767db5afd0",
-                "name": "url-c61dda7ff9748ec5f51989767db5afd0",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-1c526ee8ba68b3db940684e9093980ad",
+                "name": "url-1c526ee8ba68b3db940684e9093980ad",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "xx"
@@ -241,7 +241,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-c61dda7ff9748ec5f51989767db5afd0/pathRules/pr---https-backend-namespace-----name--HttpsBackend-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-1c526ee8ba68b3db940684e9093980ad/pathRules/pr---https-backend-namespace-----name--HttpsBackend-rule-0-path-0",
                             "name": "pr---https-backend-namespace-----name--HttpsBackend-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {
@@ -259,22 +259,22 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "url-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "defaultRedirectConfiguration": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-c61dda7ff9748ec5f51989767db5afd0"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-1c526ee8ba68b3db940684e9093980ad"
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---https-backend-namespace-----name--HttpsBackend-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---https-backend-namespace-----name--HttpsBackend-rule-0-path-0",
                             "name": "pr---https-backend-namespace-----name--HttpsBackend-rule-0-path-0",
                             "properties": {
                                 "paths": [
                                     "/A/"
                                 ],
                                 "redirectConfiguration": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-c61dda7ff9748ec5f51989767db5afd0"
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-1c526ee8ba68b3db940684e9093980ad"
                                 }
                             }
                         }

--- a/functional_tests/one_ingress_https_backend_without_backend_protocol.json
+++ b/functional_tests/one_ingress_https_backend_without_backend_protocol.json
@@ -85,8 +85,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-c61dda7ff9748ec5f51989767db5afd0",
-                "name": "fl-c61dda7ff9748ec5f51989767db5afd0",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-1c526ee8ba68b3db940684e9093980ad",
+                "name": "fl-1c526ee8ba68b3db940684e9093980ad",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -153,16 +153,16 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-c61dda7ff9748ec5f51989767db5afd0",
-                "name": "rr-c61dda7ff9748ec5f51989767db5afd0",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-1c526ee8ba68b3db940684e9093980ad",
+                "name": "rr-1c526ee8ba68b3db940684e9093980ad",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-c61dda7ff9748ec5f51989767db5afd0"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-1c526ee8ba68b3db940684e9093980ad"
                     },
                     "priority": 19500,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-c61dda7ff9748ec5f51989767db5afd0"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-1c526ee8ba68b3db940684e9093980ad"
                     }
                 }
             }
@@ -176,8 +176,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-c61dda7ff9748ec5f51989767db5afd0",
-                "name": "url-c61dda7ff9748ec5f51989767db5afd0",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-1c526ee8ba68b3db940684e9093980ad",
+                "name": "url-1c526ee8ba68b3db940684e9093980ad",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "xx"
@@ -187,7 +187,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-c61dda7ff9748ec5f51989767db5afd0/pathRules/pr---https-backend-namespace-----name--HttpsBackend-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-1c526ee8ba68b3db940684e9093980ad/pathRules/pr---https-backend-namespace-----name--HttpsBackend-rule-0-path-0",
                             "name": "pr---https-backend-namespace-----name--HttpsBackend-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/one_ingress_slash_nothing.json
+++ b/functional_tests/one_ingress_slash_nothing.json
@@ -85,8 +85,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -150,8 +150,8 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "backendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
@@ -160,7 +160,7 @@
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--SlashNothing"
                     },
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19500,
                     "ruleType": "Basic"

--- a/functional_tests/one_ingress_slash_slashnothing.json
+++ b/functional_tests/one_ingress_slash_slashnothing.json
@@ -116,8 +116,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -196,16 +196,16 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19500,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e"
                     }
                 }
             }
@@ -219,8 +219,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "url-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
@@ -230,7 +230,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--A-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--A-rule-0-path-0",
                             "name": "pr---namespace-----name--A-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/one_ingress_with_multiple_path_rules.json
+++ b/functional_tests/one_ingress_with_multiple_path_rules.json
@@ -147,8 +147,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -242,16 +242,16 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19500,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e"
                     }
                 }
             }
@@ -265,8 +265,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "url-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "xx"
@@ -276,7 +276,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--MultiplePathRules-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--MultiplePathRules-rule-0-path-0",
                             "name": "pr---namespace-----name--MultiplePathRules-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {
@@ -291,7 +291,7 @@
                             }
                         },
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--MultiplePathRules-rule-1-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--MultiplePathRules-rule-1-path-0",
                             "name": "pr---namespace-----name--MultiplePathRules-rule-1-path-0",
                             "properties": {
                                 "backendAddressPool": {
@@ -306,7 +306,7 @@
                             }
                         },
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--MultiplePathRules-rule-1-path-1",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--MultiplePathRules-rule-1-path-1",
                             "name": "pr---namespace-----name--MultiplePathRules-rule-1-path-1",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/private-ip-only-gateway.json
+++ b/functional_tests/private-ip-only-gateway.json
@@ -83,25 +83,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-99e28aff3b2f87fe177626b33f1d8d7c",
-                "name": "fl-99e28aff3b2f87fe177626b33f1d8d7c",
-                "properties": {
-                    "frontendIPConfiguration": {
-                        "id": "--front-end-ip-id-2--"
-                    },
-                    "frontendPort": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
-                    },
-                    "hostNames": [
-                        "foo.baz"
-                    ],
-                    "protocol": "Http",
-                    "requireServerNameIndication": false
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-fafc599c553da3501d29a7eb806da9c2",
-                "name": "fl-fafc599c553da3501d29a7eb806da9c2",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-7d921970c46dec616a00d964690bbab0",
+                "name": "fl-7d921970c46dec616a00d964690bbab0",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-2--"
@@ -117,6 +100,23 @@
                     "sslCertificate": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/cert---namespace-----the-name-of-the-secret--"
                     }
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-857975d96f9b44e510fcc119947f9da0",
+                "name": "fl-857975d96f9b44e510fcc119947f9da0",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-2--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
+                    },
+                    "hostNames": [
+                        "foo.baz"
+                    ],
+                    "protocol": "Http",
+                    "requireServerNameIndication": false
                 }
             }
         ],
@@ -169,36 +169,22 @@
         ],
         "redirectConfigurations": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-fafc599c553da3501d29a7eb806da9c2",
-                "name": "sslr-fl-fafc599c553da3501d29a7eb806da9c2",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-7d921970c46dec616a00d964690bbab0",
+                "name": "sslr-fl-7d921970c46dec616a00d964690bbab0",
                 "properties": {
                     "includePath": true,
                     "includeQueryString": true,
                     "redirectType": "Permanent",
                     "targetListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-fafc599c553da3501d29a7eb806da9c2"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-7d921970c46dec616a00d964690bbab0"
                     }
                 }
             }
         ],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-99e28aff3b2f87fe177626b33f1d8d7c",
-                "name": "rr-99e28aff3b2f87fe177626b33f1d8d7c",
-                "properties": {
-                    "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-99e28aff3b2f87fe177626b33f1d8d7c"
-                    },
-                    "priority": 19000,
-                    "redirectConfiguration": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-fafc599c553da3501d29a7eb806da9c2"
-                    },
-                    "ruleType": "Basic"
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-fafc599c553da3501d29a7eb806da9c2",
-                "name": "rr-fafc599c553da3501d29a7eb806da9c2",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-7d921970c46dec616a00d964690bbab0",
+                "name": "rr-7d921970c46dec616a00d964690bbab0",
                 "properties": {
                     "backendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80"
@@ -207,9 +193,23 @@
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--"
                     },
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-fafc599c553da3501d29a7eb806da9c2"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-7d921970c46dec616a00d964690bbab0"
+                    },
+                    "priority": 19000,
+                    "ruleType": "Basic"
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-857975d96f9b44e510fcc119947f9da0",
+                "name": "rr-857975d96f9b44e510fcc119947f9da0",
+                "properties": {
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-857975d96f9b44e510fcc119947f9da0"
                     },
                     "priority": 19005,
+                    "redirectConfiguration": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-7d921970c46dec616a00d964690bbab0"
+                    },
                     "ruleType": "Basic"
                 }
             }

--- a/functional_tests/rewrite_rule_sets_one_ingress_slash_slashnothing.json
+++ b/functional_tests/rewrite_rule_sets_one_ingress_slash_slashnothing.json
@@ -116,8 +116,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -196,16 +196,16 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19500,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e"
                     }
                 }
             }
@@ -254,8 +254,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "url-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
@@ -268,7 +268,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
                             "name": "pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/rewrite_rule_sets_one_ingress_slashnothing.json
+++ b/functional_tests/rewrite_rule_sets_one_ingress_slashnothing.json
@@ -85,8 +85,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -150,8 +150,8 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "backendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
@@ -160,7 +160,7 @@
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--SlashNothing"
                     },
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19500,
                     "rewriteRuleSet": {

--- a/functional_tests/rewrite_rule_sets_path-based_rules_without_default_backend.json
+++ b/functional_tests/rewrite_rule_sets_path-based_rules_without_default_backend.json
@@ -147,8 +147,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -242,16 +242,16 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19500,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e"
                     }
                 }
             }
@@ -305,8 +305,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "url-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "xx"
@@ -316,7 +316,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--MultiplePathRules-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--MultiplePathRules-rule-0-path-0",
                             "name": "pr---namespace-----name--MultiplePathRules-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {
@@ -334,7 +334,7 @@
                             }
                         },
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--MultiplePathRules-rule-1-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--MultiplePathRules-rule-1-path-0",
                             "name": "pr---namespace-----name--MultiplePathRules-rule-1-path-0",
                             "properties": {
                                 "backendAddressPool": {
@@ -352,7 +352,7 @@
                             }
                         },
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--MultiplePathRules-rule-1-path-1",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--MultiplePathRules-rule-1-path-1",
                             "name": "pr---namespace-----name--MultiplePathRules-rule-1-path-1",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/rewrite_rule_sets_two_ingress.json
+++ b/functional_tests/rewrite_rule_sets_two_ingress.json
@@ -116,8 +116,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -196,16 +196,16 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19500,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e"
                     }
                 }
             }
@@ -259,8 +259,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "url-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
@@ -273,7 +273,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--A-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--A-rule-0-path-0",
                             "name": "pr---namespace-----name--A-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/rule_priority_annotation.json
+++ b/functional_tests/rule_priority_annotation.json
@@ -116,8 +116,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -196,16 +196,16 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 100,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e"
                     }
                 }
             }
@@ -219,8 +219,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "url-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
@@ -230,7 +230,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
                             "name": "pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/three_ingresses.json
+++ b/functional_tests/three_ingresses.json
@@ -154,25 +154,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "fl-08ba2bb7da9df5927d900fca8ce96ba5",
-                "properties": {
-                    "frontendIPConfiguration": {
-                        "id": "--front-end-ip-id-1--"
-                    },
-                    "frontendPort": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
-                    },
-                    "hostNames": [
-                        "foo.baz"
-                    ],
-                    "protocol": "Http",
-                    "requireServerNameIndication": false
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-175bc9385b96d7116527143f35cdfdea",
-                "name": "fl-175bc9385b96d7116527143f35cdfdea",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-43577dd217dfc020e151430368b4c910",
+                "name": "fl-43577dd217dfc020e151430368b4c910",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -191,8 +174,8 @@
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -201,6 +184,23 @@
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
                     },
                     "hostNames": [],
+                    "protocol": "Http",
+                    "requireServerNameIndication": false
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-460bda00727325679d31c1f44e618448",
+                "name": "fl-460bda00727325679d31c1f44e618448",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
+                    },
+                    "hostNames": [
+                        "foo.baz"
+                    ],
                     "protocol": "Http",
                     "requireServerNameIndication": false
                 }
@@ -285,36 +285,22 @@
         ],
         "redirectConfigurations": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-175bc9385b96d7116527143f35cdfdea",
-                "name": "sslr-fl-175bc9385b96d7116527143f35cdfdea",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-43577dd217dfc020e151430368b4c910",
+                "name": "sslr-fl-43577dd217dfc020e151430368b4c910",
                 "properties": {
                     "includePath": true,
                     "includeQueryString": true,
                     "redirectType": "Permanent",
                     "targetListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-175bc9385b96d7116527143f35cdfdea"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-43577dd217dfc020e151430368b4c910"
                     }
                 }
             }
         ],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "rr-08ba2bb7da9df5927d900fca8ce96ba5",
-                "properties": {
-                    "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-08ba2bb7da9df5927d900fca8ce96ba5"
-                    },
-                    "priority": 19000,
-                    "redirectConfiguration": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-175bc9385b96d7116527143f35cdfdea"
-                    },
-                    "ruleType": "Basic"
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-175bc9385b96d7116527143f35cdfdea",
-                "name": "rr-175bc9385b96d7116527143f35cdfdea",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-43577dd217dfc020e151430368b4c910",
+                "name": "rr-43577dd217dfc020e151430368b4c910",
                 "properties": {
                     "backendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80"
@@ -323,24 +309,38 @@
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--"
                     },
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-175bc9385b96d7116527143f35cdfdea"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-43577dd217dfc020e151430368b4c910"
                     },
-                    "priority": 19005,
+                    "priority": 19000,
                     "ruleType": "Basic"
                 }
             },
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19500,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e"
                     }
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-460bda00727325679d31c1f44e618448",
+                "name": "rr-460bda00727325679d31c1f44e618448",
+                "properties": {
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-460bda00727325679d31c1f44e618448"
+                    },
+                    "priority": 19005,
+                    "redirectConfiguration": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-43577dd217dfc020e151430368b4c910"
+                    },
+                    "ruleType": "Basic"
                 }
             }
         ],
@@ -362,8 +362,8 @@
         ],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "url-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "xx"
@@ -373,7 +373,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--A-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--A-rule-0-path-0",
                             "name": "pr---namespace-----name--A-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {
@@ -388,7 +388,7 @@
                             }
                         },
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--B-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--B-rule-0-path-0",
                             "name": "pr---namespace-----name--B-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/two_ingresses_same_domain_tls_notls.json
+++ b/functional_tests/two_ingresses_same_domain_tls_notls.json
@@ -123,25 +123,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "fl-08ba2bb7da9df5927d900fca8ce96ba5",
-                "properties": {
-                    "frontendIPConfiguration": {
-                        "id": "--front-end-ip-id-1--"
-                    },
-                    "frontendPort": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
-                    },
-                    "hostNames": [
-                        "foo.baz"
-                    ],
-                    "protocol": "Http",
-                    "requireServerNameIndication": false
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-175bc9385b96d7116527143f35cdfdea",
-                "name": "fl-175bc9385b96d7116527143f35cdfdea",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-43577dd217dfc020e151430368b4c910",
+                "name": "fl-43577dd217dfc020e151430368b4c910",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -157,6 +140,23 @@
                     "sslCertificate": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/sslCertificates/cert---namespace-----the-name-of-the-secret--"
                     }
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-460bda00727325679d31c1f44e618448",
+                "name": "fl-460bda00727325679d31c1f44e618448",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
+                    },
+                    "hostNames": [
+                        "foo.baz"
+                    ],
+                    "protocol": "Http",
+                    "requireServerNameIndication": false
                 }
             }
         ],
@@ -224,36 +224,22 @@
         ],
         "redirectConfigurations": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-175bc9385b96d7116527143f35cdfdea",
-                "name": "sslr-fl-175bc9385b96d7116527143f35cdfdea",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-43577dd217dfc020e151430368b4c910",
+                "name": "sslr-fl-43577dd217dfc020e151430368b4c910",
                 "properties": {
                     "includePath": true,
                     "includeQueryString": true,
                     "redirectType": "Permanent",
                     "targetListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-175bc9385b96d7116527143f35cdfdea"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-43577dd217dfc020e151430368b4c910"
                     }
                 }
             }
         ],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "rr-08ba2bb7da9df5927d900fca8ce96ba5",
-                "properties": {
-                    "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-08ba2bb7da9df5927d900fca8ce96ba5"
-                    },
-                    "priority": 19000,
-                    "ruleType": "PathBasedRouting",
-                    "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-08ba2bb7da9df5927d900fca8ce96ba5"
-                    }
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-175bc9385b96d7116527143f35cdfdea",
-                "name": "rr-175bc9385b96d7116527143f35cdfdea",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-43577dd217dfc020e151430368b4c910",
+                "name": "rr-43577dd217dfc020e151430368b4c910",
                 "properties": {
                     "backendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-80-bp-80"
@@ -262,10 +248,24 @@
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-80-80---name--"
                     },
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-175bc9385b96d7116527143f35cdfdea"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-43577dd217dfc020e151430368b4c910"
+                    },
+                    "priority": 19000,
+                    "ruleType": "Basic"
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-460bda00727325679d31c1f44e618448",
+                "name": "rr-460bda00727325679d31c1f44e618448",
+                "properties": {
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-460bda00727325679d31c1f44e618448"
                     },
                     "priority": 19005,
-                    "ruleType": "Basic"
+                    "ruleType": "PathBasedRouting",
+                    "urlPathMap": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-460bda00727325679d31c1f44e618448"
+                    }
                 }
             }
         ],
@@ -287,15 +287,15 @@
         ],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "url-08ba2bb7da9df5927d900fca8ce96ba5",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-460bda00727325679d31c1f44e618448",
+                "name": "url-460bda00727325679d31c1f44e618448",
                 "properties": {
                     "defaultRedirectConfiguration": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-175bc9385b96d7116527143f35cdfdea"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/redirectConfigurations/sslr-fl-43577dd217dfc020e151430368b4c910"
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-08ba2bb7da9df5927d900fca8ce96ba5/pathRules/pr---namespace-----name--FooBazNoTLS-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-460bda00727325679d31c1f44e618448/pathRules/pr---namespace-----name--FooBazNoTLS-rule-0-path-0",
                             "name": "pr---namespace-----name--FooBazNoTLS-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/two_ingresses_same_hostname_value_different_locations.json
+++ b/functional_tests/two_ingresses_same_hostname_value_different_locations.json
@@ -99,8 +99,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "fl-08ba2bb7da9df5927d900fca8ce96ba5",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-460bda00727325679d31c1f44e618448",
+                "name": "fl-460bda00727325679d31c1f44e618448",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -181,16 +181,16 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "rr-08ba2bb7da9df5927d900fca8ce96ba5",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-460bda00727325679d31c1f44e618448",
+                "name": "rr-460bda00727325679d31c1f44e618448",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-08ba2bb7da9df5927d900fca8ce96ba5"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-460bda00727325679d31c1f44e618448"
                     },
                     "priority": 19000,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-08ba2bb7da9df5927d900fca8ce96ba5"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-460bda00727325679d31c1f44e618448"
                     }
                 }
             }
@@ -204,8 +204,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-08ba2bb7da9df5927d900fca8ce96ba5",
-                "name": "url-08ba2bb7da9df5927d900fca8ce96ba5",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-460bda00727325679d31c1f44e618448",
+                "name": "url-460bda00727325679d31c1f44e618448",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "xx"
@@ -215,7 +215,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-08ba2bb7da9df5927d900fca8ce96ba5/pathRules/pr---namespace-----name--FooBazNoTLS-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-460bda00727325679d31c1f44e618448/pathRules/pr---namespace-----name--FooBazNoTLS-rule-0-path-0",
                             "name": "pr---namespace-----name--FooBazNoTLS-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/two_ingresses_slash_slashsomething.json
+++ b/functional_tests/two_ingresses_slash_slashsomething.json
@@ -116,8 +116,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -196,16 +196,16 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19500,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e"
                     }
                 }
             }
@@ -219,8 +219,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "url-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
@@ -230,7 +230,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--A-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--A-rule-0-path-0",
                             "name": "pr---namespace-----name--A-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {

--- a/functional_tests/two_ingresses_with_and_without_extended_hostname.json
+++ b/functional_tests/two_ingresses_with_and_without_extended_hostname.json
@@ -116,8 +116,23 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-ac80e40addbf0c0bac6b5c79b565a989",
-                "name": "fl-ac80e40addbf0c0bac6b5c79b565a989",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
+                "properties": {
+                    "frontendIPConfiguration": {
+                        "id": "--front-end-ip-id-1--"
+                    },
+                    "frontendPort": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
+                    },
+                    "hostNames": [],
+                    "protocol": "Http",
+                    "requireServerNameIndication": false
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-a09123f011e10f9e55780c5837ae7946",
+                "name": "fl-a09123f011e10f9e55780c5837ae7946",
                 "properties": {
                     "frontendIPConfiguration": {
                         "id": "--front-end-ip-id-1--"
@@ -129,21 +144,6 @@
                         "test.com",
                         "t*.com"
                     ],
-                    "protocol": "Http",
-                    "requireServerNameIndication": false
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "properties": {
-                    "frontendIPConfiguration": {
-                        "id": "--front-end-ip-id-1--"
-                    },
-                    "frontendPort": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/frontendPorts/fp-80"
-                    },
-                    "hostNames": [],
                     "protocol": "Http",
                     "requireServerNameIndication": false
                 }
@@ -214,30 +214,30 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-ac80e40addbf0c0bac6b5c79b565a989",
-                "name": "rr-ac80e40addbf0c0bac6b5c79b565a989",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-ac80e40addbf0c0bac6b5c79b565a989"
-                    },
-                    "priority": 19000,
-                    "ruleType": "PathBasedRouting",
-                    "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-ac80e40addbf0c0bac6b5c79b565a989"
-                    }
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "properties": {
-                    "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19500,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e"
+                    }
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-a09123f011e10f9e55780c5837ae7946",
+                "name": "rr-a09123f011e10f9e55780c5837ae7946",
+                "properties": {
+                    "httpListener": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-a09123f011e10f9e55780c5837ae7946"
+                    },
+                    "priority": 19000,
+                    "ruleType": "PathBasedRouting",
+                    "urlPathMap": {
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-a09123f011e10f9e55780c5837ae7946"
                     }
                 }
             }
@@ -251,8 +251,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-ac80e40addbf0c0bac6b5c79b565a989",
-                "name": "url-ac80e40addbf0c0bac6b5c79b565a989",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "url-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "xx"
@@ -262,36 +262,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-ac80e40addbf0c0bac6b5c79b565a989/pathRules/pr---namespace-----name--BWithExtendedHostName-rule-0-path-0",
-                            "name": "pr---namespace-----name--BWithExtendedHostName-rule-0-path-0",
-                            "properties": {
-                                "backendAddressPool": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
-                                },
-                                "backendHttpSettings": {
-                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--BWithExtendedHostName"
-                                },
-                                "paths": [
-                                    "/B/"
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "properties": {
-                    "defaultBackendAddressPool": {
-                        "id": "xx"
-                    },
-                    "defaultBackendHttpSettings": {
-                        "id": "yy"
-                    },
-                    "pathRules": [
-                        {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--A-rule-0-path-0",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--A-rule-0-path-0",
                             "name": "pr---namespace-----name--A-rule-0-path-0",
                             "properties": {
                                 "backendAddressPool": {
@@ -302,6 +273,35 @@
                                 },
                                 "paths": [
                                     "/A/"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-a09123f011e10f9e55780c5837ae7946",
+                "name": "url-a09123f011e10f9e55780c5837ae7946",
+                "properties": {
+                    "defaultBackendAddressPool": {
+                        "id": "xx"
+                    },
+                    "defaultBackendHttpSettings": {
+                        "id": "yy"
+                    },
+                    "pathRules": [
+                        {
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-a09123f011e10f9e55780c5837ae7946/pathRules/pr---namespace-----name--BWithExtendedHostName-rule-0-path-0",
+                            "name": "pr---namespace-----name--BWithExtendedHostName-rule-0-path-0",
+                            "properties": {
+                                "backendAddressPool": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
+                                },
+                                "backendHttpSettings": {
+                                    "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp---namespace---hello-world-b-80-80---name--BWithExtendedHostName"
+                                },
+                                "paths": [
+                                    "/B/"
                                 ]
                             }
                         }

--- a/functional_tests/waf_annotation.json
+++ b/functional_tests/waf_annotation.json
@@ -116,8 +116,8 @@
         ],
         "httpListeners": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "firewallPolicy": {
                         "id": "/some/policy/here"
@@ -199,16 +199,16 @@
         "redirectConfigurations": [],
         "requestRoutingRules": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "httpListener": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
                     },
                     "priority": 19500,
                     "ruleType": "PathBasedRouting",
                     "urlPathMap": {
-                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a"
+                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e"
                     }
                 }
             }
@@ -222,8 +222,8 @@
         "sslCertificates": [],
         "urlPathMaps": [
             {
-                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a",
-                "name": "url-e1903c8aa3446b7b3207aec6d6ecba8a",
+                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e",
+                "name": "url-452c578b4f742bd7a3927c3caf2b604e",
                 "properties": {
                     "defaultBackendAddressPool": {
                         "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool---namespace---hello-world-b-80-bp-80"
@@ -233,7 +233,7 @@
                     },
                     "pathRules": [
                         {
-                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-e1903c8aa3446b7b3207aec6d6ecba8a/pathRules/pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
+                            "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/urlPathMaps/url-452c578b4f742bd7a3927c3caf2b604e/pathRules/pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
                             "name": "pr---namespace-----name--SlashNothingSlashSomething-rule-0-path-1",
                             "properties": {
                                 "backendAddressPool": {

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	defaultListenersChecker := func(appGW *n.ApplicationGatewayPropertiesFormat) {
 		// Test the listener.
 		frontendPortID := appGwIdentifier.frontendPortID(generateFrontendPortName(80))
-		_, listenerName := newTestListenerID(Port(80), []string{domainName}, false)
+		_, listenerName := newTestListenerID(Port(80), []string{domainName}, FrontendTypePublic)
 		listener := &n.ApplicationGatewayHTTPListener{
 			Etag: to.StringPtr("*"),
 			Name: &listenerName,
@@ -302,7 +302,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	}
 
 	baseRequestRoutingRulesChecker := func(appGW *n.ApplicationGatewayPropertiesFormat, frontEndPort Port, host string) {
-		listenerID, _ := newTestListenerID(Port(frontEndPort), []string{host}, false)
+		listenerID, _ := newTestListenerID(Port(frontEndPort), []string{host}, FrontendTypePublic)
 		Expect(*((*appGW.RequestRoutingRules)[0].Name)).To(Equal(generateRequestRoutingRuleName(listenerID)))
 		Expect((*appGW.RequestRoutingRules)[0].RuleType).To(Equal(n.ApplicationGatewayRequestRoutingRuleTypePathBasedRouting))
 	}
@@ -316,7 +316,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 	}
 
 	baseURLPathMapsChecker := func(appGW *n.ApplicationGatewayPropertiesFormat, frontEndPort Port, host string) {
-		listenerID, _ := newTestListenerID(Port(frontEndPort), []string{host}, false)
+		listenerID, _ := newTestListenerID(Port(frontEndPort), []string{host}, FrontendTypePublic)
 		Expect(*((*appGW.URLPathMaps)[0].Name)).To(Equal(generateURLPathMapName(listenerID)))
 		// Check the `pathRule` stored within the `urlPathMap`.
 		Expect(len(*((*appGW.URLPathMaps)[0].PathRules))).To(Equal(1), "Expected one path based rule, but got: %d", len(*((*appGW.URLPathMaps)[0].PathRules)))
@@ -659,7 +659,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 				}
 
 				frontendPortID := appGwIdentifier.frontendPortID(generateFrontendPortName(443))
-				_, httpsListenerName := newTestListenerID(Port(443), []string{domainName}, false)
+				_, httpsListenerName := newTestListenerID(Port(443), []string{domainName}, FrontendTypePublic)
 				sslCert := appGwIdentifier.sslCertificateID(secretID.secretFullName())
 				httpsListener := &n.ApplicationGatewayHTTPListener{
 					Etag: to.StringPtr("*"),

--- a/pkg/appgw/backendaddresspools_test.go
+++ b/pkg/appgw/backendaddresspools_test.go
@@ -193,7 +193,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 		It("Should get listener config from istio", func() {
 			actual := cb.getListenerConfigsFromIstio(istioGateways, istioVirtualServices, environment.GetFakeEnv())
 			expected := map[listenerIdentifier]listenerAzConfig{
-				{FrontendPort: 80, UsePrivateIP: false}: {
+				{FrontendPort: 80, FrontendType: FrontendTypePublic}: {
 					Protocol:                     "Http",
 					Secret:                       secretIdentifier{Namespace: "", Name: ""},
 					SslRedirectConfigurationName: "",
@@ -216,7 +216,7 @@ var _ = Describe("Test the creation of Backend Pools from Ingress definition", f
 			}
 			actual := cb.getIstioPathMaps(cbCtx)
 
-			expectedListerID80, _ := newTestListenerID(Port(80), nil, false)
+			expectedListerID80, _ := newTestListenerID(Port(80), nil, FrontendTypePublic)
 			expected := map[listenerIdentifier]*n.ApplicationGatewayURLPathMap{
 				expectedListerID80: {
 					ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -238,9 +238,14 @@ func generateListenerID(ingress *networking.Ingress, rule *networking.IngressRul
 
 	}
 
+	frontendType := FrontendTypePublic
+	if usePrivateIP {
+		frontendType = FrontendTypePrivate
+	}
+
 	listenerID := listenerIdentifier{
 		FrontendPort: frontendPort,
-		UsePrivateIP: usePrivateIP,
+		FrontendType: frontendType,
 	}
 
 	var hostNames []string

--- a/pkg/appgw/configbuilder_test.go
+++ b/pkg/appgw/configbuilder_test.go
@@ -333,8 +333,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --        ],
 --        "httpListeners": [
 --            {
---                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-08ba2bb7da9df5927d900fca8ce96ba5",
---                "name": "fl-08ba2bb7da9df5927d900fca8ce96ba5",
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-460bda00727325679d31c1f44e618448",
+--                "name": "fl-460bda00727325679d31c1f44e618448",
 --                "properties": {
 --                    "frontendIPConfiguration": {
 --                        "id": "--front-end-ip-id-1--"
@@ -400,8 +400,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --        "redirectConfigurations": [],
 --        "requestRoutingRules": [
 --            {
---                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-08ba2bb7da9df5927d900fca8ce96ba5",
---                "name": "rr-08ba2bb7da9df5927d900fca8ce96ba5",
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-460bda00727325679d31c1f44e618448",
+--                "name": "rr-460bda00727325679d31c1f44e618448",
 --                "properties": {
 --                    "backendAddressPool": {
 --                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-80-bp-80"
@@ -410,7 +410,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-80-80---name--"
 --                    },
 --                    "httpListener": {
---                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-08ba2bb7da9df5927d900fca8ce96ba5"
+--                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-460bda00727325679d31c1f44e618448"
 --                    },
 --                    "priority": 19000,
 --                    "ruleType": "Basic"
@@ -585,8 +585,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --        ],
 --        "httpListeners": [
 --            {
---                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a",
---                "name": "fl-e1903c8aa3446b7b3207aec6d6ecba8a",
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e",
+--                "name": "fl-452c578b4f742bd7a3927c3caf2b604e",
 --                "properties": {
 --                    "frontendIPConfiguration": {
 --                        "id": "--front-end-ip-id-1--"
@@ -635,8 +635,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --        "redirectConfigurations": [],
 --        "requestRoutingRules": [
 --            {
---                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-e1903c8aa3446b7b3207aec6d6ecba8a",
---                "name": "rr-e1903c8aa3446b7b3207aec6d6ecba8a",
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-452c578b4f742bd7a3927c3caf2b604e",
+--                "name": "rr-452c578b4f742bd7a3927c3caf2b604e",
 --                "properties": {
 --                    "backendAddressPool": {
 --                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-80-bp-80"
@@ -645,7 +645,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/defaulthttpsetting"
 --                    },
 --                    "httpListener": {
---                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-e1903c8aa3446b7b3207aec6d6ecba8a"
+--                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-452c578b4f742bd7a3927c3caf2b604e"
 --                    },
 --                    "priority": 19500,
 --                    "ruleType": "Basic"
@@ -848,8 +848,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --        ],
 --        "httpListeners": [
 --            {
---                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-b2dba5a02f61d8615cc23d8df120ac20",
---                "name": "fl-b2dba5a02f61d8615cc23d8df120ac20",
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-853f2cc01a700b4ca07424c3daf866cd",
+--                "name": "fl-853f2cc01a700b4ca07424c3daf866cd",
 --                "properties": {
 --                    "frontendIPConfiguration": {
 --                        "id": "--front-end-ip-id-1--"
@@ -917,8 +917,8 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --        "redirectConfigurations": [],
 --        "requestRoutingRules": [
 --            {
---                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-b2dba5a02f61d8615cc23d8df120ac20",
---                "name": "rr-b2dba5a02f61d8615cc23d8df120ac20",
+--                "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/requestRoutingRules/rr-853f2cc01a700b4ca07424c3daf866cd",
+--                "name": "rr-853f2cc01a700b4ca07424c3daf866cd",
 --                "properties": {
 --                    "backendAddressPool": {
 --                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendAddressPools/pool-test-ingress-controller-hello-world-80-bp-80"
@@ -927,7 +927,7 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 --                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/backendHttpSettingsCollection/bp-test-ingress-controller-hello-world-80-80---name--"
 --                    },
 --                    "httpListener": {
---                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-b2dba5a02f61d8615cc23d8df120ac20"
+--                        "id": "/subscriptions/--subscription--/resourceGroups/--resource-group--/providers/Microsoft.Network/applicationGateways/--app-gw-name--/httpListeners/fl-853f2cc01a700b4ca07424c3daf866cd"
 --                    },
 --                    "priority": 19000,
 --                    "ruleType": "Basic"

--- a/pkg/appgw/frontend_ipconfigurations.go
+++ b/pkg/appgw/frontend_ipconfigurations.go
@@ -4,13 +4,28 @@ import (
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-03-01/network"
 )
 
+type FrontendType string
+
+const (
+	// FrontendTypePublic is a public IP address
+	FrontendTypePublic FrontendType = "Public"
+
+	// FrontendTypePrivate is a private IP address
+	FrontendTypePrivate FrontendType = "Private"
+)
+
 // LookupIPConfigurationByType gets the public or private address depending upon privateIP parameter.
-func LookupIPConfigurationByType(frontendIPConfigurations *[]n.ApplicationGatewayFrontendIPConfiguration, privateIP bool) *n.ApplicationGatewayFrontendIPConfiguration {
+func LookupIPConfigurationByType(frontendIPConfigurations *[]n.ApplicationGatewayFrontendIPConfiguration, frontendType FrontendType) *n.ApplicationGatewayFrontendIPConfiguration {
 	for _, ip := range *frontendIPConfigurations {
-		if ip.ApplicationGatewayFrontendIPConfigurationPropertiesFormat != nil &&
-			((privateIP && ip.PrivateIPAddress != nil) ||
-				(!privateIP && ip.PublicIPAddress != nil)) {
-			return &ip
+		switch frontendType {
+		case FrontendTypePublic:
+			if ip.PublicIPAddress != nil {
+				return &ip
+			}
+		case FrontendTypePrivate:
+			if ip.PrivateIPAddress != nil {
+				return &ip
+			}
 		}
 	}
 
@@ -27,10 +42,10 @@ func LookupIPConfigurationByID(frontendIPConfigurations *[]n.ApplicationGatewayF
 	return nil
 }
 
-// IsPrivateIPConfiguration returns true if frontendIPConfiguration uses private IP
-func IsPrivateIPConfiguration(frontendIPConfiguration *n.ApplicationGatewayFrontendIPConfiguration) bool {
-	if frontendIPConfiguration.ApplicationGatewayFrontendIPConfigurationPropertiesFormat != nil && frontendIPConfiguration.PrivateIPAddress != nil {
-		return true
+// DetermineFrontendType determines whether frontend is public or private.
+func DetermineFrontendType(frontendIPConfiguration *n.ApplicationGatewayFrontendIPConfiguration) FrontendType {
+	if frontendIPConfiguration.PrivateIPAddress != nil {
+		return FrontendTypePrivate
 	}
-	return false
+	return FrontendTypePublic
 }

--- a/pkg/appgw/frontend_listeners_istio.go
+++ b/pkg/appgw/frontend_listeners_istio.go
@@ -22,12 +22,12 @@ func (c *appGwConfigBuilder) getIstioListenersPorts(cbCtx *ConfigBuilderContext)
 				klog.Errorf("Failed creating listener %+v: %s", listenerID, err)
 				continue
 			}
-			if listenerName, exists := publIPPorts[*port.Name]; exists && listenerID.UsePrivateIP {
+			if listenerName, exists := publIPPorts[*port.Name]; exists && listenerID.FrontendType == FrontendTypePrivate {
 				klog.Errorf("Can't assign port %s to Private IP Listener %s; already assigned to Public IP Listener %s", *port.Name, *listener.Name, listenerName)
 				continue
 			}
 
-			if !listenerID.UsePrivateIP {
+			if listenerID.FrontendType == FrontendTypePublic {
 				publIPPorts[*port.Name] = *listener.Name
 			}
 

--- a/pkg/appgw/frontend_listeners_test.go
+++ b/pkg/appgw/frontend_listeners_test.go
@@ -49,15 +49,15 @@ var _ = Describe("MutateAppGateway ingress rules and parse frontend listener con
 	BeforeEach(func() {
 		envVariables = environment.GetFakeEnv()
 
-		listenerID80, listenerID80Name = newTestListenerID(Port(80), []string{tests.Host}, false)
+		listenerID80, listenerID80Name = newTestListenerID(Port(80), []string{tests.Host}, FrontendTypePublic)
 
-		listenerID80ExtendedHost, listenerID80ExtendedHostName = newTestListenerID(Port(80), []string{"test.com", "t*.com"}, false)
+		listenerID80ExtendedHost, listenerID80ExtendedHostName = newTestListenerID(Port(80), []string{"test.com", "t*.com"}, FrontendTypePublic)
 
-		listenerID80Priv, listenerID80PrivName = newTestListenerID(Port(80), []string{tests.Host}, true)
+		listenerID80Priv, listenerID80PrivName = newTestListenerID(Port(80), []string{tests.Host}, FrontendTypePrivate)
 
-		listenerID443, listenerID443Name = newTestListenerID(Port(443), []string{tests.Host}, false)
+		listenerID443, listenerID443Name = newTestListenerID(Port(443), []string{tests.Host}, FrontendTypePublic)
 
-		_, listenerID443PrivName = newTestListenerID(Port(443), []string{tests.Host}, true)
+		_, listenerID443PrivName = newTestListenerID(Port(443), []string{tests.Host}, FrontendTypePrivate)
 
 		listenerAzConfigNoSSL = listenerAzConfig{
 			Protocol: "Http",
@@ -252,7 +252,7 @@ var _ = Describe("MutateAppGateway ingress rules and parse frontend listener con
 			listenerConfigs := cb.getListenerConfigs(cbCtx)
 
 			{
-				listenerID, _ := newTestListenerID(Port(80), []string{tests.Host}, true)
+				listenerID, _ := newTestListenerID(Port(80), []string{tests.Host}, FrontendTypePrivate)
 				listenerAzConfig, exists := listenerConfigs[listenerID]
 				Expect(exists).To(BeTrue())
 				ports := make(map[Port]n.ApplicationGatewayFrontendPort)
@@ -263,7 +263,7 @@ var _ = Describe("MutateAppGateway ingress rules and parse frontend listener con
 			}
 
 			{
-				listenerID, _ := newTestListenerID(Port(443), []string{tests.Host}, true)
+				listenerID, _ := newTestListenerID(Port(443), []string{tests.Host}, FrontendTypePrivate)
 				listenerAzConfig, exists := listenerConfigs[listenerID]
 				Expect(exists).To(BeTrue())
 				ports := make(map[Port]n.ApplicationGatewayFrontendPort)
@@ -326,6 +326,34 @@ var _ = Describe("MutateAppGateway ingress rules and parse frontend listener con
 
 			Expect(*ports).To(ContainElement(expectedPort80))
 			Expect(*ports).To(ContainElement(expectedPort443))
+		})
+	})
+
+	When("no ingresses are present and AppGW has a private frontend only", func() {
+		It("should create a default listener with private IP as frontend", func() {
+			certs := newCertsFixture()
+			cb := newConfigBuilderFixture(&certs)
+			cbCtx := &ConfigBuilderContext{
+				IngressList:           []*networking.Ingress{},
+				EnvVariables:          envVariables,
+				DefaultAddressPoolID:  to.StringPtr("xx"),
+				DefaultHTTPSettingsID: to.StringPtr("yy"),
+			}
+
+			// Setup Application Gateway with only private frontend
+			privateOnlyFrontend := []n.ApplicationGatewayFrontendIPConfiguration{
+				NewPrivateIPFrontendIPConfiguration(),
+			}
+			cb.appGw.FrontendIPConfigurations = &privateOnlyFrontend
+
+			listeners, ports := cb.getListeners(cbCtx)
+			Expect(len(*listeners)).To(Equal(1))
+			Expect(len(*ports)).To(Equal(1))
+
+			listener := (*listeners)[0]
+			port := (*ports)[0]
+			Expect(*listener.FrontendIPConfiguration.ID).To(Equal(*privateOnlyFrontend[0].ID))
+			Expect(*port.Port).To(Equal(int32(80)))
 		})
 	})
 

--- a/pkg/appgw/ingress_rules_test.go
+++ b/pkg/appgw/ingress_rules_test.go
@@ -16,7 +16,7 @@ import (
 var _ = Describe("MutateAppGateway ingress rules, listeners, and ports", func() {
 	port443 := Port(443)
 
-	expectedListener80, _ := newTestListenerID(Port(80), []string{tests.Host}, false)
+	expectedListener80, _ := newTestListenerID(Port(80), []string{tests.Host}, FrontendTypePublic)
 
 	expectedListenerAzConfigNoSSL := listenerAzConfig{
 		Protocol: "Http",
@@ -36,7 +36,7 @@ var _ = Describe("MutateAppGateway ingress rules, listeners, and ports", func() 
 		SslRedirectConfigurationName: "",
 	}
 
-	expectedListener443, expectedListener443Name := newTestListenerID(Port(443), []string{tests.Host}, false)
+	expectedListener443, expectedListener443Name := newTestListenerID(Port(443), []string{tests.Host}, FrontendTypePublic)
 
 	expectedListenerAzConfigSSL := listenerAzConfig{
 		Protocol: "Https",

--- a/pkg/appgw/internaltypes_test.go
+++ b/pkg/appgw/internaltypes_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Test internal types", func() {
 			var hostnameValues = [5]string{"www.test1.com", "www.test2.com", "www.test3.com", "www.test4.com", "www.test5.com"}
 			listenerID := listenerIdentifier{
 				FrontendPort: Port(80),
-				UsePrivateIP: false,
+				FrontendType: FrontendTypePublic,
 				HostNames:    hostnameValues,
 			}
 			actualHostName := listenerID.getHostNames()
@@ -258,7 +258,7 @@ var _ = Describe("Test internal types", func() {
 		It("should return nil if the 'HostNames' field is not set", func() {
 			listenerID := listenerIdentifier{
 				FrontendPort: Port(80),
-				UsePrivateIP: false,
+				FrontendType: FrontendTypePublic,
 			}
 			actualHostName := listenerID.getHostNames()
 			Expect(actualHostName).To(BeNil())
@@ -269,7 +269,7 @@ var _ = Describe("Test internal types", func() {
 		It("should correctly update the listenerIdentifier", func() {
 			listenerID := listenerIdentifier{
 				FrontendPort: Port(80),
-				UsePrivateIP: false,
+				FrontendType: FrontendTypePublic,
 			}
 			hostNames := []string{"www.test.com", "www.t*.com"}
 			listenerID.setHostNames(hostNames)
@@ -284,7 +284,7 @@ var _ = Describe("Test internal types", func() {
 			var hostnameValues = [5]string{"www.test*.com", "www.test?.com", "www.test*?.com", "www.test4.com", "www.test5.com"}
 			listenerID := listenerIdentifier{
 				FrontendPort: Port(80),
-				UsePrivateIP: false,
+				FrontendType: FrontendTypePublic,
 				HostNames:    hostnameValues,
 			}
 			hostName := listenerID.getHostNameForProbes()
@@ -296,7 +296,7 @@ var _ = Describe("Test internal types", func() {
 			var hostnameValues = [5]string{"www.test*.com", "www.test?.com", "www.test*?.com"}
 			listenerID := listenerIdentifier{
 				FrontendPort: Port(80),
-				UsePrivateIP: false,
+				FrontendType: FrontendTypePublic,
 				HostNames:    hostnameValues,
 			}
 			hostName := listenerID.getHostNameForProbes()
@@ -306,7 +306,7 @@ var _ = Describe("Test internal types", func() {
 		It("should return nil if no hostname provided", func() {
 			listenerID := listenerIdentifier{
 				FrontendPort: Port(80),
-				UsePrivateIP: false,
+				FrontendType: FrontendTypePublic,
 			}
 			hostName := listenerID.getHostNameForProbes()
 			Expect(hostName).To(BeNil())

--- a/pkg/appgw/redirects_test.go
+++ b/pkg/appgw/redirects_test.go
@@ -20,9 +20,9 @@ import (
 
 var _ = Describe("Test SSL Redirect Annotations", func() {
 
-	listenerID1, _ := newTestListenerID(Port(80), []string{tests.Host}, false)
+	listenerID1, _ := newTestListenerID(Port(80), []string{tests.Host}, FrontendTypePublic)
 
-	listenerID2, listenerID2Name := newTestListenerID(Port(443), []string{tests.Host}, false)
+	listenerID2, listenerID2Name := newTestListenerID(Port(443), []string{tests.Host}, FrontendTypePublic)
 
 	expectedListenerConfigs := map[listenerIdentifier]listenerAzConfig{
 		listenerID1: {

--- a/pkg/appgw/requestroutingrules_test.go
+++ b/pkg/appgw/requestroutingrules_test.go
@@ -243,7 +243,7 @@ var _ = Describe("Test routing rules generations", func() {
 			Expect(pathMap[listenerID].DefaultBackendHTTPSettings).To(BeNil())
 		})
 
-		expectedListenerID, _ := newTestListenerID(Port(443), []string{rule.Host}, false)
+		expectedListenerID, _ := newTestListenerID(Port(443), []string{rule.Host}, FrontendTypePublic)
 		expectedRedirectID := configBuilder.appGwIdentifier.redirectConfigurationID(
 			generateSSLRedirectConfigurationName(expectedListenerID))
 		actualID := *(pathMap[listenerID].DefaultRedirectConfiguration.ID)
@@ -448,7 +448,7 @@ var _ = Describe("Test routing rules generations", func() {
 			Expect(pathMap[listenerID].PathRules).To(BeNil())
 		})
 
-		expectedListenerID, _ := newTestListenerID(Port(443), []string{rule.Host}, false)
+		expectedListenerID, _ := newTestListenerID(Port(443), []string{rule.Host}, FrontendTypePublic)
 		expectedRedirectID := configBuilder.appGwIdentifier.redirectConfigurationID(
 			generateSSLRedirectConfigurationName(expectedListenerID))
 		actualID := *(pathMap[listenerID].DefaultRedirectConfiguration.ID)
@@ -479,8 +479,8 @@ var _ = Describe("Test routing rules generations", func() {
 		_ = configBuilder.Listeners(cbCtx)
 		_ = configBuilder.RequestRoutingRules(cbCtx)
 
-		expectedListenerID80, expectedListenerID80Name := newTestListenerID(Port(80), []string{"foo.baz"}, false)
-		expectedListenerID443, expectedListenerID443Name := newTestListenerID(Port(443), []string{"foo.baz"}, false)
+		expectedListenerID80, expectedListenerID80Name := newTestListenerID(Port(80), []string{"foo.baz"}, FrontendTypePublic)
+		expectedListenerID443, expectedListenerID443Name := newTestListenerID(Port(443), []string{"foo.baz"}, FrontendTypePublic)
 		It("should have correct RequestRoutingRules", func() {
 			Expect(len(*configBuilder.appGw.RequestRoutingRules)).To(Equal(2))
 
@@ -500,7 +500,7 @@ var _ = Describe("Test routing rules generations", func() {
 							"/providers/Microsoft.Network/applicationGateways/--app-gw-name--" +
 							"/redirectConfigurations/sslr-" + expectedListenerID443Name)},
 					ProvisioningState: "",
-					Priority:          to.Int32Ptr(19000),
+					Priority:          to.Int32Ptr(19005),
 				},
 				Name: to.StringPtr("rr-" + utils.GetHashCode(expectedListenerID80)),
 				Etag: to.StringPtr("*"),
@@ -529,7 +529,7 @@ var _ = Describe("Test routing rules generations", func() {
 					RewriteRuleSet:        nil,
 					RedirectConfiguration: nil,
 					ProvisioningState:     "",
-					Priority:              to.Int32Ptr(19005),
+					Priority:              to.Int32Ptr(19000),
 				},
 				Name: to.StringPtr("rr-" + utils.GetHashCode(expectedListenerID443)),
 				Etag: to.StringPtr("*"),

--- a/pkg/appgw/test_fixtures.go
+++ b/pkg/appgw/test_fixtures.go
@@ -22,30 +22,8 @@ import (
 // NewAppGwyConfigFixture creates a new struct for testing.
 func NewAppGwyConfigFixture() *n.ApplicationGatewayPropertiesFormat {
 	feIPConfigs := []n.ApplicationGatewayFrontendIPConfiguration{
-		{
-			// Public IP
-			Name: to.StringPtr("xx3"),
-			Etag: to.StringPtr("xx2"),
-			Type: to.StringPtr("xx1"),
-			ID:   to.StringPtr(tests.PublicIPID),
-			ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &n.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
-				PrivateIPAddress: nil,
-				PublicIPAddress: &n.SubResource{
-					ID: to.StringPtr("xyz"),
-				},
-			},
-		},
-		{
-			// Private IP
-			Name: to.StringPtr("yy3"),
-			Etag: to.StringPtr("yy2"),
-			Type: to.StringPtr("yy1"),
-			ID:   to.StringPtr(tests.PrivateIPID),
-			ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &n.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
-				PrivateIPAddress: to.StringPtr("abc"),
-				PublicIPAddress:  nil,
-			},
-		},
+		NewPublicIPFrontendIPConfiguration(),
+		NewPrivateIPFrontendIPConfiguration(),
 	}
 	return &n.ApplicationGatewayPropertiesFormat{
 		FrontendIPConfigurations: &feIPConfigs,
@@ -53,6 +31,36 @@ func NewAppGwyConfigFixture() *n.ApplicationGatewayPropertiesFormat {
 			Name:     n.ApplicationGatewaySkuNameStandardV2,
 			Tier:     n.ApplicationGatewayTierStandardV2,
 			Capacity: to.Int32Ptr(3),
+		},
+	}
+}
+
+func NewPublicIPFrontendIPConfiguration() n.ApplicationGatewayFrontendIPConfiguration {
+	return n.ApplicationGatewayFrontendIPConfiguration{
+		// Public IP
+		Name: to.StringPtr("xx3"),
+		Etag: to.StringPtr("xx2"),
+		Type: to.StringPtr("xx1"),
+		ID:   to.StringPtr(tests.PublicIPID),
+		ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &n.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+			PrivateIPAddress: nil,
+			PublicIPAddress: &n.SubResource{
+				ID: to.StringPtr("xyz"),
+			},
+		},
+	}
+}
+
+func NewPrivateIPFrontendIPConfiguration() n.ApplicationGatewayFrontendIPConfiguration {
+	return n.ApplicationGatewayFrontendIPConfiguration{
+		// Private IP
+		Name: to.StringPtr("yy3"),
+		Etag: to.StringPtr("yy2"),
+		Type: to.StringPtr("yy1"),
+		ID:   to.StringPtr(tests.PrivateIPID),
+		ApplicationGatewayFrontendIPConfigurationPropertiesFormat: &n.ApplicationGatewayFrontendIPConfigurationPropertiesFormat{
+			PrivateIPAddress: to.StringPtr("abc"),
+			PublicIPAddress:  nil,
 		},
 	}
 }
@@ -126,42 +134,10 @@ func newCertsFixture() map[string]interface{} {
 	return toAdd
 }
 
-func newURLPathMap() n.ApplicationGatewayURLPathMap {
-	rule := n.ApplicationGatewayPathRule{
-		ID:   to.StringPtr("-the-id-"),
-		Type: to.StringPtr("-the-type-"),
-		Etag: to.StringPtr("-the-etag-"),
-		Name: to.StringPtr("/some/path"),
-		ApplicationGatewayPathRulePropertiesFormat: &n.ApplicationGatewayPathRulePropertiesFormat{
-			// A Path Rule must have either RedirectConfiguration xor (BackendAddressPool + BackendHTTPSettings)
-			RedirectConfiguration: nil,
-
-			BackendAddressPool:  resourceRef("--BackendAddressPool--"),
-			BackendHTTPSettings: resourceRef("--BackendHTTPSettings--"),
-
-			RewriteRuleSet:    resourceRef("--RewriteRuleSet--"),
-			ProvisioningState: "--provisionStateExpected--",
-		},
-	}
-
-	return n.ApplicationGatewayURLPathMap{
-		Name: to.StringPtr("-path-map-name-"),
-		ApplicationGatewayURLPathMapPropertiesFormat: &n.ApplicationGatewayURLPathMapPropertiesFormat{
-			// URL Path Map must have either DefaultRedirectConfiguration xor (DefaultBackendAddressPool + DefaultBackendHTTPSettings)
-			DefaultRedirectConfiguration: nil,
-
-			DefaultBackendAddressPool:  resourceRef("--DefaultBackendAddressPool--"),
-			DefaultBackendHTTPSettings: resourceRef("--DefaultBackendHTTPSettings--"),
-
-			PathRules: &[]n.ApplicationGatewayPathRule{rule},
-		},
-	}
-}
-
-func newTestListenerID(port Port, hostNames []string, usePrivateIP bool) (listenerIdentifier, string) {
+func newTestListenerID(port Port, hostNames []string, frontendType FrontendType) (listenerIdentifier, string) {
 	listener := listenerIdentifier{
 		FrontendPort: port,
-		UsePrivateIP: usePrivateIP,
+		FrontendType: frontendType,
 	}
 	listener.setHostNames(hostNames)
 	return listener, generateListenerName(listener)

--- a/pkg/controller/mutate_aks.go
+++ b/pkg/controller/mutate_aks.go
@@ -55,8 +55,12 @@ func (c AppGwIngressController) updateIngressStatus(appGw *n.ApplicationGateway,
 	// determine what ipAddress to attach
 	usePrivateIP, _ := annotations.UsePrivateIP(ingress)
 	usePrivateIP = usePrivateIP || cbCtx.EnvVariables.UsePrivateIP
+	frontendType := appgw.FrontendTypePublic
+	if usePrivateIP {
+		frontendType = appgw.FrontendTypePrivate
+	}
 
-	ipConf := appgw.LookupIPConfigurationByType(appGw.FrontendIPConfigurations, usePrivateIP)
+	ipConf := appgw.LookupIPConfigurationByType(appGw.FrontendIPConfigurations, frontendType)
 	if ipConf == nil {
 		klog.V(9).Info("[mutate_aks] No IP config for App Gwy: ", appGw.Name)
 		return

--- a/pkg/controller/prune.go
+++ b/pkg/controller/prune.go
@@ -62,7 +62,7 @@ func pruneProhibitedIngress(c *AppGwIngressController, appGw *n.ApplicationGatew
 // pruneNoPrivateIP filters ingresses which use private IP annotation when AppGw doesn't have a private IP
 func pruneNoPrivateIP(c *AppGwIngressController, appGw *n.ApplicationGateway, cbCtx *appgw.ConfigBuilderContext, ingressList []*networking.Ingress) []*networking.Ingress {
 	var prunedIngresses []*networking.Ingress
-	appGwHasPrivateIP := appgw.LookupIPConfigurationByType(appGw.FrontendIPConfigurations, true) != nil
+	appGwHasPrivateIP := appgw.LookupIPConfigurationByType(appGw.FrontendIPConfigurations, appgw.FrontendTypePrivate) != nil
 	for _, ingress := range ingressList {
 		usePrivateIP, err := annotations.UsePrivateIP(ingress)
 		if err != nil && controllererrors.IsErrorCode(err, controllererrors.ErrorInvalidContent) {
@@ -90,7 +90,7 @@ func pruneNoPrivateIP(c *AppGwIngressController, appGw *n.ApplicationGateway, cb
 // pruneNoPublicIP filters ingresses which need public IP but AppGw doesn't have a public IP
 func pruneNoPublicIP(c *AppGwIngressController, appGw *n.ApplicationGateway, cbCtx *appgw.ConfigBuilderContext, ingressList []*networking.Ingress) []*networking.Ingress {
 	var prunedIngresses []*networking.Ingress
-	appGwHasPublicIP := appgw.LookupIPConfigurationByType(appGw.FrontendIPConfigurations, false) != nil
+	appGwHasPublicIP := appgw.LookupIPConfigurationByType(appGw.FrontendIPConfigurations, appgw.FrontendTypePublic) != nil
 	for _, ingress := range ingressList {
 		usePrivateIP, err := annotations.UsePrivateIP(ingress)
 		if err != nil && controllererrors.IsErrorCode(err, controllererrors.ErrorInvalidContent) {


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

This PR fixes a bug which was introduced as part of changes to support Private Only Application Gateway.

When a cluster doesn't have any/valid ingresses, then AGIC adds a default listener to the AppGW as AppGW requires a listener.
To select what frontend IP configuration to use, AGIC checks if
* if UsePrivateIP environment variable is set, then use private IP
* if public IP is present, then use public IP as that was the default behavior before
* otherwise use private IP
In a recent change to support private only appgw, a bug got introduced in which AGIC was incorrectly looking for presence of public IP frontend by passing wrong arguments.

In following image, `true` corresponds to finding a private frontend.
![image](https://user-images.githubusercontent.com/5294363/235251241-52bc7ba0-0fe9-4037-bd70-f86864dca706.png)

This was causing a `panic` as denoted in the attached issue. Because AGIC was looking for private IP instead public IP, it was returning `nil` and dereferencing that caused a `panic`.

 To fix this, instead of passing a `Boolean` to look for public or private, we use `FrontendType` with value `Public` or `Private`.
This will allow to reduce ambiguity and bugs in the future.

Multiple test files got updated due to this as AppGW resources are named using the `listener` struct hash. As this struct is now taking an enum instead of bool, it has changed hashes across multiple test files. Some places, it has the changes the order of rules in the array.
<!-- Please add a brief description of the changes made in this PR -->

## Fixes
#1532 
<!-- Please mention #issues that are fixed in this PR -->
