### PR TITLE
chore: use strings.EqualFold instead

### DIFF
--- a/pkg/brownfield/targets.go
+++ b/pkg/brownfield/targets.go
@@ -34,7 +34,7 @@ func (t Target) IsBlacklisted(blacklist TargetBlacklist) bool {
 		// An empty blacklist hostname indicates that any hostname would be blacklisted.
 		// If host names match - this target is in the blacklist.
 		// AGIC is allowed to create and modify App Gwy config for blank host.
-		hostIsBlacklisted := blTarget.Hostname == "" || strings.ToLower(t.Hostname) == strings.ToLower(blTarget.Hostname)
+		hostIsBlacklisted := blTarget.Hostname == "" || strings.EqualFold(t.Hostname, blTarget.Hostname)
 
 		pathIsBlacklisted := blTarget.Path == "" || blTarget.Path == "/*" || t.Path.lower() == blTarget.Path.lower() || blTarget.Path.contains(t.Path) // TODO(draychev): || t.Path.contains(blTarget.Path)
 

--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -136,7 +136,7 @@ func isSlice(v interface{}) bool {
 func deleteKey(m *map[string]interface{}, keyToDelete string) {
 	// Recursively search for the given keyToDelete
 	for k, v := range *m {
-		if strings.ToLower(k) == strings.ToLower(keyToDelete) {
+		if strings.EqualFold(k, keyToDelete) {
 			delete(*m, k)
 			continue
 		}


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [ ] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
use strings.EqualFold instead 
strings.EqualFold() Function in Golang reports whether s and t, interpreted as UTF-8 strings, are equal under Unicode case-folding, which is a more general form of case-insensitivity. 
<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
