### PR TITLE
Fix helm lint error with multiple AzureIngressProhibitedTarget CRDs

### DIFF
--- a/helm/ingress-azure/templates/crds.yaml
+++ b/helm/ingress-azure/templates/crds.yaml
@@ -10,7 +10,7 @@ spec:
   paths:
     - /*
 {{- end -}}
-{{- range .Values.appgw.prohibitedTargets -}}
+{{- range .Values.appgw.prohibitedTargets }}
 apiVersion: appgw.ingress.k8s.io/v1
 kind: AzureIngressProhibitedTarget
 metadata:

--- a/helm/ingress-azure/tests/fixtures/sample-config-prohibited-target.json
+++ b/helm/ingress-azure/tests/fixtures/sample-config-prohibited-target.json
@@ -12,6 +12,12 @@
                 "paths": [
                     "/blacklist/*"
                 ]
+            },
+            {
+                "name": "prohibit-another-backend-ns",
+                "paths": [
+                    "/deny/*"
+                ]
             }
         ]
     },

--- a/helm/ingress-azure/tests/snapshots/sample-config-prohibited-target/ingress-azure/templates/crds.yaml
+++ b/helm/ingress-azure/tests/snapshots/sample-config-prohibited-target/ingress-azure/templates/crds.yaml
@@ -7,3 +7,12 @@ metadata:
 spec:
   paths:
   - /blacklist/*
+---
+# Source: ingress-azure/templates/crds.yaml
+apiVersion: appgw.ingress.k8s.io/v1
+kind: AzureIngressProhibitedTarget
+metadata:
+  name: prohibit-another-backend-ns
+spec:
+  paths:
+  - /deny/*


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

If `.Values.appgw.prohibitedTargets` contains more than one element, `helm lint` (v3.7) fails with:
> [ERROR] templates/crds.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: appgw.ingress.k8s.io/v1

See for more info: https://github.com/helm/helm/issues/10149#issuecomment-929205040

I updated the snapshot test case and regenerated the output with:
```bash
$ cd helm/ingress-azure/tests
$ rm -rf snapshots/ && RENDER_SNAPSHOTS=true go test chart_test.go snapshots.go
```

## Fixes

Could not find any.
