### PR TITLE
fix: wait for CRD caches before reconciliation

### DIFF
--- a/pkg/k8scontext/context.go
+++ b/pkg/k8scontext/context.go
@@ -229,8 +229,10 @@ func (c *Context) Run(stopChannel chan struct{}, omitCRDs bool, envVariables env
 	for _, informer := range sharedInformers {
 		go informer.Run(stopChannel)
 		// NOTE: Delyan could not figure out how to make informer.HasSynced == true for the CRDs in unit tests
-		// so until we do that - we omit WaitForCacheSync for CRDs in unit testing
-		if _, isCRD := crds[informer]; isCRD {
+		// so until we do that - we omit WaitForCacheSync for CRDs in unit testing only.
+		// Production must wait for CRD caches before reconciliation starts. Otherwise, an empty
+		// AzureIngressProhibitedTarget cache can make AGIC overwrite protected brownfield config.
+		if _, isCRD := crds[informer]; omitCRDs && isCRD {
 			continue
 		}
 		hasSynced = append(hasSynced, informer.HasSynced)

--- a/pkg/k8scontext/k8scontext_test.go
+++ b/pkg/k8scontext/k8scontext_test.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	agiccrd "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned"
@@ -32,6 +33,26 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
 	"github.com/Azure/go-autorest/autorest/to"
 )
+
+type gatedSyncInformer struct {
+	cache.SharedInformer
+	syncAllowed     <-chan struct{}
+	hasSyncedCalled chan struct{}
+}
+
+func (i *gatedSyncInformer) HasSynced() bool {
+	select {
+	case i.hasSyncedCalled <- struct{}{}:
+	default:
+	}
+
+	select {
+	case <-i.syncAllowed:
+		return true
+	default:
+		return false
+	}
+}
 
 var _ = ginkgo.Describe("K8scontext", func() {
 	var k8sClient kubernetes.Interface
@@ -106,6 +127,39 @@ var _ = ginkgo.Describe("K8scontext", func() {
 
 	ginkgo.AfterEach(func() {
 		close(stopChannel)
+	})
+
+	ginkgo.Context("Checking initial cache synchronization", func() {
+		ginkgo.It("Should wait for CRD caches in production", func() {
+			envVariables := environment.GetFakeEnv()
+			envVariables.EnableBrownfieldDeployment = true
+
+			alreadySynced := make(chan struct{})
+			close(alreadySynced)
+			ctxt.informers.AzureApplicationGatewayRewrite = &gatedSyncInformer{
+				SharedInformer: ctxt.informers.AzureApplicationGatewayRewrite,
+				syncAllowed:    alreadySynced,
+			}
+
+			syncAllowed := make(chan struct{})
+			hasSyncedCalled := make(chan struct{}, 1)
+			ctxt.informers.AzureIngressProhibitedTarget = &gatedSyncInformer{
+				SharedInformer:  ctxt.informers.AzureIngressProhibitedTarget,
+				syncAllowed:     syncAllowed,
+				hasSyncedCalled: hasSyncedCalled,
+			}
+
+			runResult := make(chan error, 1)
+			go func() {
+				runResult <- ctxt.Run(stopChannel, false, envVariables)
+			}()
+
+			Eventually(hasSyncedCalled).Should(Receive())
+			Consistently(runResult, 200*time.Millisecond).ShouldNot(Receive())
+
+			close(syncAllowed)
+			Eventually(runResult).Should(Receive(BeNil()))
+		})
 	})
 
 	ginkgo.Context("Checking if we are able to listen to Ingress Resources", func() {


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist

- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

AGIC currently starts CRD informers but always excludes them from `WaitForCacheSync`. During startup, the worker can therefore reconcile Application Gateway before the `AzureIngressProhibitedTarget` cache is populated.

With shared/brownfield mode enabled, AGIC can temporarily see no prohibited targets and overwrite protected Application Gateway configuration before the CRD create event is processed.

This change:

- honors the existing `omitCRDs` flag when deciding whether CRD informers participate in initial cache synchronization
- waits for `AzureIngressProhibitedTarget` and other enabled CRD caches before production reconciliation starts
- adds a regression test verifying that production startup remains blocked until the prohibited-target informer reports successful synchronization

The existing `omitCRDs` parameter remains `true` in unit tests and `false` in the production controller.

### Testing

`go test -tags unittest ./pkg/k8scontext -count=1`

All 39 specs pass.

## Fixes
Fixes #1814


- honors the existing `omitCRDs` flag when deciding whether CRD informers participate in initial cache synchronization
- waits for `AzureIngressProhibitedTarget` and other enabled CRD caches before production reconciliation starts