### PR TITLE
Remove annotations and added ingressClassName spec

### DIFF
--- a/docs/examples/aspnetapp.yaml
+++ b/docs/examples/aspnetapp.yaml
@@ -32,9 +32,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: aspnetapp
-  annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
+  # annotations:
+  #   kubernetes.io/ingress.class: azure/application-gateway
 spec:
+  ingressClassName: azure-application-gateway
   rules:
   - http:
       paths:


### PR DESCRIPTION

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [X ] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

Tested with K8S version 1.26.6 on AKS, without ingressClassName spec pointing to IngressClass the AGIC does not seem to configure anything on ApplicationGateway. 

The default IngressClass is **azure-application-gateway** from **kubectl get IngressClass** command

The annotations are removed otherwise ingressClassName spec cannot be used.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
