### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/functional_tests/helpers.go
+++ b/functional_tests/helpers.go
@@ -8,7 +8,6 @@ package functests
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -49,10 +48,10 @@ func check(cbCtx *appgw.ConfigBuilderContext, expectedFilename string, stopChan 
 
 	// Repair tests
 	if os.Getenv("RENDER_SNAPSHOTS") != "" {
-		ioutil.WriteFile(expectedFilename, []byte(actualJSONTxt), 0644)
+		os.WriteFile(expectedFilename, []byte(actualJSONTxt), 0644)
 	}
 
-	expectedBytes, err := ioutil.ReadFile(expectedFilename)
+	expectedBytes, err := os.ReadFile(expectedFilename)
 	expectedJSON := strings.Trim(string(expectedBytes), "\n")
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 

--- a/helm/ingress-azure/tests/snapshots.go
+++ b/helm/ingress-azure/tests/snapshots.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -73,7 +72,7 @@ func RenderChart(chart, values, dir string) error {
 
 // CaptureSnapshot renders a new snapshot from a given Helm chart and values file.
 func CaptureSnapshot(chart, values string) (*Snapshot, error) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return nil, fmt.Errorf("creating tempdir: %v", err)
 	}
@@ -163,7 +162,7 @@ func StripNonDeterministic(path string) error {
 				lines = append(lines, text)
 			}
 
-			return ioutil.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644)
+			return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644)
 		})
 }
 

--- a/pkg/appgw/appgw_test.go
+++ b/pkg/appgw/appgw_test.go
@@ -8,7 +8,7 @@ package appgw
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-03-01/network"
@@ -606,11 +606,11 @@ var _ = Describe("Tests `appgw.ConfigBuilder`", func() {
 				Data: make(map[string][]byte),
 			}
 
-			key, err := ioutil.ReadFile("../../tests/data/k8s.cert.key")
+			key, err := os.ReadFile("../../tests/data/k8s.cert.key")
 			Ω(err).ToNot(HaveOccurred(), "Unable to read the cert key: %v", err)
 			ingressSecret.Data["tls.key"] = key
 
-			cert, err := ioutil.ReadFile("../../tests/data/k8s.x509.cert")
+			cert, err := os.ReadFile("../../tests/data/k8s.x509.cert")
 			Ω(err).ToNot(HaveOccurred(), "Unable to read the cert key: %v", err)
 			ingressSecret.Data["tls.crt"] = cert
 

--- a/pkg/azure/client_test.go
+++ b/pkg/azure/client_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -29,7 +29,7 @@ func (fs *FakeSender) Do(request *http.Request) (response *http.Response, err er
 		if fs.body != nil {
 			b, err := json.Marshal(fs.body)
 			if err == nil {
-				response.Body = ioutil.NopCloser(bytes.NewReader(b))
+				response.Body = io.NopCloser(bytes.NewReader(b))
 			}
 		}
 	}

--- a/pkg/azure/cloudproviderconfig.go
+++ b/pkg/azure/cloudproviderconfig.go
@@ -8,7 +8,7 @@ package azure
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // CloudProviderConfig represent the CloudProvider Context file such as Azure
@@ -29,7 +29,7 @@ type CloudProviderConfig struct {
 
 // NewCloudProviderConfig returns an CloudProviderConfig struct from file path
 func NewCloudProviderConfig(path string) (*CloudProviderConfig, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("Reading Az Context file %q failed: %v", path, err)
 	}

--- a/pkg/k8scontext/secretstore.go
+++ b/pkg/k8scontext/secretstore.go
@@ -7,7 +7,6 @@ package k8scontext
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"sync"
@@ -81,7 +80,7 @@ func (s *SecretsStore) ConvertSecret(secretKey string, secret *v1.Secret) error 
 		)
 	}
 
-	tempfileCert, err := ioutil.TempFile("", "appgw-ingress-cert")
+	tempfileCert, err := os.CreateTemp("", "appgw-ingress-cert")
 	if err != nil {
 		return controllererrors.NewErrorWithInnerErrorf(
 			controllererrors.ErrorCreatingFile,
@@ -91,7 +90,7 @@ func (s *SecretsStore) ConvertSecret(secretKey string, secret *v1.Secret) error 
 	}
 	defer os.Remove(tempfileCert.Name())
 
-	tempfileKey, err := ioutil.TempFile("", "appgw-ingress-key")
+	tempfileKey, err := os.CreateTemp("", "appgw-ingress-key")
 	if err != nil {
 		return controllererrors.NewErrorWithInnerErrorf(
 			controllererrors.ErrorCreatingFile,

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -7,7 +7,7 @@ package tests
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-03-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -150,7 +150,7 @@ func GetIngressNamespaced() (*[]networking.Ingress, error) {
 
 // GetIngressV1FromFile reads an ingress V1 from file
 func GetIngressV1FromFile(fileName string) (*networking.Ingress, error) {
-	ingr, err := ioutil.ReadFile(fileName)
+	ingr, err := os.ReadFile(fileName)
 	if err != nil {
 		fmt.Print(err)
 	}
@@ -164,7 +164,7 @@ func GetIngressV1FromFile(fileName string) (*networking.Ingress, error) {
 
 // GetIngressV1Beta1FromFile reads an ingress V1Beta1 from file
 func GetIngressV1Beta1FromFile(fileName string) (*extensions.Ingress, error) {
-	ingr, err := ioutil.ReadFile(fileName)
+	ingr, err := os.ReadFile(fileName)
 	if err != nil {
 		fmt.Print(err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,7 +9,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"math/rand"
 	"strings"
 	"time"
@@ -43,7 +43,7 @@ func GetLastChunkOfSlashed(s string) string {
 
 // SaveToFile saves the content into a file named "fileName" - a tool primarily used for debugging purposes.
 func SaveToFile(fileName string, content []byte) (string, error) {
-	tempFile, err := ioutil.TempFile("", fileName)
+	tempFile, err := os.CreateTemp("", fileName)
 	if err != nil {
 		klog.Error(err)
 		return tempFile.Name(), err


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [ ] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
