### PR TITLE
Change api version into 2022-09-01 because this version supports various response codes for custom error pages

### DIFF
--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -23,6 +23,8 @@ import (
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/version"
 )
 
+const applicationGatewayAPIVersion = "2022-09-01"
+
 // AzClient is an interface for client to Azure
 type AzClient interface {
 	SetAuthorizer(authorizer autorest.Authorizer)
@@ -83,6 +85,12 @@ func NewAzClient(subscriptionID SubscriptionID, resourceGroupName ResourceGroup,
 
 		ctx: context.Background(),
 	}
+
+	// The generated SDK package targets 2021-03-01, but newer Application Gateway
+	// features such as additional custom error status codes require 2022-09-01.
+	az.appGatewaysClient.RequestInspector = autorest.WithQueryParameters(map[string]interface{}{
+		"api-version": applicationGatewayAPIVersion,
+	})
 
 	if err := az.appGatewaysClient.AddToUserAgent(userAgent); err != nil {
 		klog.Error("Error adding User Agent to App Gateway client: ", userAgent)

--- a/pkg/azure/client_test.go
+++ b/pkg/azure/client_test.go
@@ -17,9 +17,11 @@ import (
 type FakeSender struct {
 	statusCode int
 	body       *n.ApplicationGateway
+	request    *http.Request
 }
 
 func (fs *FakeSender) Do(request *http.Request) (response *http.Response, err error) {
+	fs.request = request
 	response = &http.Response{
 		StatusCode: fs.statusCode,
 	}
@@ -61,3 +63,20 @@ var _ = DescribeTable("Az Application Gateway failures using authorizer", func(s
 	Entry("403 Error", 403, true),
 	Entry("404 Error", 404, true),
 )
+
+var _ = Describe("Application Gateway API version", func() {
+	It("uses API version 2022-09-01 for Application Gateway requests", func() {
+		azClient := NewAzClient("", "", "", "", "")
+		fakeSender := &FakeSender{
+			statusCode: http.StatusOK,
+			body:       &n.ApplicationGateway{},
+		}
+		azClient.SetSender(fakeSender)
+
+		err := azClient.WaitForGetAccessOnGateway(1)
+
+		Expect(err).To(BeNil())
+		Expect(fakeSender.request).NotTo(BeNil())
+		Expect(fakeSender.request.URL.Query().Get("api-version")).To(Equal(applicationGatewayAPIVersion))
+	})
+})


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [X] The title of the PR is clear and informative
- [X] If applicable, the changes made in the PR have proper test coverage
- [ ] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description
Old API version (2021-03-01) only supports [403, 502] response codes for custom error pages.
Other response codes (400, 503, 504 ..) are supported in application gateway.
https://learn.microsoft.com/en-us/azure/application-gateway/custom-error#supported-response-codes
And API version 2022-09-01 supports upper response codes.
<!-- Please add a brief description of the changes made in this PR -->

## Fixes
Add query parameter at AzClient interface type.
this parameter uses 2022-09-01 that documentation said.
<!-- Please mention #issues that are fixed in this PR -->