### PR TITLE
Remove note from WAF policy annotation documentation

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -559,8 +559,6 @@ The URI would have the following format:
 ```bash
 /subscriptions/<YOUR-SUBSCRIPTION>/resourceGroups/<YOUR-RESOURCE-GROUP>/providers/Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/<YOUR-POLICY-NAME>
 ```
-> **Note**
-1) Waf policy will only be applied to a listener if ingress rule path is not set or set to "/" or "/*"
 
 ### Usage
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [ ] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

Remove an invalid note from the documentation

## Fixes
The documentation has an invalid note. The note ```WAF policy will only be applied to a listener if ingress rule path is not set or set to "/" or "/*"``` is incorrect. The WAF policy is also applied if other paths are set.
