### PR TITLE
docs: fix `--query` parameter in install guide

### DIFF
--- a/docs/setup/install-new.md
+++ b/docs/setup/install-new.md
@@ -46,7 +46,7 @@ Follow the steps below to create an Azure Active Directory (AAD) [service princi
 1. Execute the commands below on the  [Cloud Shell](https://shell.azure.com/) too. This will create the `kubernetesVersion` variable and save the latest version of kubernetes that is available in the location specified. 
     ```bash
     location="westus2"
-    kubernetesVersion=$(az aks get-versions --location $location --query "orchestrators[-1].orchestratorVersion" -o tsv)
+    kubernetesVersion=$(az aks get-versions --location $location --query "values[?isDefault==\`true\`].version | [0]" -o tsv)
     ```
 
 1. Paste the entire command below (it is a single command on multiple lines) in [Cloud Shell](https://shell.azure.com/) to create the `parameters.json` file. It will be used in the ARM template deployment.


### PR DESCRIPTION


<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [ ] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

closes https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1591

The json output format might have changed since the creation of this guide. Here is an attempt to fix it by adjusting the `--query` parameter in order to follow up on the change

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

before:
```
"orchestrators[-1].orchestratorVersion"
```
now: 
```
"values[?isDefault==\`true\`].version | [0]"
```
<!-- Please mention #issues that are fixed in this PR -->
