### PR TITLE
SSL certificates are not cleaned up after Ingress recreation, eventually hitting the Application Gateway limit

### DIFF
--- a/pkg/appgw/certificates.go
+++ b/pkg/appgw/certificates.go
@@ -9,15 +9,18 @@ import (
 	"encoding/base64"
 	"fmt"
 	"sort"
+	"strings"
 
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-03-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/brownfield"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/sorter"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
 )
 
 // getSslCertificates obtains all SSL Certificates for the given Ingress object.
@@ -38,16 +41,91 @@ func (c *appGwConfigBuilder) getSslCertificates(cbCtx *ConfigBuilderContext) *[]
 		sslCertificates = append(sslCertificates, c.newCert(secretID, cert))
 	}
 
-	// Merge certs from k8s ingress with existing appgw certs
+	desiredCertNames := make(map[string]struct{}, len(sslCertificates))
+	for _, cert := range sslCertificates {
+		if cert.Name == nil {
+			continue
+		}
+		desiredCertNames[*cert.Name] = struct{}{}
+	}
+
+	// Certs referenced by the appgw-ssl-certificate annotation point to already-installed certificates on the gateway.
+	// These certs must never be garbage-collected, even if their name matches the AGIC-managed naming pattern.
+	annotatedCertNames := make(map[string]struct{})
+	for _, ingress := range cbCtx.IngressList {
+		certName, _ := annotations.GetAppGwSslCertificate(ingress)
+		if certName == "" {
+			continue
+		}
+		annotatedCertNames[certName] = struct{}{}
+	}
+
+	// Retain only non-AGIC/manual certificates from the existing gateway config.
+	// In brownfield mode, also retain any certificates referenced by blacklisted listeners.
 	if c.appGw.SslCertificates != nil {
-		// MergePools would produce unique list of pools based on Name. Blacklisted pools, which have the same name
-		// as a managed pool would be overwritten.
-		sslCertificates = brownfield.MergeCerts(*c.appGw.SslCertificates, sslCertificates)
+		referencedByBlacklisted := c.sslCertNamesReferencedByBlacklistedListeners(cbCtx)
+		retainedExisting := make([]n.ApplicationGatewaySslCertificate, 0, len(*c.appGw.SslCertificates))
+		for _, existingCert := range *c.appGw.SslCertificates {
+			if existingCert.Name == nil {
+				continue
+			}
+			existingName := *existingCert.Name
+			if _, required := annotatedCertNames[existingName]; required {
+				retainedExisting = append(retainedExisting, existingCert)
+				continue
+			}
+			if _, desired := desiredCertNames[existingName]; desired {
+				// The desired cert will be included (and will overwrite by name if needed).
+				continue
+			}
+
+			if !isAgicManagedSslCertificateName(existingName) {
+				retainedExisting = append(retainedExisting, existingCert)
+				continue
+			}
+
+			if cbCtx.EnvVariables.EnableBrownfieldDeployment {
+				if _, keep := referencedByBlacklisted[existingName]; keep {
+					retainedExisting = append(retainedExisting, existingCert)
+				}
+			}
+		}
+
+		sslCertificates = brownfield.MergeCerts(retainedExisting, sslCertificates)
 	}
 
 	sort.Sort(sorter.ByCertificateName(sslCertificates))
 	c.mem.certs = &sslCertificates
 	return &sslCertificates
+}
+
+func isAgicManagedSslCertificateName(name string) bool {
+	// AGIC-generated certificate names follow secretIdentifier.secretFullName():
+	//   <APPGW_CONFIG_NAME_PREFIX>cert-<namespace>-<secretName>
+	// Preinstalled/manual certificates (including those referenced via appgw-ssl-certificate annotation)
+	// do not follow this pattern and should be retained.
+	return strings.HasPrefix(name, agPrefix+prefixSslCertificate+"-")
+}
+
+func (c *appGwConfigBuilder) sslCertNamesReferencedByBlacklistedListeners(cbCtx *ConfigBuilderContext) map[string]struct{} {
+	result := make(map[string]struct{})
+	if !cbCtx.EnvVariables.EnableBrownfieldDeployment {
+		return result
+	}
+
+	er := brownfield.NewExistingResources(c.appGw, cbCtx.ProhibitedTargets, nil)
+	blacklistedListeners, _ := er.GetBlacklistedListeners()
+	for _, listener := range blacklistedListeners {
+		if listener.SslCertificate == nil || listener.SslCertificate.ID == nil {
+			continue
+		}
+		certName := utils.GetLastChunkOfSlashed(*listener.SslCertificate.ID)
+		if certName == "" {
+			continue
+		}
+		result[certName] = struct{}{}
+	}
+	return result
 }
 
 func (c *appGwConfigBuilder) getSecretToCertificateMap(ingress *networking.Ingress) map[secretIdentifier]*string {

--- a/pkg/appgw/certificates_test.go
+++ b/pkg/appgw/certificates_test.go
@@ -1,10 +1,16 @@
 package appgw
 
 import (
+	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-03-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	networking "k8s.io/api/networking/v1"
 
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/environment"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests/fixtures"
 )
 
 // appgw_suite_test.go launches these Ginkgo tests
@@ -76,5 +82,100 @@ var _ = Describe("Testing function newHostToSecretMap", func() {
 		It("should have generated the correct secretID struct", func() {
 			Expect(*actualSecretID).To(Equal(expectedSecret))
 		})
+	})
+})
+
+var _ = Describe("SSL certificate garbage collection", func() {
+	It("removes stale AGIC-managed certs but retains manual certs", func() {
+		cb := newConfigBuilderFixture(nil)
+
+		staleManagedName := secretIdentifier{Namespace: tests.Namespace, Name: "stale-secret"}.secretFullName()
+		manualName := "manual-cert"
+		cb.appGw.SslCertificates = &[]n.ApplicationGatewaySslCertificate{
+			{Name: to.StringPtr(staleManagedName)},
+			{Name: to.StringPtr(manualName)},
+		}
+
+		ingressList := []*networking.Ingress{tests.NewIngressFixture()}
+		cbCtx := &ConfigBuilderContext{
+			IngressList:  ingressList,
+			EnvVariables: environment.EnvVariables{},
+		}
+
+		actual := cb.getSslCertificates(cbCtx)
+		var names []string
+		for _, cert := range *actual {
+			names = append(names, *cert.Name)
+		}
+
+		expectedDesiredName := secretIdentifier{Namespace: tests.Namespace, Name: tests.NameOfSecret}.secretFullName()
+		Expect(names).To(ContainElement(expectedDesiredName))
+		Expect(names).To(ContainElement(manualName))
+		Expect(names).NotTo(ContainElement(staleManagedName))
+	})
+
+	It("retains AGIC-managed certs referenced by blacklisted listeners in brownfield mode", func() {
+		cb := newConfigBuilderFixture(nil)
+
+		staleManagedName := secretIdentifier{Namespace: tests.Namespace, Name: "stale-secret"}.secretFullName()
+		cb.appGw.SslCertificates = &[]n.ApplicationGatewaySslCertificate{
+			{Name: to.StringPtr(staleManagedName)},
+		}
+
+		listenerName := "bf-listener"
+		cb.appGw.HTTPListeners = &[]n.ApplicationGatewayHTTPListener{
+			{
+				Name: to.StringPtr(listenerName),
+				ApplicationGatewayHTTPListenerPropertiesFormat: &n.ApplicationGatewayHTTPListenerPropertiesFormat{
+					Protocol:       n.ApplicationGatewayProtocolHTTPS,
+					HostName:       to.StringPtr(tests.Host),
+					SslCertificate: &n.SubResource{ID: to.StringPtr(cb.appGwIdentifier.sslCertificateID(staleManagedName))},
+				},
+			},
+		}
+
+		cbCtx := &ConfigBuilderContext{
+			IngressList:       []*networking.Ingress{tests.NewIngressFixture()},
+			ProhibitedTargets: fixtures.GetAzureIngressProhibitedTargets(),
+			EnvVariables: environment.EnvVariables{
+				EnableBrownfieldDeployment: true,
+			},
+		}
+
+		actual := cb.getSslCertificates(cbCtx)
+		var names []string
+		for _, cert := range *actual {
+			names = append(names, *cert.Name)
+		}
+		Expect(names).To(ContainElement(staleManagedName))
+	})
+
+	It("retains certificates referenced by appgw-ssl-certificate annotation", func() {
+		cb := newConfigBuilderFixture(nil)
+
+		// This resembles an AGIC-managed name when APPGW_CONFIG_NAME_PREFIX is empty.
+		annotatedCertName := "cert-some-namespace-some-secret"
+		cb.appGw.SslCertificates = &[]n.ApplicationGatewaySslCertificate{
+			{Name: to.StringPtr(annotatedCertName)},
+		}
+
+		ingress := tests.NewIngressFixture()
+		ingress.Spec.TLS = nil
+		if ingress.Annotations == nil {
+			ingress.Annotations = map[string]string{}
+		}
+		ingress.Annotations[annotations.AppGwSslCertificate] = annotatedCertName
+
+		cbCtx := &ConfigBuilderContext{
+			IngressList:  []*networking.Ingress{ingress},
+			EnvVariables: environment.EnvVariables{},
+		}
+
+		actual := cb.getSslCertificates(cbCtx)
+		var names []string
+		for _, cert := range *actual {
+			names = append(names, *cert.Name)
+		}
+		Expect(names).To(ContainElement(annotatedCertName))
 	})
 })


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [ ] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
After repeatedly creating and deleting Ingress resources, AGIC appears to leave stale SSL certificates on the Azure Application Gateway.

As a result, the number of SSL certificates on the gateway keeps increasing over time, even though fewer than 100 Ingress objects are currently deployed. Eventually, Application Gateway reaches its SSL certificate limit and AGIC can no longer apply configuration updates.

## Expected behavior

AGIC should clean up SSL certificates that are no longer used when related Ingress resources are deleted or recreated.

The number of SSL certificates on the Application Gateway should reflect the currently active configuration and should not continue growing after repeated create/delete cycles.

## Actual behavior

Stale SSL certificates remain on the Application Gateway, and over time the gateway exceeds the maximum supported number of SSL certificates.

AGIC then fails to apply configuration with the following error:

## Fixes
Fixes #1488 
<!-- Please mention #issues that are fixed in this PR -->
