### PR TITLE
Using the ingressClassName instead of metadata annotation

### DIFF
--- a/docs/examples/aspnetapp.yaml
+++ b/docs/examples/aspnetapp.yaml
@@ -32,9 +32,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: aspnetapp
-  annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
 spec:
+  ingressClassName: azure-application-gateway
   rules:
   - http:
       paths:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
The `aspnetapp.yaml` which is referenced in MS Learn has been modified to use the AGIC add-on through the `ingressClassName`.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
