### PR TITLE
Bumped the version of Go used in builds to 1.24.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GO_BINARY_NAME ?= appgw-ingress
 GOOS ?= linux
 GARCH ?= arm64
 
-BUILD_BASE_IMAGE ?= golang:1.23.6-bookworm
+BUILD_BASE_IMAGE ?= golang:1.24.4-bookworm
 BINARY_BASE_IMAGE ?= mcr.microsoft.com/cbl-mariner/distroless/base:2.0
 
 REPO ?= appgwreg.azurecr.io


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

Updates the version of go used by `make build-image` and `make build-image-multi-arch` to the latest (1.24.4).
Patches some CVEs present in the current version of the Go stdlib being used.