### PR TITLE
Trivy uses synced Go version and permissions change

### DIFF
--- a/.github/workflows/vuln-scanner.yml
+++ b/.github/workflows/vuln-scanner.yml
@@ -22,20 +22,28 @@ jobs:
   trivy_vulnerability_scan:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    permissions: write-all
+    permissions:
+      contents: read
+      security-events: write
     env:
       BUILD_TAG: latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+    - name: Get Go version from Makefile
+      id: go-version
+      run: |
+        GO_VERSION=$(make -s print-go-version)
+        if [ -z "$GO_VERSION" ]; then echo "Failed to get Go version" && exit 1; fi
+        echo "version=$GO_VERSION" >> "$GITHUB_OUTPUT"
+
     - name: Set up Go
       uses: actions/setup-go@v5.0.1
       with:
-        go-version: '1.23.6'
-    
+        go-version: "${{ steps.go-version.outputs.version }}"
     - name: Build AGIC docker image
       run: make build-image
-    
+
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # Uses pinned SHA of v0.35.0
       with:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ GO_BINARY_NAME ?= appgw-ingress
 GOOS ?= linux
 GARCH ?= arm64
 
-BUILD_BASE_IMAGE ?= golang:1.25.8-bookworm
+GO_VERSION ?= 1.25.8
+BUILD_BASE_IMAGE ?= golang:$(GO_VERSION)-bookworm
 BINARY_BASE_IMAGE ?= mcr.microsoft.com/azurelinux/distroless/base:3.0.20260204
 
 REPO ?= appgwreg.azurecr.io
@@ -154,3 +155,6 @@ publish-staging:
 	@git pull --rebase
 	./scripts/release-image.sh
 	./scripts/release-helm.sh
+
+print-go-version:
+	@echo $(GO_VERSION)


### PR DESCRIPTION
- Trivy scan now reads the correct version of Go from the Makefile
- Trivy scan runs with slightly reduced privs

<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Fixes

<!-- Please mention #issues that are fixed in this PR -->
