### PR TITLE
Add CRD link that works on clusters >v1.22 to Shared App Gateway documentation

### DIFF
--- a/docs/how-tos/prevent-agic-from-overwriting.md
+++ b/docs/how-tos/prevent-agic-from-overwriting.md
@@ -61,11 +61,17 @@ Apply the Helm changes:
 
   1. Ensure the `AzureIngressProhibitedTarget` CRD is installed with:
 
-      ```bash
-      kubectl apply -f https://raw.githubusercontent.com/Azure/application-gateway-kubernetes-ingress/ae695ef9bd05c8b708cedf6ff545595d0b7022dc/crds/AzureIngressProhibitedTarget.yaml
-      ```
+       - If your kubernetes cluster is >= `1.16`
+         ```bash
+          kubectl apply -f https://raw.githubusercontent.com/Azure/application-gateway-kubernetes-ingress/refs/heads/master/crds/AzureIngressProhibitedTarget-v1-CRD-v1.yaml
+          ```
+       - If your kubernetes cluster is <= `1.16`
+          ```bash
+          kubectl apply -f https://raw.githubusercontent.com/Azure/application-gateway-kubernetes-ingress/refs/heads/master/crds/AzureIngressProhibitedTarget-v1-CRD-v1beta1.yaml
+          ```
+      
 
-  2. Update Helm:
+  3. Update Helm:
 
       ```bash
       helm upgrade \

--- a/docs/how-tos/prevent-agic-from-overwriting.md
+++ b/docs/how-tos/prevent-agic-from-overwriting.md
@@ -61,16 +61,14 @@ Apply the Helm changes:
 
   1. Ensure the `AzureIngressProhibitedTarget` CRD is installed with:
 
-       - If your kubernetes cluster is >= `1.16`
+       - If your kubernetes cluster is >= `v1.16`
          ```bash
           kubectl apply -f https://raw.githubusercontent.com/Azure/application-gateway-kubernetes-ingress/refs/heads/master/crds/AzureIngressProhibitedTarget-v1-CRD-v1.yaml
           ```
-       - If your kubernetes cluster is <= `1.16`
+       - If your kubernetes cluster is < `v1.16`
           ```bash
           kubectl apply -f https://raw.githubusercontent.com/Azure/application-gateway-kubernetes-ingress/refs/heads/master/crds/AzureIngressProhibitedTarget-v1-CRD-v1beta1.yaml
           ```
-      
-
   3. Update Helm:
 
       ```bash


### PR DESCRIPTION

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

The instruction to apply the CRD for AzureIngressProhibitedTarget is linked to an older revision on the repository with the apiVersion set to apiextensions.k8s.io/v1beta1. This no longer works with clusters that are above Kubernetes v1.22 [since it has been deprecated](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122).

This pull request updates the links and retains options for clusters that are below v1.16 

## Fixes

#1663 
