### PR TITLE
Add hostnameRegex support to AzureIngressProhibitedTarget CRDs

### DIFF
--- a/crds/AzureIngressProhibitedTarget-v1-CRD-v1.yaml
+++ b/crds/AzureIngressProhibitedTarget-v1-CRD-v1.yaml
@@ -24,6 +24,9 @@ spec:
                 hostname:
                   description: "(optional) Hostname of the prohibited target"
                   type: string
+                hostnameRegex:
+                  description: "(optional) Regex pattern for matching hostnames. Takes precedence over hostname field if both are set."
+                  type: string
                 paths:
                   description: "(optional) A list of URL paths, for which the Ingress Controller is prohibited from mutating Application Gateway configuration; Must begin with a / and end with /*"
                   type: array

--- a/crds/AzureIngressProhibitedTarget-v1-CRD-v1beta1.yaml
+++ b/crds/AzureIngressProhibitedTarget-v1-CRD-v1beta1.yaml
@@ -17,6 +17,9 @@ spec:
             hostname:
               description: "(optional) Hostname of the prohibited target"
               type: string
+            hostnameRegex:
+              description: "(optional) Regex pattern for matching hostnames. Takes precedence over hostname field if both are set."
+              type: string
             paths:
               description: "(optional) A list of URL paths, for which the Ingress Controller is prohibited from mutating Application Gateway configuration; Must begin with a / and end with /*"
               type: array

--- a/crds/examples/AzureIngressProhibitedTarget-regex.yaml
+++ b/crds/examples/AzureIngressProhibitedTarget-regex.yaml
@@ -1,0 +1,53 @@
+# Example: AzureIngressProhibitedTarget with regex pattern matching
+# This example demonstrates how to use the hostnameRegex field to match multiple hostnames
+# using regular expression patterns instead of exact string matching.
+
+apiVersion: "appgw.ingress.k8s.io/v1"
+kind: AzureIngressProhibitedTarget
+metadata:
+  name: prohibited-staging-environments
+spec:
+  # Match all subdomains under *.staging.example.com
+  # This will prohibit: dev.staging.example.com, api.staging.example.com, etc.
+  hostnameRegex: "^.*\\.staging\\.example\\.com$"
+  paths:
+    - "/admin/*"
+    - "/internal/*"
+---
+apiVersion: "appgw.ingress.k8s.io/v1"
+kind: AzureIngressProhibitedTarget
+metadata:
+  name: prohibited-test-environments
+spec:
+  # Match all test and qa environments across any domain
+  # This will prohibit: test.example.com, test-api.example.com, qa.example.com, qa-api.example.com
+  hostnameRegex: "^(test|qa).*\\.example\\.com$"
+---
+apiVersion: "appgw.ingress.k8s.io/v1"
+kind: AzureIngressProhibitedTarget
+metadata:
+  name: prohibited-legacy-system
+spec:
+  # Exact hostname can still be used (backward compatible)
+  hostname: "legacy.contoso.com"
+  paths:
+    - "/old-api/*"
+---
+apiVersion: "appgw.ingress.k8s.io/v1"
+kind: AzureIngressProhibitedTarget
+metadata:
+  name: prohibited-internal-services
+spec:
+  # Match any hostname ending with .internal
+  # This will prohibit: api.internal, db.internal, cache.internal, etc.
+  hostnameRegex: "^.*\\.internal$"
+
+# Notes:
+# 1. hostnameRegex takes precedence over hostname if both are specified
+# 2. Regex patterns are case-insensitive by default
+# 3. Use standard Go regexp syntax (https://golang.org/pkg/regexp/syntax/)
+# 4. Common patterns:
+#    - ^.*\.domain\.com$ = Match all subdomains of domain.com
+#    - ^(dev|test|qa)- = Match hostnames starting with dev-, test-, or qa-
+#    - ^.*\.internal$ = Match all .internal hostnames
+# 5. Invalid regex patterns will be logged and ignored (target will not be prohibited)

--- a/docs/how-tos/prevent-agic-from-overwriting.md
+++ b/docs/how-tos/prevent-agic-from-overwriting.md
@@ -145,3 +145,83 @@ We can prohibit AGIC from making changes to a subset of configuration.
 3. Modify App Gateway config via portal - add listeners, routing rules, backends etc. The new object we created
 (`manually-configured-staging-environment`) will prohibit AGIC from overwriting App Gateway configuration related to
 `staging.contoso.com`.
+
+## Using Regex Patterns for Hostname Matching
+
+In addition to exact hostname matching, you can use regular expression patterns to match multiple hostnames with a single `AzureIngressProhibitedTarget` resource. This is useful when you need to prohibit AGIC from managing multiple related hostnames.
+
+### Basic Regex Usage
+
+Use the `hostnameRegex` field instead of `hostname` to specify a regex pattern:
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: "appgw.ingress.k8s.io/v1"
+kind: AzureIngressProhibitedTarget
+metadata:
+  name: prohibit-all-staging
+spec:
+  hostnameRegex: "^.*\\.staging\\.contoso\\.com$"
+EOF
+```
+
+This will prohibit AGIC from managing any hostname ending with `.staging.contoso.com`, such as:
+- `api.staging.contoso.com`
+- `web.staging.contoso.com`
+- `dev.api.staging.contoso.com`
+
+### Common Regex Patterns
+
+**Match all subdomains of a domain:**
+```yaml
+spec:
+  hostnameRegex: "^.*\\.example\\.com$"
+```
+
+**Match multiple environment prefixes:**
+```yaml
+spec:
+  hostnameRegex: "^(dev|test|qa).*\\.contoso\\.com$"
+```
+
+**Match all internal services:**
+```yaml
+spec:
+  hostnameRegex: "^.*\\.internal$"
+```
+
+### Important Notes
+
+1. **Precedence**: When both `hostname` and `hostnameRegex` are specified, `hostnameRegex` takes precedence and `hostname` is ignored.
+
+2. **Case-insensitive**: Regex patterns are automatically case-insensitive, so `^api\\.contoso\\.com$` matches both `api.contoso.com` and `API.CONTOSO.COM`.
+
+3. **Regex Syntax**: Use standard [Go regexp syntax](https://golang.org/pkg/regexp/syntax/). Common metacharacters:
+   - `.` - matches any character (use `\\.` to match a literal dot)
+   - `*` - zero or more of the preceding element
+   - `^` - start of string
+   - `$` - end of string
+   - `|` - alternation (OR)
+   - `[]` - character class
+
+4. **Validation**: Invalid regex patterns will be logged as errors and the entire prohibited target will be skipped (ignored). Check AGIC logs if your regex pattern isn't working as expected.
+
+5. **Backward Compatibility**: The existing `hostname` field continues to work as before with exact string matching (case-insensitive). No changes are required for existing configurations.
+
+### Example: Comprehensive Environment Protection
+
+```yaml
+apiVersion: "appgw.ingress.k8s.io/v1"
+kind: AzureIngressProhibitedTarget
+metadata:
+  name: prohibit-non-production
+spec:
+  hostnameRegex: "^(dev|test|qa|staging).*\\.contoso\\.com$"
+  paths:
+    - "/admin/*"
+    - "/internal/*"
+```
+
+This prohibits AGIC from managing admin and internal paths on any hostname that starts with `dev`, `test`, `qa`, or `staging` and ends with `.contoso.com`.
+
+See [crds/examples/AzureIngressProhibitedTarget-regex.yaml](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/crds/examples/AzureIngressProhibitedTarget-regex.yaml) for more examples.

--- a/helm/ingress-azure/crds/azureingressprohibitedtarget.yaml
+++ b/helm/ingress-azure/crds/azureingressprohibitedtarget.yaml
@@ -24,6 +24,9 @@ spec:
                 hostname:
                   description: "(optional) Hostname of the prohibited target"
                   type: string
+                hostnameRegex:
+                  description: "(optional) Regex pattern for matching hostnames. Takes precedence over hostname field if both are set."
+                  type: string
                 paths:
                   description: "(optional) A list of URL paths, for which the Ingress Controller is prohibited from mutating Application Gateway configuration; Must begin with a / and end with /*"
                   type: array

--- a/pkg/apis/azureingressprohibitedtarget/v1/types.go
+++ b/pkg/apis/azureingressprohibitedtarget/v1/types.go
@@ -37,6 +37,10 @@ type AzureIngressProhibitedTargetSpec struct {
 	Hostname string `json:"hostname,omitempty"`
 
 	// +optional
+	// Regex pattern for matching hostnames. Takes precedence over hostname field if both are set.
+	HostnameRegex string `json:"hostnameRegex,omitempty"`
+
+	// +optional
 	// Port number of the prohibited target
 	Port int32 `json:"port,omitempty"`
 

--- a/pkg/brownfield/targets.go
+++ b/pkg/brownfield/targets.go
@@ -7,6 +7,7 @@ package brownfield
 
 import (
 	"encoding/json"
+	"regexp"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -22,8 +23,9 @@ type TargetPath string
 
 // Target uniquely identifies a subset of App Gateway configuration, which AGIC will manage or be prohibited from managing.
 type Target struct {
-	Hostname string     `json:"Hostname,omitempty"`
-	Path     TargetPath `json:"Path,omitempty"`
+	Hostname              string          `json:"Hostname,omitempty"`
+	Path                  TargetPath      `json:"Path,omitempty"`
+	compiledHostnameRegex *regexp.Regexp  // Cache for compiled regex pattern
 }
 
 // IsBlacklisted figures out whether a given Target objects in a list of blacklisted targets.
@@ -31,10 +33,17 @@ func (t Target) IsBlacklisted(blacklist TargetBlacklist) bool {
 	jsonTarget, _ := json.Marshal(t)
 	for _, blTarget := range *blacklist {
 
-		// An empty blacklist hostname indicates that any hostname would be blacklisted.
-		// If host names match - this target is in the blacklist.
-		// AGIC is allowed to create and modify App Gwy config for blank host.
-		hostIsBlacklisted := blTarget.Hostname == "" || strings.EqualFold(t.Hostname, blTarget.Hostname)
+		// Check if blacklisted target has a compiled regex pattern
+		var hostIsBlacklisted bool
+		if blTarget.compiledHostnameRegex != nil {
+			// Use regex matching (case-insensitive)
+			hostIsBlacklisted = blTarget.compiledHostnameRegex.MatchString(t.Hostname)
+		} else {
+			// An empty blacklist hostname indicates that any hostname would be blacklisted.
+			// If host names match - this target is in the blacklist.
+			// AGIC is allowed to create and modify App Gwy config for blank host.
+			hostIsBlacklisted = blTarget.Hostname == "" || strings.EqualFold(t.Hostname, blTarget.Hostname)
+		}
 
 		pathIsBlacklisted := blTarget.Path == "" || blTarget.Path == "/*" || t.Path.lower() == blTarget.Path.lower() || blTarget.Path.contains(t.Path) // TODO(draychev): || t.Path.contains(blTarget.Path)
 
@@ -55,15 +64,38 @@ func GetTargetBlacklist(prohibitedTargets []*ptv1.AzureIngressProhibitedTarget) 
 	// TODO(draychev): make this a method of ExistingResources and memoize it.
 	var target []Target
 	for _, prohibitedTarget := range prohibitedTargets {
+		// Determine hostname and compile regex if needed
+		hostname := prohibitedTarget.Spec.Hostname
+		var compiledRegex *regexp.Regexp
+		
+		// HostnameRegex takes precedence over Hostname
+		if prohibitedTarget.Spec.HostnameRegex != "" {
+			// Compile regex with case-insensitive flag
+			pattern := "(?i)" + prohibitedTarget.Spec.HostnameRegex
+			var err error
+			compiledRegex, err = regexp.Compile(pattern)
+			if err != nil {
+				klog.Errorf("[brownfield] Invalid hostname regex pattern '%s' in prohibited target %s/%s: %v. This target will be ignored.", 
+					prohibitedTarget.Spec.HostnameRegex, 
+					prohibitedTarget.Namespace, 
+					prohibitedTarget.Name, 
+					err)
+				continue // Skip this prohibited target
+			}
+			hostname = "" // Clear hostname when using regex
+		}
+		
 		if len(prohibitedTarget.Spec.Paths) == 0 {
 			target = append(target, Target{
-				Hostname: prohibitedTarget.Spec.Hostname,
+				Hostname:              hostname,
+				compiledHostnameRegex: compiledRegex,
 			})
 		}
 		for _, path := range prohibitedTarget.Spec.Paths {
 			target = append(target, Target{
-				Hostname: prohibitedTarget.Spec.Hostname,
-				Path:     TargetPath(strings.ToLower(path)),
+				Hostname:              hostname,
+				Path:                  TargetPath(strings.ToLower(path)),
+				compiledHostnameRegex: compiledRegex,
 			})
 		}
 	}

--- a/pkg/brownfield/targets_test.go
+++ b/pkg/brownfield/targets_test.go
@@ -6,6 +6,8 @@
 package brownfield
 
 import (
+	"regexp"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -150,4 +152,125 @@ var _ = Describe("Test blacklisting targets", func() {
 			Expect(er.getProhibitedHostNames()).To(Equal(expected))
 		})
 	})
+
+	Context("Test hostname regex matching", func() {
+		It("should match hostnames using regex patterns", func() {
+			// Test regex pattern matching for subdomains
+			blacklistWithRegex := []Target{
+				{
+					Hostname:              "",
+					compiledHostnameRegex: compileTestRegex("^.*\\.example\\.com$"),
+				},
+			}
+
+			Expect(Target{Hostname: "api.example.com"}.IsBlacklisted(&blacklistWithRegex)).To(BeTrue())
+			Expect(Target{Hostname: "www.example.com"}.IsBlacklisted(&blacklistWithRegex)).To(BeTrue())
+			Expect(Target{Hostname: "dev.staging.example.com"}.IsBlacklisted(&blacklistWithRegex)).To(BeTrue())
+			Expect(Target{Hostname: "example.com"}.IsBlacklisted(&blacklistWithRegex)).To(BeFalse())
+			Expect(Target{Hostname: "notexample.com"}.IsBlacklisted(&blacklistWithRegex)).To(BeFalse())
+		})
+
+		It("should be case-insensitive for regex patterns", func() {
+			blacklistWithRegex := []Target{
+				{
+					Hostname:              "",
+					compiledHostnameRegex: compileTestRegex("^api\\.example\\.com$"),
+				},
+			}
+
+			Expect(Target{Hostname: "api.example.com"}.IsBlacklisted(&blacklistWithRegex)).To(BeTrue())
+			Expect(Target{Hostname: "API.EXAMPLE.COM"}.IsBlacklisted(&blacklistWithRegex)).To(BeTrue())
+			Expect(Target{Hostname: "Api.Example.Com"}.IsBlacklisted(&blacklistWithRegex)).To(BeTrue())
+		})
+
+		It("should prefer regex over exact match when regex is present", func() {
+			blacklistWithRegex := []Target{
+				{
+					Hostname:              "exact.example.com",
+					compiledHostnameRegex: compileTestRegex("^.*\\.staging\\.com$"),
+				},
+			}
+
+			// Should use regex, not exact match
+			Expect(Target{Hostname: "api.staging.com"}.IsBlacklisted(&blacklistWithRegex)).To(BeTrue())
+			Expect(Target{Hostname: "exact.example.com"}.IsBlacklisted(&blacklistWithRegex)).To(BeFalse())
+		})
+
+		It("should fall back to exact match when no regex is present", func() {
+			blacklistExact := []Target{
+				{
+					Hostname: "exact.example.com",
+				},
+			}
+
+			Expect(Target{Hostname: "exact.example.com"}.IsBlacklisted(&blacklistExact)).To(BeTrue())
+			Expect(Target{Hostname: "EXACT.EXAMPLE.COM"}.IsBlacklisted(&blacklistExact)).To(BeTrue()) // case-insensitive
+			Expect(Target{Hostname: "api.example.com"}.IsBlacklisted(&blacklistExact)).To(BeFalse())
+		})
+	})
+
+	Context("Test GetTargetBlacklist with regex", func() {
+		It("should compile valid regex patterns", func() {
+			prohibitedTargets := []*v1.AzureIngressProhibitedTarget{
+				{
+					Spec: v1.AzureIngressProhibitedTargetSpec{
+						HostnameRegex: "^.*\\.staging\\.com$",
+						Paths:         []string{"/api/*"},
+					},
+				},
+			}
+
+			blacklist := GetTargetBlacklist(prohibitedTargets)
+			Expect(len(*blacklist)).To(Equal(1))
+			Expect((*blacklist)[0].compiledHostnameRegex).ToNot(BeNil())
+			Expect((*blacklist)[0].Hostname).To(Equal("")) // Hostname should be cleared when using regex
+		})
+
+		It("should skip invalid regex patterns and log error", func() {
+			prohibitedTargets := []*v1.AzureIngressProhibitedTarget{
+				{
+					Spec: v1.AzureIngressProhibitedTargetSpec{
+						HostnameRegex: "[invalid(regex",
+					},
+				},
+				{
+					Spec: v1.AzureIngressProhibitedTargetSpec{
+						Hostname: "valid.example.com",
+					},
+				},
+			}
+
+			blacklist := GetTargetBlacklist(prohibitedTargets)
+			// Invalid regex should be skipped, only valid hostname should remain
+			Expect(len(*blacklist)).To(Equal(1))
+			Expect((*blacklist)[0].Hostname).To(Equal("valid.example.com"))
+			Expect((*blacklist)[0].compiledHostnameRegex).To(BeNil())
+		})
+
+		It("should prioritize hostnameRegex over hostname field", func() {
+			prohibitedTargets := []*v1.AzureIngressProhibitedTarget{
+				{
+					Spec: v1.AzureIngressProhibitedTargetSpec{
+						Hostname:      "exact.example.com",
+						HostnameRegex: "^.*\\.example\\.com$",
+					},
+				},
+			}
+
+			blacklist := GetTargetBlacklist(prohibitedTargets)
+			Expect(len(*blacklist)).To(Equal(1))
+			Expect((*blacklist)[0].compiledHostnameRegex).ToNot(BeNil())
+			Expect((*blacklist)[0].Hostname).To(Equal("")) // Should be cleared when regex is used
+
+			// Verify regex matching works
+			Expect(Target{Hostname: "api.example.com"}.IsBlacklisted(blacklist)).To(BeTrue())
+			Expect(Target{Hostname: "exact.example.com"}.IsBlacklisted(blacklist)).To(BeTrue())
+		})
+	})
 })
+
+// Helper function to compile regex patterns for testing
+func compileTestRegex(pattern string) *regexp.Regexp {
+	compiled, _ := regexp.Compile("(?i)" + pattern)
+	return compiled
+}


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [X] The title of the PR is clear and informative
- [X] If applicable, the changes made in the PR have proper test coverage
- [X] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
Add a new field to use regular expressions with hostname matching to make easier to implement a shared Application Gateway

## Fixes

#1296 
