### PR TITLE
Add missing quote for AzureIngressProhibitedTarget

### DIFF
--- a/helm/ingress-azure/templates/crds.yaml
+++ b/helm/ingress-azure/templates/crds.yaml
@@ -24,7 +24,7 @@ metadata:
   {{- end }}
 spec:
   {{- if .hostname }}
-  hostname: {{ .hostname }}
+  hostname: {{ .hostname | quote }}
   {{- end }}
   {{- if .paths }}
   paths:


### PR DESCRIPTION

<!-- DO NOT DELETE THIS TEMPLATE -->

- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

Add a missing quote for hostname when generating AzureIngressProhibitedTarget

## Fixes

Fixes #1548
