### PR TITLE
fix: detect overlay CNI via NetworkContainer type when NNC label is absent

### DIFF
--- a/pkg/cni/overlay.go
+++ b/pkg/cni/overlay.go
@@ -84,12 +84,29 @@ func (r *Reconciler) isClusterOverlayCNI(ctx context.Context) (bool, error) {
 		return false, errors.Wrap(err, "failed to list node network configs")
 	}
 
-	// if any NNCs are overlay then this cluster is using CNI Overlay
+	if len(nodeNetworkConfigs.Items) == 0 {
+		klog.V(3).Infof("No NodeNetworkConfigs found, cluster is not using overlay CNI")
+		return false, nil
+	}
+
+	// Check NNC metadata label first (set after migration completes)
 	for _, nnc := range nodeNetworkConfigs.Items {
 		if val, ok := nnc.Labels[PodNetworkTypeLabel]; ok && val == "overlay" {
 			return true, nil
 		}
 	}
+
+	// Fallback: check NetworkContainer type on status (set by DNC-RC during migration)
+	for _, nnc := range nodeNetworkConfigs.Items {
+		for _, nc := range nnc.Status.NetworkContainers {
+			if nc.Type == nodenetworkconfig_v1alpha.Overlay {
+				klog.Infof("Detected overlay CNI via NetworkContainer type on NNC %s/%s", nnc.Namespace, nnc.Name)
+				return true, nil
+			}
+		}
+	}
+
+	klog.V(3).Infof("NodeNetworkConfigs found (%d) but none indicate overlay CNI", len(nodeNetworkConfigs.Items))
 	return false, nil
 }
 

--- a/pkg/cni/overlay_test.go
+++ b/pkg/cni/overlay_test.go
@@ -110,6 +110,75 @@ var _ = Describe("Overlay CNI", func() {
 		})
 	})
 
+	Context("NodeNetworkConfig has no label but NetworkContainer type is overlay", func() {
+		BeforeEach(func() {
+			azClient.GetSubnetFunc = func(subnetID string) (n.Subnet, error) {
+				return n.Subnet{SubnetPropertiesFormat: &n.SubnetPropertiesFormat{AddressPrefix: to.StringPtr(subnetCIDR)}}, nil
+			}
+			go mockOecReconciler()
+		})
+
+		It("should detect overlay via NetworkContainer type and create OEC", func() {
+			// Create NNC without the overlay label but with overlay NetworkContainer type
+			// This matches the state during Kubenet→Overlay migration
+			config := &nodenetworkconfig_v1alpha.NodeNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-node-no-label",
+					Namespace: namespace,
+					// No labels at all — exactly what DNC-RC creates during migration
+				},
+				Spec: nodenetworkconfig_v1alpha.NodeNetworkConfigSpec{},
+				Status: nodenetworkconfig_v1alpha.NodeNetworkConfigStatus{
+					NetworkContainers: []nodenetworkconfig_v1alpha.NetworkContainer{
+						{
+							ID:                 "nc-1",
+							Type:               nodenetworkconfig_v1alpha.Overlay,
+							AssignmentMode:     nodenetworkconfig_v1alpha.Static,
+							PrimaryIP:          "10.244.0.0/24",
+							SubnetName:         "routingdomain_test_overlaysubnet",
+							SubnetAddressSpace: "10.244.0.0/16",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, config)).To(BeNil())
+
+			Expect(reconciler.Reconcile(ctx)).To(BeNil())
+
+			// Verify OEC was created — proves the fallback detection worked
+			var oec overlayextensionconfig_v1alpha1.OverlayExtensionConfig
+			Expect(k8sClient.Get(ctx, ctrl_client.ObjectKey{Name: cni.OverlayExtensionConfigName, Namespace: namespace}, &oec)).To(BeNil())
+			Expect(oec.Spec.ExtensionIPRange).To(Equal(subnetCIDR))
+		})
+
+		It("should not detect overlay when NetworkContainer type is vnet", func() {
+			// Create NNC with vnet type — should not trigger overlay detection
+			config := &nodenetworkconfig_v1alpha.NodeNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-node-vnet",
+					Namespace: namespace,
+				},
+				Spec: nodenetworkconfig_v1alpha.NodeNetworkConfigSpec{},
+				Status: nodenetworkconfig_v1alpha.NodeNetworkConfigStatus{
+					NetworkContainers: []nodenetworkconfig_v1alpha.NetworkContainer{
+						{
+							ID:   "nc-1",
+							Type: nodenetworkconfig_v1alpha.VNET,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, config)).To(BeNil())
+
+			Expect(reconciler.Reconcile(ctx)).To(BeNil())
+
+			// Verify OEC was NOT created
+			var oec overlayextensionconfig_v1alpha1.OverlayExtensionConfig
+			err := k8sClient.Get(ctx, ctrl_client.ObjectKey{Name: cni.OverlayExtensionConfigName, Namespace: namespace}, &oec)
+			Expect(err).To(Not(BeNil()))
+		})
+	})
+
 	Context("Handle Overlay CNI cluster", func() {
 		BeforeEach(func() {
 			// Create NodeNetworkConfig so that cluster is considered as overlay CNI


### PR DESCRIPTION
## Problem

During Kubenet→Overlay migration, AKS RP restarts AGIC and polls for an OverlayExtensionConfig (OEC). AGIC never creates it because `isClusterOverlayCNI()` only checks for the metadata label `kubernetes.azure.com/podnetwork-type: overlay` on NodeNetworkConfigs (NNCs).

DNC-RC creates NNCs with `status.networkContainers[].type` set to `overlay` but **does not set the metadata label** at that point. This causes a deadlock:

- AKS RP declares NNCs ready (checks `status.NetworkContainers` length)
- AGIC checks the metadata label → not found → returns `false` silently
- No OEC created → AKS RP times out → cluster enters `Failed` state

This has been reproduced live in a test cluster and matches a production customer issue (7+ day `Failed` state).

## Fix

Add a fallback check in `isClusterOverlayCNI()` that examines `status.networkContainers[].type` when the metadata label is not found. Also adds logging on the `false` path for debuggability.

### Before
\\\go
for _, nnc := range nodeNetworkConfigs.Items {
    if val, ok := nnc.Labels[PodNetworkTypeLabel]; ok && val == "overlay" {
        return true, nil
    }
}
return false, nil  // silent
\\\

### After
\\\go
// Check metadata label first (fast path)
for _, nnc := range nodeNetworkConfigs.Items {
    if val, ok := nnc.Labels[PodNetworkTypeLabel]; ok && val == "overlay" {
        return true, nil
    }
}

// Fallback: check NetworkContainer type on status (set by DNC-RC during migration)
for _, nnc := range nodeNetworkConfigs.Items {
    for _, nc := range nnc.Status.NetworkContainers {
        if nc.Type == nodenetworkconfig_v1alpha.Overlay {
            return true, nil
        }
    }
}
\\\

## Testing

- All 18 existing unit tests pass
- 2 new unit tests added:
  - Detects overlay when NNC has no label but `NetworkContainer.Type = Overlay`
  - Does NOT falsely detect overlay when `NetworkContainer.Type = VNET`
- Reproduced the bug in a live AKS cluster (Kubenet + AGIC addon → overlay upgrade)
- Confirmed NNCs have `type: overlay` in status but zero metadata labels during migration

## Files Changed

- `pkg/cni/overlay.go` — fallback detection + logging
- `pkg/cni/overlay_test.go` — 2 new test cases