### PR TITLE
Support overlay upgrades + wait for OEC to reach terminal state

### DIFF
--- a/cmd/appgw-ingress/utils.go
+++ b/cmd/appgw-ingress/utils.go
@@ -39,7 +39,7 @@ func validateNamespaces(namespaces []string, kubeClient *kubernetes.Clientset) e
 			controllererrors.ErrorNoSuchNamespace,
 			"error creating informers; Namespaces do not exist or Ingress Controller has no access to: %v", strings.Join(nonExistent, ","),
 		)
-		klog.Errorf(err.Error())
+		klog.Error(err.Error())
 		return err
 	}
 	return nil

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -248,9 +248,6 @@ func (az *azClient) ApplyRouteTable(subnetID string, routeTableID string) error 
 
 	// if route table is not found, then simply add a log and return no error. routeTable will always be initialized.
 	if routeTable.Response.StatusCode == 404 {
-		klog.V(3).Infof("Error getting route table '%s' (this is relevant for AKS clusters using 'Kubenet' network plugin): %s",
-			routeTableID,
-			err.Error())
 		return nil
 	}
 

--- a/pkg/cni/cni.go
+++ b/pkg/cni/cni.go
@@ -2,11 +2,19 @@ package cni
 
 import (
 	"context"
+	"time"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/azure"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-03-01/network"
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// PollInterval is the interval at which the reconciler polls for the status of the resources.
+	PollInterval = 5 * time.Second
 )
 
 // Reconciler reconciles the resources required to configure
@@ -14,30 +22,43 @@ import (
 type Reconciler struct {
 	armClient azure.AzClient
 	client    client.Client
+	cpConfig  *azure.CloudProviderConfig
+	appGw     n.ApplicationGateway
 	namespace string
 	addonMode bool
+
+	routeTableAttached bool
 }
 
-func ReconcileCNI(ctx context.Context, armClient azure.AzClient, client client.Client, namespace string, cpConfig *azure.CloudProviderConfig, appGw n.ApplicationGateway, addonMode bool) error {
-	r := &Reconciler{
-		armClient: armClient,
-		client:    client,
-		namespace: namespace,
-		addonMode: addonMode,
+func NewReconciler(armClient azure.AzClient,
+	client client.Client,
+	recorder record.EventRecorder,
+	cpConfig *azure.CloudProviderConfig,
+	appGw n.ApplicationGateway,
+	agicPod *v1.Pod,
+	namespace string,
+	addonMode bool) *Reconciler {
+	return &Reconciler{
+		armClient:          armClient,
+		client:             client,
+		cpConfig:           cpConfig,
+		appGw:              appGw,
+		namespace:          namespace,
+		addonMode:          addonMode,
+		routeTableAttached: false,
 	}
-
-	return r.Reconcile(ctx, cpConfig, appGw)
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, cpConfig *azure.CloudProviderConfig, appGw n.ApplicationGateway) error {
-	subnetID := *(*appGw.GatewayIPConfigurations)[0].Subnet.ID
+func (r *Reconciler) Reconcile(ctx context.Context) error {
+	subnetID := *(*r.appGw.GatewayIPConfigurations)[0].Subnet.ID
+
+	if err := r.reconcileKubenetCniIfNeeded(r.cpConfig, subnetID); err != nil {
+		return errors.Wrap(err, "failed to reconcile kubenet CNI")
+	}
 
 	if err := r.reconcileOverlayCniIfNeeded(ctx, subnetID); err != nil {
 		return errors.Wrap(err, "failed to reconcile overlay CNI")
 	}
 
-	if err := r.reconcileKubenetCniIfNeeded(cpConfig, subnetID); err != nil {
-		return errors.Wrap(err, "failed to reconcile kubenet CNI")
-	}
 	return nil
 }

--- a/pkg/cni/cni.go
+++ b/pkg/cni/cni.go
@@ -2,7 +2,6 @@ package cni
 
 import (
 	"context"
-	"time"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/azure"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-03-01/network"
@@ -10,11 +9,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	// PollInterval is the interval at which the reconciler polls for the status of the resources.
-	PollInterval = 5 * time.Second
 )
 
 // Reconciler reconciles the resources required to configure

--- a/pkg/cni/cni.go
+++ b/pkg/cni/cni.go
@@ -27,7 +27,8 @@ type Reconciler struct {
 	namespace string
 	addonMode bool
 
-	routeTableAttached bool
+	reconciledKubenetCNI bool
+	reconciledOverlayCNI bool
 }
 
 func NewReconciler(armClient azure.AzClient,
@@ -39,13 +40,14 @@ func NewReconciler(armClient azure.AzClient,
 	namespace string,
 	addonMode bool) *Reconciler {
 	return &Reconciler{
-		armClient:          armClient,
-		client:             client,
-		cpConfig:           cpConfig,
-		appGw:              appGw,
-		namespace:          namespace,
-		addonMode:          addonMode,
-		routeTableAttached: false,
+		armClient:            armClient,
+		client:               client,
+		cpConfig:             cpConfig,
+		appGw:                appGw,
+		namespace:            namespace,
+		addonMode:            addonMode,
+		reconciledKubenetCNI: false,
+		reconciledOverlayCNI: false,
 	}
 }
 

--- a/pkg/cni/kubenet.go
+++ b/pkg/cni/kubenet.go
@@ -6,11 +6,11 @@ import (
 )
 
 func (r *Reconciler) reconcileKubenetCniIfNeeded(cpConfig *azure.CloudProviderConfig, subnetID string) error {
-	if cpConfig == nil || cpConfig.RouteTableName == "" {
+	if r.reconciledKubenetCNI {
 		return nil
 	}
 
-	if r.routeTableAttached {
+	if cpConfig == nil || cpConfig.RouteTableName == "" {
 		return nil
 	}
 
@@ -21,6 +21,6 @@ func (r *Reconciler) reconcileKubenetCniIfNeeded(cpConfig *azure.CloudProviderCo
 			routeTableID)
 	}
 
-	r.routeTableAttached = true
+	r.reconciledKubenetCNI = true
 	return nil
 }

--- a/pkg/cni/kubenet.go
+++ b/pkg/cni/kubenet.go
@@ -10,6 +10,10 @@ func (r *Reconciler) reconcileKubenetCniIfNeeded(cpConfig *azure.CloudProviderCo
 		return nil
 	}
 
+	if r.routeTableAttached {
+		return nil
+	}
+
 	routeTableID := azure.RouteTableID(azure.SubscriptionID(cpConfig.SubscriptionID), azure.ResourceGroup(cpConfig.RouteTableResourceGroup), azure.ResourceName(cpConfig.RouteTableName))
 	if err := r.armClient.ApplyRouteTable(subnetID, routeTableID); err != nil {
 		return errors.Wrapf(err, "Unable to associate Application Gateway subnet '%s' with route table '%s' due to error (this is relevant for AKS clusters using 'Kubenet' network plugin)",
@@ -17,5 +21,6 @@ func (r *Reconciler) reconcileKubenetCniIfNeeded(cpConfig *azure.CloudProviderCo
 			routeTableID)
 	}
 
+	r.routeTableAttached = true
 	return nil
 }

--- a/pkg/cni/kubenet_test.go
+++ b/pkg/cni/kubenet_test.go
@@ -5,6 +5,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl_client "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -16,9 +20,12 @@ import (
 )
 
 var _ = Describe("Kubenet CNI", func() {
-	var ctx = context.TODO()
+	var ctx context.Context
+	var cancel context.CancelFunc
 	var azClient *azure.FakeAzClient
 	var k8sClient ctrl_client.Client
+	var recorder *record.FakeRecorder
+	var agicPod *v1.Pod
 	var appGw = n.ApplicationGateway{
 		ApplicationGatewayPropertiesFormat: &n.ApplicationGatewayPropertiesFormat{
 			GatewayIPConfigurations: &[]n.ApplicationGatewayIPConfiguration{
@@ -32,12 +39,32 @@ var _ = Describe("Kubenet CNI", func() {
 			},
 		},
 	}
+	var reconciler *cni.Reconciler
 
 	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
 		azClient = azure.NewFakeAzClient()
+		recorder = record.NewFakeRecorder(100)
+		recorder.IncludeObject = true
+		agicPod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "agic",
+				Namespace: "kube-system",
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: "v1",
+			},
+		}
 
 		scheme, _ := k8s.NewScheme()
 		k8sClient = ctrl_client_fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		reconciler = cni.NewReconciler(azClient, k8sClient, recorder, &azure.CloudProviderConfig{
+			SubscriptionID:          "test-sub",
+			RouteTableResourceGroup: "test-rg",
+			RouteTableName:          "test-rt",
+		}, appGw, agicPod, "test", false)
 	})
 
 	Context("reconcileKubenetCniIfNeeded", func() {
@@ -48,12 +75,8 @@ var _ = Describe("Kubenet CNI", func() {
 				return nil
 			}
 
-			err := cni.ReconcileCNI(ctx, azClient, k8sClient, "test", &azure.CloudProviderConfig{
-				SubscriptionID:          "test-sub",
-				RouteTableResourceGroup: "test-rg",
-				RouteTableName:          "test-rt",
-			}, appGw, false)
-			Expect(err).To(BeNil())
+			reconciler.Reconcile(ctx)
+			Eventually(recorder.Events).ShouldNot(Receive())
 		})
 
 		It("should return nil if RouteTableName is empty", func() {
@@ -62,10 +85,26 @@ var _ = Describe("Kubenet CNI", func() {
 				return nil
 			}
 
-			err := cni.ReconcileCNI(ctx, azClient, k8sClient, "test", &azure.CloudProviderConfig{
-				RouteTableName: "",
-			}, appGw, false)
-			Expect(err).To(BeNil())
+			reconciler = cni.NewReconciler(azClient, k8sClient, recorder, &azure.CloudProviderConfig{
+				SubscriptionID: "test-sub",
+			}, appGw, agicPod, "test", false)
+
+			err := reconciler.Reconcile(ctx)
+			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("should create event if ApplyRouteTable fails", func() {
+			azClient.ApplyRouteTableFunc = func(subnetID string, routeTableID string) error {
+				return errors.New("failed to apply route table")
+			}
+
+			err := reconciler.Reconcile(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to apply route table"))
+		})
+	})
+
+	AfterEach(func() {
+		cancel()
 	})
 })

--- a/pkg/cni/overlay.go
+++ b/pkg/cni/overlay.go
@@ -2,6 +2,7 @@ package cni
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	nodenetworkconfig_v1alpha "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
@@ -129,9 +130,12 @@ func (r *Reconciler) checkOverlayExtensionConfigStatus(ctx context.Context) erro
 			return false, errors.Wrap(err, "failed to get overlay extension config")
 		}
 
-		if config.Status.State == overlayextensionconfig_v1alpha1.Succeeded {
+		switch config.Status.State {
+		case overlayextensionconfig_v1alpha1.Succeeded:
 			klog.Infof("Overlay extension config is ready")
 			return true, nil
+		case overlayextensionconfig_v1alpha1.Failed:
+			return true, fmt.Errorf("overlay extension config failed with error: %s", config.Status.Message)
 		}
 
 		klog.Infof("Waiting for overlay extension config to be ready")

--- a/pkg/cni/overlay.go
+++ b/pkg/cni/overlay.go
@@ -33,6 +33,10 @@ const (
 )
 
 func (r *Reconciler) reconcileOverlayCniIfNeeded(ctx context.Context, subnetID string) error {
+	if r.reconciledOverlayCNI {
+		return nil
+	}
+
 	isOverlay, err := r.isClusterOverlayCNI(ctx)
 	if err != nil {
 		return errors.New("failed to check if cluster is using overlay CNI")
@@ -54,6 +58,7 @@ func (r *Reconciler) reconcileOverlayCniIfNeeded(ctx context.Context, subnetID s
 		return errors.Wrap(err, "failed to reconcile overlay resources")
 	}
 
+	r.reconciledOverlayCNI = true
 	return nil
 }
 

--- a/pkg/cni/overlay.go
+++ b/pkg/cni/overlay.go
@@ -15,10 +15,6 @@ import (
 )
 
 const (
-	ErrClusterNotUsingOverlayCNI = "failed to check if cluster is using overlay CNI"
-)
-
-const (
 	ResourceManagedByLabel      = "app.kubernetes.io/managed-by"
 	ResourceManagedByAddonValue = "ingress-appgw-addon"
 	ResourceManagedByHelmValue  = "ingress-appgw-helm"
@@ -38,7 +34,7 @@ const (
 func (r *Reconciler) reconcileOverlayCniIfNeeded(ctx context.Context, subnetID string) error {
 	isOverlay, err := r.isClusterOverlayCNI(ctx)
 	if err != nil {
-		return errors.Wrap(err, ErrClusterNotUsingOverlayCNI)
+		return errors.New("failed to check if cluster is using overlay CNI")
 	}
 
 	if !isOverlay {

--- a/pkg/cni/overlay.go
+++ b/pkg/cni/overlay.go
@@ -112,6 +112,10 @@ func (r *Reconciler) reconcileOverlayExtensionConfig(ctx context.Context, subnet
 		return r.checkOverlayExtensionConfigStatus(ctx)
 	}
 
+	if config.Spec.ExtensionIPRange == subnetCIDR {
+		return r.checkOverlayExtensionConfigStatus(ctx)
+	}
+
 	config.Spec.ExtensionIPRange = subnetCIDR
 	klog.Infof("Updating overlay extension config with subnet CIDR %s", subnetCIDR)
 	err := r.client.Update(ctx, &config)

--- a/pkg/cni/overlay_test.go
+++ b/pkg/cni/overlay_test.go
@@ -3,12 +3,15 @@ package cni_test
 import (
 	"context"
 	"errors"
+	"time"
 
 	nodenetworkconfig_v1alpha "github.com/Azure/azure-container-networking/crd/nodenetworkconfig/api/v1alpha"
 	overlayextensionconfig_v1alpha1 "github.com/Azure/azure-container-networking/crd/overlayextensionconfig/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	ctrl_client "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl_client_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -20,93 +23,114 @@ import (
 )
 
 var _ = Describe("Overlay CNI", func() {
-	var ctx = context.TODO()
-	var azClient *azure.FakeAzClient
-	var k8sClient ctrl_client.Client
-	var namespace = "test-namespace"
-	var subnetCIDR = "10.0.0.0/16"
-	var appGw = n.ApplicationGateway{
-		ApplicationGatewayPropertiesFormat: &n.ApplicationGatewayPropertiesFormat{
-			GatewayIPConfigurations: &[]n.ApplicationGatewayIPConfiguration{
-				{
-					ApplicationGatewayIPConfigurationPropertiesFormat: &n.ApplicationGatewayIPConfigurationPropertiesFormat{
-						Subnet: &n.SubResource{
-							ID: to.StringPtr("subnet-id"),
-						},
-					},
-				},
-			},
-		},
-	}
+	var (
+		ctx        context.Context
+		cancel     context.CancelFunc
+		azClient   *azure.FakeAzClient
+		k8sClient  ctrl_client.Client
+		recorder   *record.FakeRecorder
+		agicPod    *v1.Pod
+		namespace  = "test-namespace"
+		subnetCIDR = "10.0.0.0/16"
+		appGw      n.ApplicationGateway
+		reconciler *cni.Reconciler
+	)
 
 	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
 		azClient = azure.NewFakeAzClient()
-		azClient.ApplyRouteTableFunc = func(subnetID string, routeTableID string) error {
+		azClient.ApplyRouteTableFunc = func(subnetID, routeTableID string) error {
 			Fail("ApplyRouteTable should not be called")
 			return nil
 		}
 
 		scheme, _ := k8s.NewScheme()
 		k8sClient = ctrl_client_fake.NewClientBuilder().WithScheme(scheme).Build()
-
-		config := &nodenetworkconfig_v1alpha.NodeNetworkConfig{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name:      "test-node-network-config",
-				Namespace: namespace,
-			},
-			Spec: nodenetworkconfig_v1alpha.NodeNetworkConfigSpec{},
+		recorder = record.NewFakeRecorder(100)
+		recorder.IncludeObject = true
+		agicPod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "agic", Namespace: "kube-system"},
+			TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
 		}
-		err := k8sClient.Create(ctx, config)
-		Expect(err).To(BeNil())
+
+		appGw = n.ApplicationGateway{
+			ApplicationGatewayPropertiesFormat: &n.ApplicationGatewayPropertiesFormat{
+				GatewayIPConfigurations: &[]n.ApplicationGatewayIPConfiguration{
+					{
+						ApplicationGatewayIPConfigurationPropertiesFormat: &n.ApplicationGatewayIPConfigurationPropertiesFormat{
+							Subnet: &n.SubResource{ID: to.StringPtr("subnet-id")},
+						},
+					},
+				},
+			},
+		}
+
+		reconciler = cni.NewReconciler(azClient, k8sClient, recorder, &azure.CloudProviderConfig{
+			SubscriptionID: "test-sub",
+		}, appGw, agicPod, namespace, false)
 	})
 
-	Context("reconcileOverlayCniIfNeeded", func() {
-		It("should create overlay extension config with addon if controller is addon", func() {
-			azClient.GetSubnetFunc = func(subnetID string) (n.Subnet, error) {
-				return n.Subnet{
-					SubnetPropertiesFormat: &n.SubnetPropertiesFormat{
-						AddressPrefix: to.StringPtr(subnetCIDR),
-					},
-				}, nil
+	Context("Handle Overlay CNI cluster", func() {
+		BeforeEach(func() {
+			// Create NodeNetworkConfig so that cluster is considered as overlay CNI
+			config := &nodenetworkconfig_v1alpha.NodeNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-node-network-config", Namespace: namespace},
+				Spec:       nodenetworkconfig_v1alpha.NodeNetworkConfigSpec{},
 			}
+			Expect(k8sClient.Create(ctx, config)).To(BeNil())
 
-			err := cni.ReconcileCNI(context.TODO(), azClient, k8sClient, namespace, nil, appGw, true)
-			Expect(err).To(BeNil())
+			// Run a goroutine to update the status of
+			// OverlayExtensionConfig to Succeeded.
+			go func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-time.After(1 * time.Second):
+						var config overlayextensionconfig_v1alpha1.OverlayExtensionConfig
+						if err := k8sClient.Get(ctx, ctrl_client.ObjectKey{Name: cni.OverlayExtensionConfigName, Namespace: namespace}, &config); err != nil {
+							continue
+						}
 
-			var config overlayextensionconfig_v1alpha1.OverlayExtensionConfig
-			err = k8sClient.Get(ctx, ctrl_client.ObjectKey{
-				Name:      cni.OverlayExtensionConfigName,
-				Namespace: namespace,
-			}, &config)
-			Expect(err).To(BeNil())
-
-			Expect(config.Labels).To(HaveLen(1))
-			Expect(config.Labels[cni.ResourceManagedByLabel]).To(Equal(cni.ResourceManagedByAddonValue))
-			Expect(config.Spec.ExtensionIPRange).To(Equal(subnetCIDR))
+						config.Status.State = overlayextensionconfig_v1alpha1.Succeeded
+						_ = k8sClient.Update(ctx, &config)
+						return
+					}
+				}
+			}()
 		})
 
-		It("should create overlay extension config with addon if controller is addon", func() {
-			azClient.GetSubnetFunc = func(subnetID string) (n.Subnet, error) {
-				return n.Subnet{
-					SubnetPropertiesFormat: &n.SubnetPropertiesFormat{
-						AddressPrefix: to.StringPtr(subnetCIDR),
-					},
-				}, nil
-			}
+		When("OEC doesn't exist", func() {
+			BeforeEach(func() {
+				azClient.GetSubnetFunc = func(subnetID string) (n.Subnet, error) {
+					return n.Subnet{SubnetPropertiesFormat: &n.SubnetPropertiesFormat{AddressPrefix: to.StringPtr(subnetCIDR)}}, nil
+				}
+			})
 
-			err := cni.ReconcileCNI(context.TODO(), azClient, k8sClient, namespace, nil, appGw, false)
-			Expect(err).To(BeNil())
+			It("should create overlay extension config with Helm", func() {
+				Expect(reconciler.Reconcile(ctx)).To(BeNil())
 
-			var config overlayextensionconfig_v1alpha1.OverlayExtensionConfig
-			err = k8sClient.Get(ctx, ctrl_client.ObjectKey{
-				Name:      cni.OverlayExtensionConfigName,
-				Namespace: namespace,
-			}, &config)
-			Expect(err).To(BeNil())
+				var config overlayextensionconfig_v1alpha1.OverlayExtensionConfig
+				Expect(k8sClient.Get(ctx, ctrl_client.ObjectKey{Name: cni.OverlayExtensionConfigName, Namespace: namespace}, &config)).To(BeNil())
+				Expect(config.Labels).To(HaveLen(1))
+				Expect(config.Labels[cni.ResourceManagedByLabel]).To(Equal(cni.ResourceManagedByHelmValue))
+				Expect(config.Spec.ExtensionIPRange).To(Equal(subnetCIDR))
+			})
 
-			Expect(config.Labels).To(HaveLen(1))
-			Expect(config.Labels[cni.ResourceManagedByLabel]).To(Equal(cni.ResourceManagedByHelmValue))
-			Expect(config.Spec.ExtensionIPRange).To(Equal(subnetCIDR))
+			It("should create overlay extension config with addon", func() {
+				// Create a new reconciler with addonMode set to true
+				reconciler = cni.NewReconciler(azClient, k8sClient, recorder, &azure.CloudProviderConfig{
+					SubscriptionID: "test-sub",
+				}, appGw, agicPod, namespace, true)
+
+				Expect(reconciler.Reconcile(ctx)).To(BeNil())
+
+				var config overlayextensionconfig_v1alpha1.OverlayExtensionConfig
+				Expect(k8sClient.Get(ctx, ctrl_client.ObjectKey{Name: cni.OverlayExtensionConfigName, Namespace: namespace}, &config)).To(BeNil())
+				Expect(config.Labels).To(HaveLen(1))
+				Expect(config.Labels[cni.ResourceManagedByLabel]).To(Equal(cni.ResourceManagedByAddonValue))
+				Expect(config.Spec.ExtensionIPRange).To(Equal(subnetCIDR))
+			})
 		})
 
 		It("should return error if failed to get subnet", func() {
@@ -114,8 +138,53 @@ var _ = Describe("Overlay CNI", func() {
 				return n.Subnet{}, errors.New("failed to get subnet")
 			}
 
-			err := cni.ReconcileCNI(context.TODO(), azClient, k8sClient, namespace, nil, appGw, false)
-			Expect(err).ToNot(BeNil())
+			err := reconciler.Reconcile(ctx)
+			Expect(err).To(Not(BeNil()))
+			Expect(err.Error()).To(ContainSubstring("failed to get subnet"))
 		})
+	})
+
+	When("a non-overlay cluster is upgraded to Overlay CNI", func() {
+		BeforeEach(func() {
+			azClient.GetSubnetFunc = func(subnetID string) (n.Subnet, error) {
+				return n.Subnet{SubnetPropertiesFormat: &n.SubnetPropertiesFormat{AddressPrefix: to.StringPtr(subnetCIDR)}}, nil
+			}
+
+			go func() {
+				for {
+					var config overlayextensionconfig_v1alpha1.OverlayExtensionConfig
+					if err := k8sClient.Get(ctx, ctrl_client.ObjectKey{Name: cni.OverlayExtensionConfigName, Namespace: namespace}, &config); err != nil {
+						time.Sleep(1 * time.Second)
+						continue
+					}
+					config.Status.State = overlayextensionconfig_v1alpha1.Succeeded
+					_ = k8sClient.Update(ctx, &config)
+					break
+				}
+			}()
+		})
+
+		It("should create overlay extension config eventually", func() {
+			Expect(reconciler.Reconcile(ctx)).To(BeNil())
+
+			// It should not create OverlayExtensionConfig as the cluster is not overlay CNI
+			var config overlayextensionconfig_v1alpha1.OverlayExtensionConfig
+			Expect(k8sClient.Get(ctx, ctrl_client.ObjectKey{Name: cni.OverlayExtensionConfigName, Namespace: namespace}, &config)).To(Not(BeNil()))
+
+			// Create NodeNetworkConfig so that cluster is considered as overlay CNI
+			Expect(k8sClient.Create(ctx, &nodenetworkconfig_v1alpha.NodeNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-node-network-config", Namespace: namespace},
+				Spec:       nodenetworkconfig_v1alpha.NodeNetworkConfigSpec{},
+			})).To(BeNil())
+
+			Expect(reconciler.Reconcile(ctx)).To(BeNil())
+
+			// It should create OverlayExtensionConfig as the cluster is overlay CNI
+			Expect(k8sClient.Get(ctx, ctrl_client.ObjectKey{Name: cni.OverlayExtensionConfigName, Namespace: namespace}, &config)).To(BeNil())
+		})
+	})
+
+	AfterEach(func() {
+		cancel()
 	})
 })

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -119,7 +119,7 @@ func (c *AppGwIngressController) Readiness() bool {
 func (c *AppGwIngressController) ProcessEvent(event events.Event) error {
 	processEventStart := time.Now()
 
-	err := c.cniReconciler.Reconcile((context.Background()))
+	err := c.cniReconciler.Reconcile(context.Background())
 	if err != nil {
 		// Not treated as fatal errors, but we log them and emit a warning event.
 		if c.agicPod != nil {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -26,14 +26,13 @@ import (
 )
 
 var _ = Describe("test NewAppGwIngressController", func() {
-
 	Context("ensure NewAppGwIngressController works as expected", func() {
 		azClient := azure.NewFakeAzClient()
 		appGwIdentifier := appgw.Identifier{}
 		metricStore := metricstore.NewFakeMetricStore()
 		k8sContext := &k8scontext.Context{MetricStore: metricStore}
 		recorder := record.NewFakeRecorder(0)
-		controller := NewAppGwIngressController(azClient, appGwIdentifier, k8sContext, recorder, metricStore, nil, false)
+		controller := NewAppGwIngressController(azClient, appGwIdentifier, k8sContext, recorder, metricStore, nil, nil, false)
 		It("should have created the AppGwIngressController struct", func() {
 			err := controller.Start(environment.GetFakeEnv())
 			Expect(err).To(HaveOccurred())
@@ -57,7 +56,7 @@ var _ = Describe("test NewAppGwIngressController", func() {
 			azClient := azure.NewFakeAzClient()
 			appGwIdentifier := appgw.Identifier{}
 			recorder := record.NewFakeRecorder(0)
-			controller = NewAppGwIngressController(azClient, appGwIdentifier, k8sContext, recorder, metricstore.NewFakeMetricStore(), nil, false)
+			controller = NewAppGwIngressController(azClient, appGwIdentifier, k8sContext, recorder, metricstore.NewFakeMetricStore(), nil, nil, false)
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
This PR
* runs the CNI reconciler during the config building instead just during bootup. This enables supporting cluster upgrades.
* waits for OEC to reach terminal state before moving forward.
* re-creates OEC if subnet changes

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
