### PR TITLE
fix: adjust logging verbosity and event logs

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -206,7 +206,7 @@ func main() {
 
 		err = azClient.ApplyRouteTable(subnetID, routeTableID)
 		if err != nil {
-			klog.V(5).Infof("Unable to associate Application Gateway subnet '%s' with route table '%s' due to error (this is relevant for AKS clusters using 'Kubenet' network plugin): [%+v]",
+			klog.V(3).Infof("Unable to associate Application Gateway subnet '%s' with route table '%s' due to error (this is relevant for AKS clusters using 'Kubenet' network plugin): [%+v]",
 				subnetID,
 				routeTableID,
 				err)

--- a/cmd/appgw-ingress/utils.go
+++ b/cmd/appgw-ingress/utils.go
@@ -87,7 +87,6 @@ func getKubeClientConfig() *rest.Config {
 
 func getEventRecorder(kubeClient kubernetes.Interface, ingressClassControllerName string) record.EventRecorder {
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(klog.V(3).Infof)
 	sink := &typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")}
 	eventBroadcaster.StartRecordingToSink(sink)
 	hostname, err := os.Hostname()

--- a/cmd/appgw-ingress/utils.go
+++ b/cmd/appgw-ingress/utils.go
@@ -87,7 +87,7 @@ func getKubeClientConfig() *rest.Config {
 
 func getEventRecorder(kubeClient kubernetes.Interface, ingressClassControllerName string) record.EventRecorder {
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(klog.V(5).Infof)
+	eventBroadcaster.StartLogging(klog.V(3).Infof)
 	sink := &typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")}
 	eventBroadcaster.StartRecordingToSink(sink)
 	hostname, err := os.Hostname()

--- a/pkg/appgw/backendaddresspools.go
+++ b/pkg/appgw/backendaddresspools.go
@@ -33,7 +33,7 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 	}
 
 	defaultPool := defaultBackendAddressPool(c.appGwIdentifier)
-	klog.V(5).Infof("Created default backend pool %s", *defaultPool.Name)
+	klog.V(3).Infof("Created default backend pool %s", *defaultPool.Name)
 	managedPoolsByName := map[string]*n.ApplicationGatewayBackendAddressPool{
 		*defaultPool.Name: &defaultPool,
 	}
@@ -44,7 +44,7 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 	for backendID, serviceBackendPair := range serviceBackendPairMap {
 		if pool := c.getBackendAddressPool(backendID, serviceBackendPair, managedPoolsByName); pool != nil {
 			managedPoolsByName[*pool.Name] = pool
-			klog.V(5).Infof("Created backend pool %s for service %s", *pool.Name, backendID.serviceKey())
+			klog.V(3).Infof("Created backend pool %s for service %s", *pool.Name, backendID.serviceKey())
 		}
 	}
 
@@ -53,7 +53,7 @@ func (c appGwConfigBuilder) getPools(cbCtx *ConfigBuilderContext) []n.Applicatio
 		for destinationID, serviceBackendPair := range istioServiceBackendPairMap {
 			if pool := c.getIstioBackendAddressPool(destinationID, serviceBackendPair, managedPoolsByName); pool != nil {
 				managedPoolsByName[*pool.Name] = pool
-				klog.V(5).Infof("Created backend pool %s for service %s", *pool.Name, destinationID.serviceKey())
+				klog.V(3).Infof("Created backend pool %s for service %s", *pool.Name, destinationID.serviceKey())
 			}
 		}
 	}

--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -171,7 +171,7 @@ func (c *appGwConfigBuilder) resolveBackendPort(backendID backendIdentifier) (Po
 
 		// if target port is port name, then resolve the port number for the port name
 		// k8s matches service port name against endpoints port name retrieved by passing backendID service key to endpoint api.
-		klog.V(5).Infof("resolving port name '%s' for service '%s' and service port '%s' for Ingress '%s'", servicePort.Name, backendID.serviceKey(), serviceBackendPortToStr(backendID.Backend.Service.Port), backendID.Ingress.Name)
+		klog.V(3).Infof("resolving port name '%s' for service '%s' and service port '%s' for Ingress '%s'", servicePort.Name, backendID.serviceKey(), serviceBackendPortToStr(backendID.Backend.Service.Port), backendID.Ingress.Name)
 		targetPortsResolved := c.resolvePortName(servicePort.Name, &backendID)
 		for targetPort := range targetPortsResolved {
 			pair := serviceBackendPortPair{
@@ -315,7 +315,7 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 			certs = append(certs, *resourceRef(trustCertID))
 		}
 		httpSettings.TrustedRootCertificates = &certs
-		klog.V(5).Infof("Found trusted root certificate(s): %s from ingress: %s/%s", certificateNames, backendID.Ingress.Namespace, backendID.Ingress.Name)
+		klog.V(3).Infof("Found trusted root certificate(s): %s from ingress: %s/%s", certificateNames, backendID.Ingress.Namespace, backendID.Ingress.Name)
 
 	} else if err != nil && !controllererrors.IsErrorCode(err, controllererrors.ErrorMissingAnnotation) {
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())

--- a/pkg/appgw/configbuilder.go
+++ b/pkg/appgw/configbuilder.go
@@ -233,9 +233,9 @@ func generateListenerID(ingress *networking.Ingress, rule *networking.IngressRul
 	if overridePort != nil {
 		if *overridePort > 0 && *overridePort < 65000 {
 			frontendPort = *overridePort
-			klog.V(5).Infof("Using custom port specified in the override annotation: %d", *overridePort)
+			klog.V(3).Infof("Using custom port specified in the override annotation: %d", *overridePort)
 		} else {
-			klog.V(5).Infof("Derived listener port from ingress: %d", frontendPort)
+			klog.V(3).Infof("Derived listener port from ingress: %d", frontendPort)
 		}
 
 	}
@@ -257,7 +257,7 @@ func generateListenerID(ingress *networking.Ingress, rule *networking.IngressRul
 
 	extendedHostNames, err := annotations.GetHostNameExtensions(ingress)
 	if err != nil && !controllererrors.IsErrorCode(err, controllererrors.ErrorMissingAnnotation) {
-		klog.V(5).Infof("Error while parsing host name extensions: %s", err)
+		klog.V(3).Infof("Error while parsing host name extensions: %s", err)
 	} else {
 		if extendedHostNames != nil {
 			hostNames = append(hostNames, extendedHostNames...)
@@ -279,7 +279,7 @@ func (c *appGwConfigBuilder) addTags() {
 	if aksResourceID, err := azure.ConvertToClusterResourceGroup(c.k8sContext.GetInfrastructureResourceGroupID()); err == nil {
 		c.appGw.Tags[tags.IngressForAKSClusterID] = to.StringPtr(aksResourceID)
 	} else {
-		klog.V(5).Infof("Error while parsing cluster resource ID for tagging: %s", err)
+		klog.V(3).Infof("Error while parsing cluster resource ID for tagging: %s", err)
 	}
 }
 

--- a/pkg/appgw/frontend_listeners.go
+++ b/pkg/appgw/frontend_listeners.go
@@ -107,13 +107,13 @@ func (c *appGwConfigBuilder) getListenerConfigs(cbCtx *ConfigBuilderContext) map
 
 	if cbCtx.EnvVariables.AttachWAFPolicyToListener {
 		// logging to see if customer configures env.AttachWAFPolicyToListener or not
-		klog.V(5).Info("env.AttachWAFPolicyToListener is enabled")
+		klog.V(3).Info("env.AttachWAFPolicyToListener is enabled")
 	}
 
 	// TODO(draychev): Emit an error event if 2 namespaces define different TLS for the same domain!
 	allListeners := make(map[listenerIdentifier]listenerAzConfig)
 	for _, ingress := range cbCtx.IngressList {
-		klog.V(5).Infof("Processing Rules for Ingress: %s/%s", ingress.Namespace, ingress.Name)
+		klog.V(3).Infof("Processing Rules for Ingress: %s/%s", ingress.Namespace, ingress.Name)
 		azListenerConfigs := c.getListenersFromIngress(ingress, cbCtx.EnvVariables)
 		for listenerID, azConfig := range azListenerConfigs {
 			allListeners[listenerID] = azConfig

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -52,8 +52,8 @@ func (c *appGwConfigBuilder) newProbesMap(cbCtx *ConfigBuilderContext) (map[stri
 
 	healthProbeCollection[*defaultHTTPProbe.Name] = defaultHTTPProbe
 	healthProbeCollection[*defaultHTTPSProbe.Name] = defaultHTTPSProbe
-	klog.V(5).Info("Created default HTTP probe ", *defaultHTTPProbe.Name)
-	klog.V(5).Info("Created default HTTPS probe ", *defaultHTTPProbe.Name)
+	klog.V(3).Info("Created default HTTP probe ", *defaultHTTPProbe.Name)
+	klog.V(3).Info("Created default HTTPS probe ", *defaultHTTPProbe.Name)
 
 	for backendID := range c.newBackendIdsFiltered(cbCtx) {
 		probe := c.generateHealthProbe(backendID)
@@ -67,7 +67,7 @@ func (c *appGwConfigBuilder) newProbesMap(cbCtx *ConfigBuilderContext) (map[stri
 				probesMap[backendID] = &defaultHTTPSProbe
 			}
 		}
-		klog.V(5).Infof("Created probe %s for ingress %s/%s at service %s", *probesMap[backendID].Name, backendID.Ingress.Namespace, backendID.Ingress.Name, backendID.serviceKey())
+		klog.V(3).Infof("Created probe %s for ingress %s/%s at service %s", *probesMap[backendID].Name, backendID.Ingress.Namespace, backendID.Ingress.Name, backendID.serviceKey())
 	}
 
 	c.mem.probesByName = &healthProbeCollection

--- a/pkg/appgw/ingress_rules.go
+++ b/pkg/appgw/ingress_rules.go
@@ -78,13 +78,13 @@ func (c *appGwConfigBuilder) processIngressRuleWithTLS(rule *networking.IngressR
 	appgwCertName, _ := annotations.GetAppGwSslCertificate(ingress)
 	if len(appgwCertName) > 0 {
 		// logging to see the namespace of the ingress annotated with appgw-ssl-certificate
-		klog.V(5).Infof("Found annotation appgw-ssl-certificate: %s in ingress %s/%s", appgwCertName, ingress.Namespace, ingress.Name)
+		klog.V(3).Infof("Found annotation appgw-ssl-certificate: %s in ingress %s/%s", appgwCertName, ingress.Namespace, ingress.Name)
 	}
 
 	appgwProfileName, _ := annotations.GetAppGwSslProfile(ingress)
 	if len(appgwProfileName) > 0 {
 		// logging to see the namespace of the ingress annotated with appgw-ssl-certificate
-		klog.V(5).Infof("Found annotation appgw-ssl-profile: %s in ingress %s/%s", appgwProfileName, ingress.Namespace, ingress.Name)
+		klog.V(3).Infof("Found annotation appgw-ssl-profile: %s in ingress %s/%s", appgwProfileName, ingress.Namespace, ingress.Name)
 	}
 
 	cert, secID := c.getCertificate(ingress, rule.Host, ingressHostNamesecretIDMap)
@@ -152,13 +152,13 @@ func (c *appGwConfigBuilder) newBackendIdsFiltered(cbCtx *ConfigBuilderContext) 
 			rule := &ingress.Spec.Rules[ruleIdx]
 			if rule.HTTP == nil {
 				// skip no http rule
-				klog.V(5).Infof("[%s] Skip rule #%d for host '%s' - it has no HTTP rules.", ingress.Namespace, ruleIdx+1, rule.Host)
+				klog.V(3).Infof("[%s] Skip rule #%d for host '%s' - it has no HTTP rules.", ingress.Namespace, ruleIdx+1, rule.Host)
 				continue
 			}
 			for pathIdx := range rule.HTTP.Paths {
 				path := &rule.HTTP.Paths[pathIdx]
 				backendID := generateBackendID(ingress, rule, path, &path.Backend)
-				klog.V(5).Info("Found backend:", backendID.serviceKey())
+				klog.V(3).Info("Found backend:", backendID.serviceKey())
 				backendIDs[backendID] = nil
 			}
 		}

--- a/pkg/appgw/istio_settings.go
+++ b/pkg/appgw/istio_settings.go
@@ -36,7 +36,7 @@ func istioMatchDestinationIds(cbCtx *ConfigBuilderContext) ([]istioMatchIdentifi
 			}
 			for _, match := range rule.Match {
 				if match.URI == nil {
-					klog.V(5).Infof("Skipped match request, no URI field. Other forms of match requests are not supported.")
+					klog.V(3).Infof("Skipped match request, no URI field. Other forms of match requests are not supported.")
 					continue
 				}
 				matchID := generateIstioMatchID(virtualService, &rule, &match, destinations)
@@ -190,7 +190,7 @@ func (c *appGwConfigBuilder) generateIstioHTTPSettings(destinationID istioDestin
 		// TODO(delqn): Implement port lookup by name
 	}
 	httpSettingsName := generateHTTPSettingsName(destinationID.serviceFullName(), backendServicePort, port, destinationID.istioVirtualServiceIdentifier.Name)
-	klog.V(5).Infof("Created a new HTTP setting w/ name: %s\n", httpSettingsName)
+	klog.V(3).Infof("Created a new HTTP setting w/ name: %s\n", httpSettingsName)
 	httpSettings := n.ApplicationGatewayBackendHTTPSettings{
 		Etag: to.StringPtr("*"),
 		Name: &httpSettingsName,

--- a/pkg/appgw/requestroutingrules.go
+++ b/pkg/appgw/requestroutingrules.go
@@ -118,12 +118,12 @@ func (c *appGwConfigBuilder) getRules(cbCtx *ConfigBuilderContext) ([]n.Applicat
 			pathMap = append(pathMap, *urlPathMap)
 		}
 		if rule.RuleType == n.ApplicationGatewayRequestRoutingRuleTypePathBasedRouting {
-			klog.V(5).Infof("Bound path-based rule: %s to listener: %s (%s, %d) and url path map %s", *rule.Name, *httpListener.Name, listenerID.HostNames, listenerID.FrontendPort, utils.GetLastChunkOfSlashed(*rule.URLPathMap.ID))
+			klog.V(3).Infof("Bound path-based rule: %s to listener: %s (%s, %d) and url path map %s", *rule.Name, *httpListener.Name, listenerID.HostNames, listenerID.FrontendPort, utils.GetLastChunkOfSlashed(*rule.URLPathMap.ID))
 		} else {
 			if rule.RedirectConfiguration != nil {
-				klog.V(5).Infof("Bound basic rule: %s to listener: %s (%s, %d) and redirect configuration %s", *rule.Name, *httpListener.Name, listenerID.HostNames, listenerID.FrontendPort, utils.GetLastChunkOfSlashed(*rule.RedirectConfiguration.ID))
+				klog.V(3).Infof("Bound basic rule: %s to listener: %s (%s, %d) and redirect configuration %s", *rule.Name, *httpListener.Name, listenerID.HostNames, listenerID.FrontendPort, utils.GetLastChunkOfSlashed(*rule.RedirectConfiguration.ID))
 			} else {
-				klog.V(5).Infof("Bound basic rule: %s to listener: %s (%s, %d) for backend pool %s and backend http settings %s", *rule.Name, *httpListener.Name, listenerID.HostNames, listenerID.FrontendPort, utils.GetLastChunkOfSlashed(*rule.BackendAddressPool.ID), utils.GetLastChunkOfSlashed(*rule.BackendHTTPSettings.ID))
+				klog.V(3).Infof("Bound basic rule: %s to listener: %s (%s, %d) for backend pool %s and backend http settings %s", *rule.Name, *httpListener.Name, listenerID.HostNames, listenerID.FrontendPort, utils.GetLastChunkOfSlashed(*rule.BackendAddressPool.ID), utils.GetLastChunkOfSlashed(*rule.BackendHTTPSettings.ID))
 			}
 		}
 
@@ -273,7 +273,7 @@ func (c *appGwConfigBuilder) getDefaultFromRule(cbCtx *ConfigBuilderContext, lis
 		redirectsSet := *c.groupRedirectsByID(c.getRedirectConfigurations(cbCtx))
 
 		if _, exists := redirectsSet[*redirectRef.ID]; exists {
-			klog.V(5).Infof("Attached default redirection %s to rule %+v", *redirectRef.ID, *rule)
+			klog.V(3).Infof("Attached default redirection %s to rule %+v", *redirectRef.ID, *rule)
 			return nil, nil, redirectRef.ID, nil
 		}
 		klog.Errorf("Will not attach default redirect to rule; SSL Redirect does not exist: %s", *redirectRef.ID)
@@ -350,7 +350,7 @@ func (c *appGwConfigBuilder) getPathRules(cbCtx *ConfigBuilderContext, listenerI
 			if pathRule.Paths != nil {
 				paths = strings.Join(*pathRule.Paths, ",")
 			}
-			klog.V(5).Infof("Attach Firewall Policy %s to Path Rule %s", wafPolicy, paths)
+			klog.V(3).Infof("Attach Firewall Policy %s to Path Rule %s", wafPolicy, paths)
 		}
 
 		// check both annotations for rewrite-rule-set, use appropriate one, if both are present - throw error
@@ -366,7 +366,7 @@ func (c *appGwConfigBuilder) getPathRules(cbCtx *ConfigBuilderContext, listenerI
 			if pathRule.Paths != nil {
 				paths = strings.Join(*pathRule.Paths, ",")
 			}
-			klog.V(5).Infof("Attach Rewrite Rule Set %s to Path Rule %s", rewriteRuleSet, paths)
+			klog.V(3).Infof("Attach Rewrite Rule Set %s to Path Rule %s", rewriteRuleSet, paths)
 
 		} else if err2 == nil && rewriteRuleSetCR != "" {
 
@@ -376,7 +376,7 @@ func (c *appGwConfigBuilder) getPathRules(cbCtx *ConfigBuilderContext, listenerI
 			if pathRule.Paths != nil {
 				paths = strings.Join(*pathRule.Paths, ",")
 			}
-			klog.V(5).Infof("Attach Rewrite Rule Set %s to Path Rule %s", rewriteRuleSetCR, paths)
+			klog.V(3).Infof("Attach Rewrite Rule Set %s to Path Rule %s", rewriteRuleSetCR, paths)
 
 		}
 
@@ -392,7 +392,7 @@ func (c *appGwConfigBuilder) getPathRules(cbCtx *ConfigBuilderContext, listenerI
 				// This Path Rule has a SSL Redirect!
 				// Add it and move on to the next Path Rule; No need to attach Backend Pools and Settings
 				pathRule.RedirectConfiguration = redirectRef
-				klog.V(5).Infof("Attached redirection %s to path rule: %s", *redirectRef.ID, *pathRule.Name)
+				klog.V(3).Infof("Attached redirection %s to path rule: %s", *redirectRef.ID, *pathRule.Name)
 				pathRules = append(pathRules, pathRule)
 				continue
 			} else {
@@ -409,7 +409,7 @@ func (c *appGwConfigBuilder) getPathRules(cbCtx *ConfigBuilderContext, listenerI
 
 		pathRule.BackendAddressPool = &n.SubResource{ID: backendPool.ID}
 		pathRule.BackendHTTPSettings = &n.SubResource{ID: backendHTTPSettings.ID}
-		klog.V(5).Infof("Attached pool %s and http setting %s to path rule: %s", *backendPool.Name, *backendHTTPSettings.Name, *pathRule.Name)
+		klog.V(3).Infof("Attached pool %s and http setting %s to path rule: %s", *backendPool.Name, *backendHTTPSettings.Name, *pathRule.Name)
 
 		pathRules = append(pathRules, pathRule)
 	}
@@ -471,11 +471,11 @@ func (c *appGwConfigBuilder) getListenerPriorities(cbCtx *ConfigBuilderContext) 
 	priorityExists := make(map[int32]bool)
 	allPriorities := make(map[listenerIdentifier]*int32)
 	for _, ingress := range cbCtx.IngressList {
-		klog.V(5).Infof("Getting Request Routing Rules Priority for Ingress: %s/%s", ingress.Namespace, ingress.Name)
+		klog.V(3).Infof("Getting Request Routing Rules Priority for Ingress: %s/%s", ingress.Namespace, ingress.Name)
 		azListenerConfigs := c.getListenersFromIngress(ingress, cbCtx.EnvVariables)
 		for listenerID := range azListenerConfigs {
 			if priority, err := annotations.GetRequestRoutingRulePriority(ingress); err == nil {
-				klog.V(5).Infof("Request Routing Rules Priority for Ingress: %s/%s is Priority: %d", ingress.Namespace, ingress.Name, *priority)
+				klog.V(3).Infof("Request Routing Rules Priority for Ingress: %s/%s is Priority: %d", ingress.Namespace, ingress.Name, *priority)
 				prioritySet = true
 				if _, value := priorityExists[*priority]; !value {
 					priorityExists[*priority] = true

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -84,7 +84,7 @@ func ConvertToClusterResourceGroup(subscriptionID SubscriptionID, resourceGroup 
 			controllererrors.ErrorMissingResourceGroup,
 			"infrastructure resource group name: %s is expected to be of format MC_ResourceGroup_ResourceName_Location", string(resourceGroup),
 		)
-		klog.V(5).Info(err.Error())
+		klog.V(3).Info(err.Error())
 		return "", err
 	}
 

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -130,7 +130,7 @@ func (az *azClient) SetDuration(retryDuration time.Duration) {
 }
 
 func (az *azClient) WaitForGetAccessOnGateway(maxRetryCount int) (err error) {
-	klog.V(5).Info("Getting Application Gateway configuration.")
+	klog.V(3).Info("Getting Application Gateway configuration.")
 	err = utils.Retry(maxRetryCount, retryPause,
 		func() (utils.Retriable, error) {
 			response, err := az.appGatewaysClient.Get(az.ctx, string(az.resourceGroupName), string(az.appGwName))
@@ -247,7 +247,7 @@ func (az *azClient) ApplyRouteTable(subnetID string, routeTableID string) error 
 
 	// if route table is not found, then simply add a log and return no error. routeTable will always be initialized.
 	if routeTable.Response.StatusCode == 404 {
-		klog.V(5).Infof("Error getting route table '%s' (this is relevant for AKS clusters using 'Kubenet' network plugin): %s",
+		klog.V(3).Infof("Error getting route table '%s' (this is relevant for AKS clusters using 'Kubenet' network plugin): %s",
 			routeTableID,
 			err.Error())
 		return nil
@@ -267,12 +267,12 @@ func (az *azClient) ApplyRouteTable(subnetID string, routeTableID string) error 
 
 	if subnet.RouteTable != nil {
 		if *subnet.RouteTable.ID != routeTableID {
-			klog.V(5).Infof("Skipping associating Application Gateway subnet '%s' with route table '%s' used by k8s cluster as it is already associated to route table '%s'.",
+			klog.V(3).Infof("Skipping associating Application Gateway subnet '%s' with route table '%s' used by k8s cluster as it is already associated to route table '%s'.",
 				subnetID,
 				routeTableID,
 				*subnet.SubnetPropertiesFormat.RouteTable.ID)
 		} else {
-			klog.V(5).Infof("Application Gateway subnet '%s' is associated with route table '%s' used by k8s cluster.",
+			klog.V(3).Infof("Application Gateway subnet '%s' is associated with route table '%s' used by k8s cluster.",
 				subnetID,
 				routeTableID)
 		}

--- a/pkg/brownfield/health_probes.go
+++ b/pkg/brownfield/health_probes.go
@@ -24,11 +24,11 @@ func (er ExistingResources) GetBlacklistedProbes() ([]n.ApplicationGatewayProbe,
 	var blacklistedProbes []n.ApplicationGatewayProbe
 	for _, probe := range er.Probes {
 		if _, isBlacklisted := blacklistedProbesSet[probeName(*probe.Name)]; isBlacklisted {
-			klog.V(5).Infof("Probe %s is blacklisted", *probe.Name)
+			klog.V(3).Infof("Probe %s is blacklisted", *probe.Name)
 			blacklistedProbes = append(blacklistedProbes, probe)
 			continue
 		}
-		klog.V(5).Infof("Probe %s is not blacklisted", *probe.Name)
+		klog.V(3).Infof("Probe %s is not blacklisted", *probe.Name)
 		nonBlacklistedProbes = append(nonBlacklistedProbes, probe)
 	}
 	return blacklistedProbes, nonBlacklistedProbes

--- a/pkg/brownfield/http_settings.go
+++ b/pkg/brownfield/http_settings.go
@@ -26,10 +26,10 @@ func (er ExistingResources) GetBlacklistedHTTPSettings() ([]n.ApplicationGateway
 	for _, setting := range er.HTTPSettings {
 		if _, isBlacklisted := blacklistedSettingsSet[settingName(*setting.Name)]; isBlacklisted {
 			blacklisted = append(blacklisted, setting)
-			klog.V(5).Infof("HTTP Setting %s is blacklisted", *setting.Name)
+			klog.V(3).Infof("HTTP Setting %s is blacklisted", *setting.Name)
 			continue
 		}
-		klog.V(5).Infof("HTTP Setting %s is NOT blacklisted", *setting.Name)
+		klog.V(3).Infof("HTTP Setting %s is NOT blacklisted", *setting.Name)
 		nonBlacklisted = append(nonBlacklisted, setting)
 	}
 	return blacklisted, nonBlacklisted

--- a/pkg/brownfield/listeners.go
+++ b/pkg/brownfield/listeners.go
@@ -29,11 +29,11 @@ func (er ExistingResources) GetBlacklistedListeners() ([]n.ApplicationGatewayHTT
 	for _, listener := range er.Listeners {
 		listenerNm := listenerName(*listener.Name)
 		if _, exists := blacklistedListenersSet[listenerNm]; exists {
-			klog.V(5).Infof("[brownfield] Listener %s is blacklisted", listenerNm)
+			klog.V(3).Infof("[brownfield] Listener %s is blacklisted", listenerNm)
 			blacklisted = append(blacklisted, listener)
 			continue
 		}
-		klog.V(5).Infof("[brownfield] Listener %s is not blacklisted", listenerNm)
+		klog.V(3).Infof("[brownfield] Listener %s is not blacklisted", listenerNm)
 		nonBlacklisted = append(nonBlacklisted, listener)
 	}
 	return blacklisted, nonBlacklisted

--- a/pkg/brownfield/pathmaps.go
+++ b/pkg/brownfield/pathmaps.go
@@ -26,7 +26,7 @@ func (er ExistingResources) GetBlacklistedPathMaps() ([]n.ApplicationGatewayURLP
 		return nil, er.URLPathMaps
 	}
 	_, pathMapToTargets := er.getRuleToTargets()
-	klog.V(5).Infof("[brownfield] PathMap to Targets map: %+v", pathMapToTargets)
+	klog.V(3).Infof("[brownfield] PathMap to Targets map: %+v", pathMapToTargets)
 
 	// Figure out if the given BackendAddressPathMap is blacklisted. It will be if it has a host/path that
 	// has been referenced in a AzureIngressProhibitedTarget CRD (even if it has some other paths that are not)
@@ -34,11 +34,11 @@ func (er ExistingResources) GetBlacklistedPathMaps() ([]n.ApplicationGatewayURLP
 		targetsForPathMap := pathMapToTargets[urlPathMapName(*pathMap.Name)]
 		for _, target := range targetsForPathMap {
 			if target.IsBlacklisted(blacklist) {
-				klog.V(5).Infof("[brownfield] Routing PathMap %s is blacklisted", *pathMap.Name)
+				klog.V(3).Infof("[brownfield] Routing PathMap %s is blacklisted", *pathMap.Name)
 				return true
 			}
 		}
-		klog.V(5).Infof("[brownfield] Routing PathMap %s is NOT blacklisted", *pathMap.Name)
+		klog.V(3).Infof("[brownfield] Routing PathMap %s is NOT blacklisted", *pathMap.Name)
 		return false
 	}
 
@@ -60,10 +60,10 @@ func MergePathMaps(pathMapBuckets ...[]n.ApplicationGatewayURLPathMap) []n.Appli
 	for _, bucket := range pathMapBuckets {
 		for _, pathMap := range bucket {
 			if existingPathMap, exists := uniq[urlPathMapName(*pathMap.Name)]; exists {
-				klog.V(5).Infof("[brownfield] Merging urlpath %s in existing blacklist and AGIC list", *existingPathMap.Name)
+				klog.V(3).Infof("[brownfield] Merging urlpath %s in existing blacklist and AGIC list", *existingPathMap.Name)
 				uniq[urlPathMapName(*pathMap.Name)].PathRules = mergePathRules(existingPathMap.PathRules, pathMap.PathRules)
 			} else {
-				klog.V(5).Infof("[brownfield] Adding urlpath %s to the uniq map", *pathMap.Name)
+				klog.V(3).Infof("[brownfield] Adding urlpath %s to the uniq map", *pathMap.Name)
 				uniq[urlPathMapName(*pathMap.Name)] = pathMap
 			}
 		}
@@ -119,7 +119,7 @@ func mergePathRules(pathRulesBucket ...*[]n.ApplicationGatewayPathRule) *[]n.App
 	}
 	var merged []n.ApplicationGatewayPathRule
 	for _, pathRule := range uniq {
-		klog.V(5).Infof("[brownfield] Appending %s with paths %v", *pathRule.Name, pathRule.Paths)
+		klog.V(3).Infof("[brownfield] Appending %s with paths %v", *pathRule.Name, pathRule.Paths)
 		merged = append(merged, pathRule)
 	}
 	return &merged
@@ -142,7 +142,7 @@ func deletePathMap(pathMapsPtr *[]n.ApplicationGatewayURLPathMap, resourceID *st
 	deleteIdx := -1
 	for idx, pathMap := range pathMaps {
 		if *pathMap.ID == *resourceID {
-			klog.V(5).Infof("[brownfield] Deleting %s", *resourceID)
+			klog.V(3).Infof("[brownfield] Deleting %s", *resourceID)
 			deleteIdx = idx
 		}
 	}

--- a/pkg/brownfield/pools.go
+++ b/pkg/brownfield/pools.go
@@ -25,10 +25,10 @@ func (er ExistingResources) GetBlacklistedPools() ([]n.ApplicationGatewayBackend
 	for _, pool := range er.BackendPools {
 		if _, isBlacklisted := blacklistedPoolsSet[backendPoolName(*pool.Name)]; isBlacklisted {
 			blacklistedPools = append(blacklistedPools, pool)
-			klog.V(5).Infof("[brownfield] Backend Address Pool %s is blacklisted", *pool.Name)
+			klog.V(3).Infof("[brownfield] Backend Address Pool %s is blacklisted", *pool.Name)
 			continue
 		}
-		klog.V(5).Infof("[brownfield] Backend Address Pool %s is NOT blacklisted", *pool.Name)
+		klog.V(3).Infof("[brownfield] Backend Address Pool %s is NOT blacklisted", *pool.Name)
 		nonBlacklistedPools = append(nonBlacklistedPools, pool)
 	}
 	return blacklistedPools, nonBlacklistedPools

--- a/pkg/brownfield/redirects.go
+++ b/pkg/brownfield/redirects.go
@@ -25,10 +25,10 @@ func (er ExistingResources) GetBlacklistedRedirects() ([]n.ApplicationGatewayRed
 	for _, redirect := range er.Redirects {
 		if _, isBlacklisted := blacklisted[redirectName(*redirect.Name)]; isBlacklisted {
 			blacklistedRedirects = append(blacklistedRedirects, redirect)
-			klog.V(5).Infof("[brownfield] Redirect %s is blacklisted", *redirect.Name)
+			klog.V(3).Infof("[brownfield] Redirect %s is blacklisted", *redirect.Name)
 			continue
 		}
-		klog.V(5).Infof("[brownfield] Redirect %s is not blacklisted", *redirect.Name)
+		klog.V(3).Infof("[brownfield] Redirect %s is not blacklisted", *redirect.Name)
 		nonBlacklistedRedirects = append(nonBlacklistedRedirects, redirect)
 	}
 	return blacklistedRedirects, nonBlacklistedRedirects

--- a/pkg/brownfield/routing_rules.go
+++ b/pkg/brownfield/routing_rules.go
@@ -28,7 +28,7 @@ func (er ExistingResources) GetBlacklistedRoutingRules() ([]n.ApplicationGateway
 		return nil, er.RoutingRules
 	}
 	ruleToTargets, _ := er.getRuleToTargets()
-	klog.V(5).Infof("[brownfield] Rule to Targets map: %+v", ruleToTargets)
+	klog.V(3).Infof("[brownfield] Rule to Targets map: %+v", ruleToTargets)
 
 	// Figure out if the given routing rule is blacklisted. It will be if it has a host/path that
 	// has been referenced in a AzureIngressProhibitedTarget CRD (even if it has some other paths that are not)
@@ -36,11 +36,11 @@ func (er ExistingResources) GetBlacklistedRoutingRules() ([]n.ApplicationGateway
 		targetsForRule := ruleToTargets[ruleName(*rule.Name)]
 		for _, target := range targetsForRule {
 			if target.IsBlacklisted(blacklist) {
-				klog.V(5).Infof("[brownfield] Routing Rule %s is blacklisted", *rule.Name)
+				klog.V(3).Infof("[brownfield] Routing Rule %s is blacklisted", *rule.Name)
 				return true
 			}
 		}
-		klog.V(5).Infof("[brownfield] Routing Rule %s is NOT blacklisted", *rule.Name)
+		klog.V(3).Infof("[brownfield] Routing Rule %s is NOT blacklisted", *rule.Name)
 		return false
 	}
 
@@ -106,19 +106,19 @@ func mergeRoutingRules(appGw *n.ApplicationGateway, firstRoutingRule *n.Applicat
 
 	if firstRoutingRule.RuleType == n.ApplicationGatewayRequestRoutingRuleTypePathBasedRouting {
 		// Get the url path map of the first rule
-		klog.V(5).Infof("[brownfield] Merging path based rule %s with rule %s", *firstRoutingRule.Name, *secondRoutingRule.Name)
+		klog.V(3).Infof("[brownfield] Merging path based rule %s with rule %s", *firstRoutingRule.Name, *secondRoutingRule.Name)
 		firstPathMap := lookupPathMap(appGw.URLPathMaps, firstRoutingRule.URLPathMap.ID)
 
 		if secondRoutingRule.RuleType == n.ApplicationGatewayRequestRoutingRuleTypeBasic {
 			// Replace the default values from the second rule
-			klog.V(5).Infof("[brownfield] Merging path map %s with rule %s", *firstPathMap.Name, *secondRoutingRule.Name)
+			klog.V(3).Infof("[brownfield] Merging path map %s with rule %s", *firstPathMap.Name, *secondRoutingRule.Name)
 			mergePathMapsWithBasicRule(firstPathMap, secondRoutingRule)
 			return firstRoutingRule
 		}
 
 		if *firstRoutingRule.URLPathMap.ID == *secondRoutingRule.URLPathMap.ID {
 			// No merge needed as both routing rule point to the same URL Path map
-			klog.V(5).Infof("[brownfield] Rule %s and rule %s share the same path map %s; Skipping merge", *firstRoutingRule.Name, *secondRoutingRule.Name, *firstPathMap.Name)
+			klog.V(3).Infof("[brownfield] Rule %s and rule %s share the same path map %s; Skipping merge", *firstRoutingRule.Name, *secondRoutingRule.Name, *firstPathMap.Name)
 			return firstRoutingRule
 		}
 
@@ -126,11 +126,11 @@ func mergeRoutingRules(appGw *n.ApplicationGateway, firstRoutingRule *n.Applicat
 		secondPathMap := lookupPathMap(appGw.URLPathMaps, secondRoutingRule.URLPathMap.ID)
 
 		// Merge the path rules from second path map to first path map
-		klog.V(5).Infof("[brownfield] Merging path map %s with path map %s", *firstPathMap.Name, *secondPathMap.Name)
+		klog.V(3).Infof("[brownfield] Merging path map %s with path map %s", *firstPathMap.Name, *secondPathMap.Name)
 		firstPathMap.PathRules = mergePathRules(firstPathMap.PathRules, secondPathMap.PathRules)
 
 		// Delete the second path map
-		klog.V(5).Infof("[brownfield] Deleting path map %s", *secondPathMap.Name)
+		klog.V(3).Infof("[brownfield] Deleting path map %s", *secondPathMap.Name)
 		appGw.URLPathMaps = deletePathMap(appGw.URLPathMaps, secondPathMap.ID)
 	}
 
@@ -204,7 +204,7 @@ func (er ExistingResources) getRuleToTargets() (ruleToTargets, pathmapToTargets)
 			pathMapName, pathRules := er.getPathRules(rule)
 			for _, pathRule := range pathRules {
 				if pathRule.Paths == nil {
-					klog.V(5).Infof("[brownfield] Path Rule %+v does not have paths list", *pathRule.Name)
+					klog.V(3).Infof("[brownfield] Path Rule %+v does not have paths list", *pathRule.Name)
 					continue
 				}
 				for _, path := range *pathRule.Paths {

--- a/pkg/brownfield/targets.go
+++ b/pkg/brownfield/targets.go
@@ -42,11 +42,11 @@ func (t Target) IsBlacklisted(blacklist TargetBlacklist) bool {
 		// whether given target is in the blacklist. Ideally this would be URL Path set overlap operation,
 		// which we deliberately leave for a later time.
 		if hostIsBlacklisted && pathIsBlacklisted {
-			klog.V(5).Infof("[brownfield] Target %s is blacklisted", jsonTarget)
+			klog.V(3).Infof("[brownfield] Target %s is blacklisted", jsonTarget)
 			return true // Found it
 		}
 	}
-	klog.V(5).Infof("[brownfield] Target %s is not blacklisted", jsonTarget)
+	klog.V(3).Infof("[brownfield] Target %s is not blacklisted", jsonTarget)
 	return false // Did not find it
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -155,7 +155,7 @@ func (c *AppGwIngressController) ProcessEvent(event events.Event) error {
 }
 
 func reconcilerTickerTask(work chan events.Event, stopChannel chan struct{}, reconcilePeriodSecondsStr string) {
-	klog.V(5).Info("Reconciler Ticker task started with period: ", reconcilePeriodSecondsStr)
+	klog.V(3).Info("Reconciler Ticker task started with period: ", reconcilePeriodSecondsStr)
 
 	reconcilePeriodSeconds, _ := strconv.Atoi(reconcilePeriodSecondsStr)
 	reconcileTicker := time.NewTicker(time.Duration(reconcilePeriodSeconds) * time.Second)

--- a/pkg/controller/mutate_aks.go
+++ b/pkg/controller/mutate_aks.go
@@ -46,7 +46,7 @@ func (c AppGwIngressController) ResetAllIngress(appGw *n.ApplicationGateway, cbC
 
 		msg := fmt.Sprintf("Reset IP for Ingress %s/%s. Application Gateway %s is in stopped state", ingress.Namespace, ingress.Name, *appGw.ID)
 		c.recorder.Event(ingress, v1.EventTypeNormal, events.ReasonResetIngressStatus, msg)
-		klog.V(5).Infof(msg)
+		klog.V(3).Infof(msg)
 	}
 }
 
@@ -66,14 +66,14 @@ func (c AppGwIngressController) updateIngressStatus(appGw *n.ApplicationGateway,
 		return
 	}
 
-	klog.V(5).Infof("[mutate_aks] Resolving IP for ID (%s)", *ipConf.ID)
+	klog.V(3).Infof("[mutate_aks] Resolving IP for ID (%s)", *ipConf.ID)
 	if newIP, found := ips[ipResource(*ipConf.ID)]; found {
 		if err := c.k8sContext.UpdateIngressStatus(*ingress, k8scontext.IPAddress(newIP)); err != nil {
 			c.recorder.Event(ingress, v1.EventTypeWarning, events.ReasonUnableToUpdateIngressStatus, err.Error())
 			klog.Errorf("[mutate_aks] Error updating ingress %s/%s IP to %+v", ingress.Namespace, ingress.Name, newIP)
 			return
 		}
-		klog.V(5).Infof("[mutate_aks] Updated Ingress %s/%s IP to %+v", ingress.Namespace, ingress.Name, newIP)
+		klog.V(3).Infof("[mutate_aks] Updated Ingress %s/%s IP to %+v", ingress.Namespace, ingress.Name, newIP)
 	}
 }
 
@@ -91,7 +91,7 @@ func getIPsFromAppGateway(appGw *n.ApplicationGateway, azClient azure.AzClient) 
 			ips[ipID] = *ipAddress
 		}
 	}
-	klog.V(5).Infof("[mutate_aks] Found IPs: %+v", ips)
+	klog.V(3).Infof("[mutate_aks] Found IPs: %+v", ips)
 	return ips
 }
 

--- a/pkg/controller/mutate_app_gateway.go
+++ b/pkg/controller/mutate_app_gateway.go
@@ -67,7 +67,7 @@ func (c AppGwIngressController) GetAppGw() (*n.ApplicationGateway, *appgw.Config
 func (c AppGwIngressController) MutateAppGateway(event events.Event, appGw *n.ApplicationGateway, cbCtx *appgw.ConfigBuilderContext) error {
 	var err error
 	existingConfigJSON, _ := dumpSanitizedJSON(appGw, false, to.StringPtr("-- Existing App Gwy Config --"))
-	klog.V(5).Info("Existing App Gateway config: ", string(existingConfigJSON))
+	klog.V(3).Info("Existing App Gateway config: ", string(existingConfigJSON))
 
 	// Prepare k8s resources Phase //
 	// --------------------------- //
@@ -106,7 +106,7 @@ func (c AppGwIngressController) MutateAppGateway(event events.Event, appGw *n.Ap
 		for _, gateway := range cbCtx.IstioGateways {
 			gatewaysInfo = append(gatewaysInfo, fmt.Sprintf("%s/%s", gateway.Namespace, gateway.Name))
 		}
-		klog.V(5).Infof("Istio Gateways: %+v", strings.Join(gatewaysInfo, ","))
+		klog.V(3).Infof("Istio Gateways: %+v", strings.Join(gatewaysInfo, ","))
 	}
 
 	// Generate App Gateway Phase //
@@ -160,7 +160,7 @@ func (c AppGwIngressController) MutateAppGateway(event events.Event, appGw *n.Ap
 	// ---------------- //
 
 	configJSON, _ := dumpSanitizedJSON(appGw, cbCtx.EnvVariables.EnableSaveConfigToFile, nil)
-	klog.V(5).Infof("Generated config:\n%s", string(configJSON))
+	klog.V(3).Infof("Generated config:\n%s", string(configJSON))
 
 	// Initiate deployment
 	klog.V(3).Info("BEGIN AppGateway deployment")

--- a/pkg/controller/prune.go
+++ b/pkg/controller/prune.go
@@ -47,13 +47,13 @@ func (c *AppGwIngressController) PruneIngress(appGw *n.ApplicationGateway, cbCtx
 func pruneProhibitedIngress(c *AppGwIngressController, appGw *n.ApplicationGateway, cbCtx *appgw.ConfigBuilderContext, ingressList []*networking.Ingress) []*networking.Ingress {
 	// Mutate the list of Ingresses by removing ones that AGIC should not be creating configuration.
 	for idx, ingress := range ingressList {
-		klog.V(5).Infof("Original Ingress[%d] Rules: %+v", idx, ingress.Spec.Rules)
+		klog.V(3).Infof("Original Ingress[%d] Rules: %+v", idx, ingress.Spec.Rules)
 
 		ingressClone := ingressList[idx].DeepCopy()
 		ingressClone.Spec.Rules = brownfield.PruneIngressRules(ingress, cbCtx.ProhibitedTargets)
 		ingressList[idx] = ingressClone
 
-		klog.V(5).Infof("Sanitized Ingress[%d] Rules: %+v", idx, ingressList[idx].Spec.Rules)
+		klog.V(3).Infof("Sanitized Ingress[%d] Rules: %+v", idx, ingressList[idx].Spec.Rules)
 	}
 
 	return ingressList

--- a/pkg/controller/should_process.go
+++ b/pkg/controller/should_process.go
@@ -48,7 +48,7 @@ func (c AppGwIngressController) ShouldProcess(event events.Event) (bool, *string
 			return false, to.StringPtr(reason)
 		}
 
-		klog.V(5).Info("Triggered by reconciler event")
+		klog.V(3).Info("Triggered by reconciler event")
 	}
 
 	return true, nil

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -22,6 +22,21 @@ const (
 	PeriodicReconcile
 )
 
+func (e EventType) String() string {
+	switch e {
+	case Create:
+		return "Create"
+	case Update:
+		return "Update"
+	case Delete:
+		return "Delete"
+	case PeriodicReconcile:
+		return "PeriodicReconcile"
+	default:
+		return "Unknown"
+	}
+}
+
 // Event is the combined type and actual object we received from Kubernetes
 type Event struct {
 	Type  EventType

--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -568,7 +568,7 @@ func (c *Context) ListAzureProhibitedTargets() []*prohibitedv1.AzureIngressProhi
 		prohibitedTargets = append(prohibitedTargets, fmt.Sprintf("%s/%s", target.Namespace, target.Name))
 	}
 
-	klog.V(5).Infof("AzureIngressProhibitedTargets: %+v", strings.Join(prohibitedTargets, ","))
+	klog.V(3).Infof("AzureIngressProhibitedTargets: %+v", strings.Join(prohibitedTargets, ","))
 
 	return targets
 }
@@ -651,7 +651,7 @@ func (c *Context) GetVirtualServicesForGateway(gateway v1alpha3.Gateway) []*v1al
 	for _, virtualService := range virtualServices {
 		virtualServiceLogging = append(virtualServiceLogging, fmt.Sprintf("%s/%s", virtualService.Namespace, virtualService.Name))
 	}
-	klog.V(5).Infof("Found Virtual Services: %+v", strings.Join(virtualServiceLogging, ","))
+	klog.V(3).Infof("Found Virtual Services: %+v", strings.Join(virtualServiceLogging, ","))
 	return virtualServices
 }
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -50,12 +50,14 @@ func (w *Worker) Run(work chan events.Event, stopChannel chan struct{}) {
 				continue
 			}
 
-			// get name, namespace and kind from event.Value
-			name := reflect.ValueOf(event.Value).Elem().FieldByName("Name").String()
-			namespace := reflect.ValueOf(event.Value).Elem().FieldByName("Namespace").String()
-			objectType := reflect.TypeOf(event.Value).Elem()
+			if event.Value != nil {
+				// get name, namespace and kind from event.Value
+				name := reflect.ValueOf(event.Value).Elem().FieldByName("Name").String()
+				namespace := reflect.ValueOf(event.Value).Elem().FieldByName("Namespace").String()
+				objectType := reflect.TypeOf(event.Value).Elem()
 
-			klog.V(3).Infof("Processing k8s event of type:%s object:%s/%s/%s", event.Type, objectType, namespace, name)
+				klog.V(3).Infof("Processing k8s event of type:%s object:%s/%s/%s", event.Type, objectType, namespace, name)
+			}
 
 			since := time.Since(lastUpdate)
 			if since < minTimeBetweenUpdates {

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Worker Test", func() {
 			}
 			go worker.Run(work, stopChannel)
 
-			ingress := *tests.NewIngressFixture()
+			ingress := tests.NewIngressFixture()
 			work <- events.Event{
 				Type:  events.Create,
 				Value: ingress,


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

* This PR modifies the verbosity numbering from 5 to 3 for many log statements as 5 is also used by go-client and that causes a lot of noise in logging.
* This PR also prints when events are processed and skipped by AGIC. This is to help in debugging when AGIC doesn't perform actions.

```
I0712 15:48:50.613169   63055 worker.go:48] Skipping event. Reason: pod default/unrelated-55866f769d-8f92k is not used by any Ingress
I0712 15:49:03.618992   63055 worker.go:58] Processing k8s event of type:Update object:v1.Pod/default/related-5b79994554-tchxs
```

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
