### PR TITLE
Use cloud env variable to determine token scope

### DIFF
--- a/pkg/azure/defaultazurecredential/authorizer.go
+++ b/pkg/azure/defaultazurecredential/authorizer.go
@@ -44,7 +44,7 @@ func tokenScopeFromEnvironment() string {
 		env = azure.PublicCloud
 	}
 
-	return fmt.Sprintf("%s.default", env.ResourceManagerEndpoint)
+	return fmt.Sprintf("%s.default", env.TokenAudience)
 }
 
 type tokenCredentialWrapper struct {

--- a/pkg/azure/defaultazurecredential/authorizer_test.go
+++ b/pkg/azure/defaultazurecredential/authorizer_test.go
@@ -1,0 +1,22 @@
+package defaultazurecredential
+
+import (
+	"os"
+	"testing"
+)
+
+func TestTokenScopeFromEnvironment(t *testing.T) {
+	scope := map[string]string{
+		"AZUREPUBLICCLOUD":       "https://management.azure.com/.default",
+		"AZURECHINACLOUD":        "https://management.chinacloudapi.cn/.default",
+		"AZUREUSGOVERNMENTCLOUD": "https://management.usgovcloudapi.net/.default",
+	}
+
+	for env, expectedScope := range scope {
+		os.Setenv("AZURE_ENVIRONMENT", env)
+		scope := tokenScopeFromEnvironment()
+		if scope != expectedScope {
+			t.Errorf("Expected scope %s, got %s", expectedScope, scope)
+		}
+	}
+}


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->
This PR uses the `AZURE_ENVIRONMENT` to select the scope for fetching token.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
