### PR TITLE
Move overlay cleanup to code

### DIFF
--- a/cmd/appgw-ingress/main.go
+++ b/cmd/appgw-ingress/main.go
@@ -56,6 +56,7 @@ var (
 	resyncPeriod   = flags.Duration("sync-period", resyncPause, "Interval at which to re-list and confirm cloud resources.")
 	versionInfo    = flags.Bool("version", false, "Print version")
 	verbosity      = flags.Int(verbosityFlag, 1, "Set logging verbosity level")
+	cleanupOEC     = flags.Bool("cleanup-oec", false, "Cleanup OverlayExtensionConfig resources")
 )
 
 var allowedSkus = map[n.ApplicationGatewayTier]interface{}{
@@ -103,6 +104,14 @@ func main() {
 	})
 	if err != nil {
 		klog.Fatalf("Failed to create controller-runtime client: %v", err)
+	}
+
+	if *cleanupOEC {
+		if err := cni.CleanupOverlayExtensionConfigs(ctrlClient, env.AGICPodNamespace, env.AddonMode); err != nil {
+			klog.Fatalf("Failed to cleanup OverlayExtensionConfig resources: %v", err)
+		}
+		klog.Info("Successfully cleaned up OverlayExtensionConfig resources")
+		return
 	}
 
 	kubeClient := kubernetes.NewForConfigOrDie(apiConfig)

--- a/helm/ingress-azure/templates/cleanup-job.yaml
+++ b/helm/ingress-azure/templates/cleanup-job.yaml
@@ -17,22 +17,16 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: cleanup
-        image: "mcr.microsoft.com/oss/kubernetes/kubectl:v1.30.5"
-        imagePullPolicy: IfNotPresent
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: AGIC_POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         command:
-          - "kubectl"
-          - "delete"
-          - "--ignore-not-found"
-          - "--wait"
-          - "-n"
-          - "$(AGIC_POD_NAMESPACE)"
-          - "overlayextensionconfigs.acn.azure.com"
-          - "-l"
+          - "/appgw-ingress"
+          - "--cleanup-oec"
 {{- if .Values.addon }}
           - "app.kubernetes.io/managed-by=ingress-appgw-addon"
 {{- else }}

--- a/helm/ingress-azure/tests/snapshots/sample-config-addon/ingress-azure/templates/cleanup-job.yaml
+++ b/helm/ingress-azure/tests/snapshots/sample-config-addon/ingress-azure/templates/cleanup-job.yaml
@@ -19,22 +19,16 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: cleanup
-        image: "mcr.microsoft.com/oss/kubernetes/kubectl:v1.30.5"
-        imagePullPolicy: IfNotPresent
+        image: mcr.microsoft.com/azure-application-gateway/kubernetes-ingress:1.6.0
+        imagePullPolicy: Always
         env:
         - name: AGIC_POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         command:
-          - "kubectl"
-          - "delete"
-          - "--ignore-not-found"
-          - "--wait"
-          - "-n"
-          - "$(AGIC_POD_NAMESPACE)"
-          - "overlayextensionconfigs.acn.azure.com"
-          - "-l"
+          - "/appgw-ingress"
+          - "--cleanup-oec"
           - "app.kubernetes.io/managed-by=ingress-appgw-addon"
         securityContext:
           capabilities:

--- a/helm/ingress-azure/tests/snapshots/sample-config-empty/ingress-azure/templates/cleanup-job.yaml
+++ b/helm/ingress-azure/tests/snapshots/sample-config-empty/ingress-azure/templates/cleanup-job.yaml
@@ -19,22 +19,16 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: cleanup
-        image: "mcr.microsoft.com/oss/kubernetes/kubectl:v1.30.5"
-        imagePullPolicy: IfNotPresent
+        image: mcr.microsoft.com/azure-application-gateway/kubernetes-ingress:1.6.0
+        imagePullPolicy: Always
         env:
         - name: AGIC_POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         command:
-          - "kubectl"
-          - "delete"
-          - "--ignore-not-found"
-          - "--wait"
-          - "-n"
-          - "$(AGIC_POD_NAMESPACE)"
-          - "overlayextensionconfigs.acn.azure.com"
-          - "-l"
+          - "/appgw-ingress"
+          - "--cleanup-oec"
           - "app.kubernetes.io/managed-by=ingress-appgw-helm"
         securityContext:
           capabilities:

--- a/helm/ingress-azure/tests/snapshots/sample-config-existing-secret/ingress-azure/templates/cleanup-job.yaml
+++ b/helm/ingress-azure/tests/snapshots/sample-config-existing-secret/ingress-azure/templates/cleanup-job.yaml
@@ -19,22 +19,16 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: cleanup
-        image: "mcr.microsoft.com/oss/kubernetes/kubectl:v1.30.5"
-        imagePullPolicy: IfNotPresent
+        image: mcr.microsoft.com/azure-application-gateway/kubernetes-ingress:1.6.0
+        imagePullPolicy: Always
         env:
         - name: AGIC_POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         command:
-          - "kubectl"
-          - "delete"
-          - "--ignore-not-found"
-          - "--wait"
-          - "-n"
-          - "$(AGIC_POD_NAMESPACE)"
-          - "overlayextensionconfigs.acn.azure.com"
-          - "-l"
+          - "/appgw-ingress"
+          - "--cleanup-oec"
           - "app.kubernetes.io/managed-by=ingress-appgw-helm"
         securityContext:
           capabilities:

--- a/helm/ingress-azure/tests/snapshots/sample-config-prohibited-target/ingress-azure/templates/cleanup-job.yaml
+++ b/helm/ingress-azure/tests/snapshots/sample-config-prohibited-target/ingress-azure/templates/cleanup-job.yaml
@@ -19,22 +19,16 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: cleanup
-        image: "mcr.microsoft.com/oss/kubernetes/kubectl:v1.30.5"
-        imagePullPolicy: IfNotPresent
+        image: mcr.microsoft.com/azure-application-gateway/kubernetes-ingress:1.6.0
+        imagePullPolicy: Always
         env:
         - name: AGIC_POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         command:
-          - "kubectl"
-          - "delete"
-          - "--ignore-not-found"
-          - "--wait"
-          - "-n"
-          - "$(AGIC_POD_NAMESPACE)"
-          - "overlayextensionconfigs.acn.azure.com"
-          - "-l"
+          - "/appgw-ingress"
+          - "--cleanup-oec"
           - "app.kubernetes.io/managed-by=ingress-appgw-helm"
         securityContext:
           capabilities:

--- a/helm/ingress-azure/tests/snapshots/sample-config-workload-identity/ingress-azure/templates/cleanup-job.yaml
+++ b/helm/ingress-azure/tests/snapshots/sample-config-workload-identity/ingress-azure/templates/cleanup-job.yaml
@@ -19,22 +19,16 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: cleanup
-        image: "mcr.microsoft.com/oss/kubernetes/kubectl:v1.30.5"
-        imagePullPolicy: IfNotPresent
+        image: mcr.microsoft.com/azure-application-gateway/kubernetes-ingress:1.6.0
+        imagePullPolicy: Always
         env:
         - name: AGIC_POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         command:
-          - "kubectl"
-          - "delete"
-          - "--ignore-not-found"
-          - "--wait"
-          - "-n"
-          - "$(AGIC_POD_NAMESPACE)"
-          - "overlayextensionconfigs.acn.azure.com"
-          - "-l"
+          - "/appgw-ingress"
+          - "--cleanup-oec"
           - "app.kubernetes.io/managed-by=ingress-appgw-helm"
         securityContext:
           capabilities:

--- a/helm/ingress-azure/tests/snapshots/sample-config/ingress-azure/templates/cleanup-job.yaml
+++ b/helm/ingress-azure/tests/snapshots/sample-config/ingress-azure/templates/cleanup-job.yaml
@@ -19,22 +19,16 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: cleanup
-        image: "mcr.microsoft.com/oss/kubernetes/kubectl:v1.30.5"
-        imagePullPolicy: IfNotPresent
+        image: mcr.microsoft.com/azure-application-gateway/kubernetes-ingress:1.6.0
+        imagePullPolicy: Always
         env:
         - name: AGIC_POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         command:
-          - "kubectl"
-          - "delete"
-          - "--ignore-not-found"
-          - "--wait"
-          - "-n"
-          - "$(AGIC_POD_NAMESPACE)"
-          - "overlayextensionconfigs.acn.azure.com"
-          - "-l"
+          - "/appgw-ingress"
+          - "--cleanup-oec"
           - "app.kubernetes.io/managed-by=ingress-appgw-helm"
         securityContext:
           capabilities:

--- a/pkg/cni/cleanup.go
+++ b/pkg/cni/cleanup.go
@@ -1,0 +1,68 @@
+package cni
+
+import (
+	"context"
+
+	overlayv1alpha1 "github.com/Azure/azure-container-networking/crd/overlayextensionconfig/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CleanupOverlayExtensionConfigs(k8sClient client.Client, namespace string, addonMode bool) error {
+	// Define a label selector for filtering the resources to delete.
+	managedByValue := ResourceManagedByHelmValue
+	if addonMode {
+		managedByValue = ResourceManagedByAddonValue
+	}
+
+	// Perform cleanup of OverlayExtensionConfig resources.
+	if err := cleanupOverlayExtensionConfigs(k8sClient, namespace, managedByValue); err != nil {
+		klog.Errorf("Error cleaning up OverlayExtensionConfig resources: %v", err)
+		return err
+	}
+
+	klog.Infof("Cleanup completed successfully.")
+	return nil
+}
+
+// cleanupOverlayExtensionConfigs lists and deletes OverlayExtensionConfig resources in the given namespace
+// that match the provided label selector. If the CRD is not present, it logs a warning and returns nil.
+func cleanupOverlayExtensionConfigs(c client.Client, namespace string, label string) error {
+	ctx := context.Background()
+
+	// Create an empty list to hold OverlayExtensionConfig resources.
+	var overlayList overlayv1alpha1.OverlayExtensionConfigList
+
+	// List the resources with the provided namespace and label selector.
+	if err := c.List(ctx, &overlayList,
+		client.InNamespace(namespace),
+		client.MatchingLabels(map[string]string{ResourceManagedByLabel: label})); err != nil {
+		// If the API server does not recognize the CRD, skip cleanup.
+		if meta.IsNoMatchError(err) {
+			klog.Warning("CRD OverlayExtensionConfig not found in the cluster. Skipping cleanup.")
+			return nil
+		}
+		return err
+	}
+
+	// If no resources are found, log and exit.
+	if len(overlayList.Items) == 0 {
+		klog.Infof("No OverlayExtensionConfig resources found in namespace %q with labels %q", namespace, label)
+		return nil
+	}
+
+	// Iterate through and delete each OverlayExtensionConfig resource.
+	var deletionError error
+	for _, item := range overlayList.Items {
+		klog.Infof("Deleting OverlayExtensionConfig: %q", item.Name)
+		if err := c.Delete(ctx, &item, &client.DeleteOptions{}); err != nil {
+			klog.Errorf("Error deleting resource %q: %v", item.Name, err)
+			deletionError = err
+		} else {
+			klog.Infof("Successfully deleted resource %q", item.Name)
+		}
+	}
+
+	return deletionError
+}

--- a/pkg/cni/cleanup_test.go
+++ b/pkg/cni/cleanup_test.go
@@ -1,0 +1,149 @@
+package cni_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/cni"
+	overlayv1alpha1 "github.com/Azure/azure-container-networking/crd/overlayextensionconfig/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CleanupOverlayExtensionConfigs", func() {
+	var (
+		scheme    *runtime.Scheme
+		namespace string
+		label     string
+	)
+
+	BeforeEach(func() {
+		namespace = "default"
+		// Use the Helm-managed value as default.
+		label = cni.ResourceManagedByHelmValue
+
+		scheme = runtime.NewScheme()
+		err := overlayv1alpha1.AddToScheme(scheme)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when the CRD is not present", func() {
+		It("should log a warning and succeed", func() {
+			// Use a fake client that simulates a NoMatch error during List.
+			fakeClient := &FakeClient{
+				ListFunc: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					// Simulate that the API server does not recognize the CRD.
+					return &meta.NoResourceMatchError{
+						PartialResource: schema.GroupVersionResource{Group: "acn.azure.com", Resource: "overlayextensionconfigs"},
+					}
+				},
+			}
+
+			err := cni.CleanupOverlayExtensionConfigs(fakeClient, namespace, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when no OverlayExtensionConfig resources are found", func() {
+		It("should succeed without deleting anything", func() {
+			// Build a fake client with no objects.
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			err := cni.CleanupOverlayExtensionConfigs(k8sClient, namespace, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when OverlayExtensionConfig resources are present", func() {
+		const resourceName = "test-resource"
+		var k8sClient client.Client
+		BeforeEach(func() {
+			// Create a resource with the expected label.
+			resource := &overlayv1alpha1.OverlayExtensionConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						cni.ResourceManagedByLabel: label,
+					},
+				},
+			}
+			// Build the fake client with this object.
+			k8sClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(resource).Build()
+		})
+
+		It("should delete the resource successfully", func() {
+			err := cni.CleanupOverlayExtensionConfigs(k8sClient, namespace, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify that the resource was deleted by attempting to get it.
+			retrieved := &overlayv1alpha1.OverlayExtensionConfig{}
+			err = k8sClient.Get(context.Background(), client.ObjectKey{Name: resourceName, Namespace: namespace}, retrieved)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("when deletion fails", func() {
+		It("should return an error", func() {
+			// Use a fake client that returns an error when Delete is called.
+			fakeClient := &FakeClient{
+				ListFunc: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					// Populate the list with one resource.
+					overlayList, ok := list.(*overlayv1alpha1.OverlayExtensionConfigList)
+					if !ok {
+						return fmt.Errorf("unexpected type")
+					}
+					overlayList.Items = []overlayv1alpha1.OverlayExtensionConfig{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "fail-resource",
+								Namespace: namespace,
+								Labels: map[string]string{
+									cni.ResourceManagedByLabel: label,
+								},
+							},
+						},
+					}
+					return nil
+				},
+				DeleteFunc: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+					return errors.New("deletion error")
+				},
+			}
+
+			err := cni.CleanupOverlayExtensionConfigs(fakeClient, namespace, false)
+			Expect(err).To(MatchError("deletion error"))
+		})
+	})
+})
+
+// FakeClient implements client.Client for testing purposes.
+// We only implement the List and Delete methods.
+type FakeClient struct {
+	client.Client
+
+	ListFunc   func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
+	DeleteFunc func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error
+}
+
+func (f *FakeClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if f.ListFunc != nil {
+		return f.ListFunc(ctx, list, opts...)
+	}
+	return nil
+}
+
+func (f *FakeClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if f.DeleteFunc != nil {
+		return f.DeleteFunc(ctx, obj, opts...)
+	}
+	return nil
+}


### PR DESCRIPTION
## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

This PR moves the cleanup logic from directly using kubectl to moving it inside agic binary. This allows for more complicated cleanup logic which doesn't fail in non-overlay clusters.

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
