### PR TITLE
Fix tombstone-handling panics in k8scontext delete handlers

### DIFF
--- a/pkg/k8scontext/handlers.go
+++ b/pkg/k8scontext/handlers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 )
 
 type handlers struct {
@@ -48,6 +49,14 @@ func (h handlers) updateFunc(oldObj, newObj interface{}) {
 }
 
 func (h handlers) deleteFunc(obj interface{}) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		if tombstone.Obj == nil {
+			klog.Errorf("unable to get object from tombstone with key %s", tombstone.Key)
+			return
+		}
+		obj = tombstone.Obj
+	}
+
 	ns := getNamespace(obj)
 	if _, exists := namespacesToIgnore[ns]; exists {
 		return
@@ -64,11 +73,5 @@ func (h handlers) deleteFunc(obj interface{}) {
 }
 
 func getNamespace(obj interface{}) string {
-	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-		obj = tombstone.Obj
-	}
-	if obj == nil {
-		return ""
-	}
 	return reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 }

--- a/pkg/k8scontext/handlers.go
+++ b/pkg/k8scontext/handlers.go
@@ -49,12 +49,9 @@ func (h handlers) updateFunc(oldObj, newObj interface{}) {
 }
 
 func (h handlers) deleteFunc(obj interface{}) {
-	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-		if tombstone.Obj == nil {
-			klog.Errorf("unable to get object from tombstone with key %s", tombstone.Key)
-			return
-		}
-		obj = tombstone.Obj
+	obj, ok := unwrapTombstone(obj)
+	if !ok {
+		return
 	}
 
 	ns := getNamespace(obj)
@@ -74,4 +71,19 @@ func (h handlers) deleteFunc(obj interface{}) {
 
 func getNamespace(obj interface{}) string {
 	return reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
+}
+
+// unwrapTombstone returns the object a cache.DeletedFinalStateUnknown tombstone wraps, or
+// obj unchanged if it isn't one. ok is false if the tombstone has no recoverable object,
+// in which case the caller should drop the event.
+func unwrapTombstone(obj interface{}) (interface{}, bool) {
+	tombstone, isTombstone := obj.(cache.DeletedFinalStateUnknown)
+	if !isTombstone {
+		return obj, true
+	}
+	if tombstone.Obj == nil {
+		klog.Errorf("unable to get object from tombstone with key %s", tombstone.Key)
+		return nil, false
+	}
+	return tombstone.Obj, true
 }

--- a/pkg/k8scontext/handlers.go
+++ b/pkg/k8scontext/handlers.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+	"k8s.io/client-go/tools/cache"
 )
 
 type handlers struct {
@@ -63,5 +64,11 @@ func (h handlers) deleteFunc(obj interface{}) {
 }
 
 func getNamespace(obj interface{}) string {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	if obj == nil {
+		return ""
+	}
 	return reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 }

--- a/pkg/k8scontext/handlers_test.go
+++ b/pkg/k8scontext/handlers_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/fake"
 	multiClusterFake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/azure_multicluster_crd_client/clientset/versioned/fake"
@@ -78,6 +79,29 @@ var _ = ginkgo.Describe("K8scontext General Cache Handlers", func() {
 			h.deleteFunc(&pod)
 			Expect(len(h.context.Work)).To(Equal(0))
 			h.updateFunc(&pod, &pod)
+			Expect(len(h.context.Work)).To(Equal(0))
+		})
+
+		ginkgo.It("should not panic when deleteFunc receives a DeletedFinalStateUnknown tombstone", func() {
+			pod := tests.NewPodTestFixture("ns", "pod")
+			ctx.ingressSecretsMap.Insert("ns/ingress", utils.GetResourceKey(pod.Namespace, pod.Name))
+
+			tombstone := cache.DeletedFinalStateUnknown{
+				Key: "ns/pod",
+				Obj: &pod,
+			}
+
+			Expect(func() { h.deleteFunc(tombstone) }).ToNot(Panic())
+			Expect(len(h.context.Work)).To(Equal(1))
+		})
+
+		ginkgo.It("should not panic when deleteFunc receives a DeletedFinalStateUnknown tombstone with a nil Obj", func() {
+			tombstone := cache.DeletedFinalStateUnknown{
+				Key: "ns/pod",
+				Obj: nil,
+			}
+
+			Expect(func() { h.deleteFunc(tombstone) }).ToNot(Panic())
 			Expect(len(h.context.Work)).To(Equal(0))
 		})
 	})

--- a/pkg/k8scontext/handlers_test.go
+++ b/pkg/k8scontext/handlers_test.go
@@ -82,7 +82,7 @@ var _ = ginkgo.Describe("K8scontext General Cache Handlers", func() {
 			Expect(len(h.context.Work)).To(Equal(0))
 		})
 
-		ginkgo.It("should not panic when deleteFunc receives a DeletedFinalStateUnknown tombstone", func() {
+		ginkgo.It("should queue the unwrapped object when deleteFunc receives a DeletedFinalStateUnknown tombstone", func() {
 			pod := tests.NewPodTestFixture("ns", "pod")
 			ctx.ingressSecretsMap.Insert("ns/ingress", utils.GetResourceKey(pod.Namespace, pod.Name))
 
@@ -93,9 +93,11 @@ var _ = ginkgo.Describe("K8scontext General Cache Handlers", func() {
 
 			Expect(func() { h.deleteFunc(tombstone) }).ToNot(Panic())
 			Expect(len(h.context.Work)).To(Equal(1))
+			event := <-h.context.Work
+			Expect(event.Value).To(Equal(&pod))
 		})
 
-		ginkgo.It("should not panic when deleteFunc receives a DeletedFinalStateUnknown tombstone with a nil Obj", func() {
+		ginkgo.It("should drop a DeletedFinalStateUnknown tombstone with a nil Obj", func() {
 			tombstone := cache.DeletedFinalStateUnknown{
 				Key: "ns/pod",
 				Obj: nil,
@@ -103,6 +105,19 @@ var _ = ginkgo.Describe("K8scontext General Cache Handlers", func() {
 
 			Expect(func() { h.deleteFunc(tombstone) }).ToNot(Panic())
 			Expect(len(h.context.Work)).To(Equal(0))
+		})
+
+		ginkgo.It("should drop a DeletedFinalStateUnknown tombstone with a nil Obj when watching all namespaces", func() {
+			allNamespacesCtx := NewContext(k8sClient, fake.NewSimpleClientset(), multiClusterFake.NewSimpleClientset(), istioFake.NewSimpleClientset(), []string{}, 1000*time.Second, metricstore.NewFakeMetricStore(), environment.GetFakeEnv())
+			allNamespacesHandlers := handlers{context: allNamespacesCtx}
+
+			tombstone := cache.DeletedFinalStateUnknown{
+				Key: "ns/pod",
+				Obj: nil,
+			}
+
+			Expect(func() { allNamespacesHandlers.deleteFunc(tombstone) }).ToNot(Panic())
+			Expect(len(allNamespacesHandlers.context.Work)).To(Equal(0))
 		})
 	})
 })

--- a/pkg/k8scontext/handlers_test.go
+++ b/pkg/k8scontext/handlers_test.go
@@ -94,7 +94,7 @@ var _ = ginkgo.Describe("K8scontext General Cache Handlers", func() {
 			Expect(func() { h.deleteFunc(tombstone) }).ToNot(Panic())
 			Expect(len(h.context.Work)).To(Equal(1))
 			event := <-h.context.Work
-			Expect(event.Value).To(Equal(&pod))
+			Expect(event.Value).To(BeIdenticalTo(&pod))
 		})
 
 		ginkgo.It("should drop a DeletedFinalStateUnknown tombstone with a nil Obj", func() {
@@ -105,19 +105,6 @@ var _ = ginkgo.Describe("K8scontext General Cache Handlers", func() {
 
 			Expect(func() { h.deleteFunc(tombstone) }).ToNot(Panic())
 			Expect(len(h.context.Work)).To(Equal(0))
-		})
-
-		ginkgo.It("should drop a DeletedFinalStateUnknown tombstone with a nil Obj when watching all namespaces", func() {
-			allNamespacesCtx := NewContext(k8sClient, fake.NewSimpleClientset(), multiClusterFake.NewSimpleClientset(), istioFake.NewSimpleClientset(), []string{}, 1000*time.Second, metricstore.NewFakeMetricStore(), environment.GetFakeEnv())
-			allNamespacesHandlers := handlers{context: allNamespacesCtx}
-
-			tombstone := cache.DeletedFinalStateUnknown{
-				Key: "ns/pod",
-				Obj: nil,
-			}
-
-			Expect(func() { allNamespacesHandlers.deleteFunc(tombstone) }).ToNot(Panic())
-			Expect(len(allNamespacesHandlers.context.Work)).To(Equal(0))
 		})
 	})
 })

--- a/pkg/k8scontext/ingress_handlers.go
+++ b/pkg/k8scontext/ingress_handlers.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
@@ -54,16 +53,12 @@ func (h handlers) ingressAdd(obj interface{}) {
 }
 
 func (h handlers) ingressDelete(obj interface{}) {
+	obj, ok := unwrapTombstone(obj)
+	if !ok {
+		return
+	}
 	ing, ok := convert.ToIngressV1(obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			// unable to get from tombstone
-			return
-		}
-		ing, _ = convert.ToIngressV1(tombstone.Obj)
-	}
-	if ing == nil {
 		return
 	}
 

--- a/pkg/k8scontext/ingress_handlers.go
+++ b/pkg/k8scontext/ingress_handlers.go
@@ -56,13 +56,6 @@ func (h handlers) ingressAdd(obj interface{}) {
 
 func (h handlers) ingressDelete(obj interface{}) {
 	ing, ok := convert.ToIngressV1(obj)
-	if _, exists := namespacesToIgnore[ing.Namespace]; exists {
-		return
-	}
-	if _, exists := h.context.namespaces[ing.Namespace]; len(h.context.namespaces) > 0 && !exists {
-		return
-	}
-
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
@@ -74,6 +67,13 @@ func (h handlers) ingressDelete(obj interface{}) {
 	if ing == nil {
 		return
 	}
+
+	if _, exists := namespacesToIgnore[ing.Namespace]; exists {
+		return
+	}
+	if _, exists := h.context.namespaces[ing.Namespace]; len(h.context.namespaces) > 0 && !exists {
+		return
+	}
 	if !h.context.IsIngressClass(ing) {
 		return
 	}
@@ -82,7 +82,7 @@ func (h handlers) ingressDelete(obj interface{}) {
 
 	h.context.Work <- events.Event{
 		Type:  events.Delete,
-		Value: obj,
+		Value: ing,
 	}
 	h.context.MetricStore.IncK8sAPIEventCounter()
 }

--- a/pkg/k8scontext/ingress_handlers.go
+++ b/pkg/k8scontext/ingress_handlers.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 
 	v1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -62,7 +61,7 @@ func (h handlers) ingressDelete(obj interface{}) {
 			// unable to get from tombstone
 			return
 		}
-		ing, _ = tombstone.Obj.(*networking.Ingress)
+		ing, _ = convert.ToIngressV1(tombstone.Obj)
 	}
 	if ing == nil {
 		return

--- a/pkg/k8scontext/ingress_handlers_test.go
+++ b/pkg/k8scontext/ingress_handlers_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/fake"
@@ -126,6 +127,21 @@ var _ = ginkgo.Describe("K8scontext Ingress Cache Handlers", func() {
 
 			// check that map is updated with the new key
 			Expect(h.context.ingressSecretsMap.ContainsValue(secKey)).To(BeTrue())
+		})
+
+		ginkgo.It("should queue the unwrapped ingress when ingressDelete receives a DeletedFinalStateUnknown tombstone", func() {
+			ing := fixtures.GetIngress()
+			ing.Namespace = "ns"
+
+			tombstone := cache.DeletedFinalStateUnknown{
+				Key: "ns/" + ing.Name,
+				Obj: ing,
+			}
+
+			Expect(func() { h.ingressDelete(tombstone) }).ToNot(Panic())
+			Expect(len(h.context.Work)).To(Equal(1))
+			event := <-h.context.Work
+			Expect(event.Value).To(Equal(ing))
 		})
 
 		ginkgo.When("using ingress class", func() {

--- a/pkg/k8scontext/ingress_handlers_test.go
+++ b/pkg/k8scontext/ingress_handlers_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
@@ -142,7 +143,7 @@ var _ = ginkgo.Describe("K8scontext Ingress Cache Handlers", func() {
 			Expect(func() { h.ingressDelete(tombstone) }).ToNot(Panic())
 			Expect(len(h.context.Work)).To(Equal(1))
 			event := <-h.context.Work
-			Expect(event.Value).To(Equal(ing))
+			Expect(event.Value).To(BeIdenticalTo(ing))
 		})
 
 		ginkgo.It("should queue an ingress delete from a tombstone wrapping an extensions/v1beta1 Ingress", func() {
@@ -164,6 +165,22 @@ var _ = ginkgo.Describe("K8scontext Ingress Cache Handlers", func() {
 
 			Expect(func() { h.ingressDelete(tombstone) }).ToNot(Panic())
 			Expect(len(h.context.Work)).To(Equal(1))
+			event := <-h.context.Work
+			queuedIng, ok := event.Value.(*networking.Ingress)
+			Expect(ok).To(BeTrue())
+			Expect(queuedIng.Namespace).To(Equal(ing.Namespace))
+			Expect(queuedIng.Name).To(Equal(ing.Name))
+		})
+
+		ginkgo.It("should drop a DeletedFinalStateUnknown tombstone wrapping the wrong type", func() {
+			pod := tests.NewPodTestFixture("ns", "pod")
+			tombstone := cache.DeletedFinalStateUnknown{
+				Key: "ns/pod",
+				Obj: &pod,
+			}
+
+			Expect(func() { h.ingressDelete(tombstone) }).ToNot(Panic())
+			Expect(len(h.context.Work)).To(Equal(0))
 		})
 
 		ginkgo.When("using ingress class", func() {

--- a/pkg/k8scontext/ingress_handlers_test.go
+++ b/pkg/k8scontext/ingress_handlers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
@@ -142,6 +143,27 @@ var _ = ginkgo.Describe("K8scontext Ingress Cache Handlers", func() {
 			Expect(len(h.context.Work)).To(Equal(1))
 			event := <-h.context.Work
 			Expect(event.Value).To(Equal(ing))
+		})
+
+		ginkgo.It("should queue an ingress delete from a tombstone wrapping an extensions/v1beta1 Ingress", func() {
+			IsNetworkingV1PackageSupported = false
+			ing := &extensionsv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ing",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						annotations.IngressClassKey: tests.IngressClassController,
+					},
+				},
+			}
+
+			tombstone := cache.DeletedFinalStateUnknown{
+				Key: "ns/" + ing.Name,
+				Obj: ing,
+			}
+
+			Expect(func() { h.ingressDelete(tombstone) }).ToNot(Panic())
+			Expect(len(h.context.Work)).To(Equal(1))
 		})
 
 		ginkgo.When("using ingress class", func() {

--- a/pkg/k8scontext/secrets_handlers.go
+++ b/pkg/k8scontext/secrets_handlers.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/utils"
@@ -79,16 +78,13 @@ func (h handlers) secretUpdate(oldObj, newObj interface{}) {
 }
 
 func (h handlers) secretDelete(obj interface{}) {
+	obj, ok := unwrapTombstone(obj)
+	if !ok {
+		return
+	}
 	sec, ok := obj.(*v1.Secret)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.Error("error decoding object, invalid type")
-			return
-		}
-		sec, _ = tombstone.Obj.(*v1.Secret)
-	}
-	if sec == nil {
+		klog.Error("error decoding object, invalid type")
 		return
 	}
 

--- a/pkg/k8scontext/secrets_handlers.go
+++ b/pkg/k8scontext/secrets_handlers.go
@@ -81,7 +81,14 @@ func (h handlers) secretUpdate(oldObj, newObj interface{}) {
 func (h handlers) secretDelete(obj interface{}) {
 	sec, ok := obj.(*v1.Secret)
 	if !ok {
-		klog.Error("error decoding object, invalid type")
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Error("error decoding object, invalid type")
+			return
+		}
+		sec, _ = tombstone.Obj.(*v1.Secret)
+	}
+	if sec == nil {
 		return
 	}
 
@@ -92,24 +99,12 @@ func (h handlers) secretDelete(obj interface{}) {
 		return
 	}
 
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			// unable to get from tombstone
-			return
-		}
-		sec, _ = tombstone.Obj.(*v1.Secret)
-	}
-	if sec == nil {
-		return
-	}
-
 	secKey := utils.GetResourceKey(sec.Namespace, sec.Name)
 	h.context.CertificateSecretStore.delete(secKey)
 	if h.context.ingressSecretsMap.ContainsValue(secKey) {
 		h.context.Work <- events.Event{
 			Type:  events.Delete,
-			Value: obj,
+			Value: sec,
 		}
 		h.context.MetricStore.IncK8sAPIEventCounter()
 	}

--- a/pkg/k8scontext/secrets_handlers_test.go
+++ b/pkg/k8scontext/secrets_handlers_test.go
@@ -97,7 +97,18 @@ var _ = ginkgo.Describe("K8scontext Secrets Cache Handlers", func() {
 			Expect(func() { h.secretDelete(tombstone) }).ToNot(Panic())
 			Expect(len(h.context.Work)).To(Equal(1))
 			event := <-h.context.Work
-			Expect(event.Value).To(Equal(secret))
+			Expect(event.Value).To(BeIdenticalTo(secret))
+		})
+
+		ginkgo.It("should drop a DeletedFinalStateUnknown tombstone wrapping the wrong type", func() {
+			pod := tests.NewPodTestFixture("ns", "pod")
+			tombstone := cache.DeletedFinalStateUnknown{
+				Key: "ns/pod",
+				Obj: &pod,
+			}
+
+			Expect(func() { h.secretDelete(tombstone) }).ToNot(Panic())
+			Expect(len(h.context.Work)).To(Equal(0))
 		})
 	})
 })

--- a/pkg/k8scontext/secrets_handlers_test.go
+++ b/pkg/k8scontext/secrets_handlers_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/agic_crd_client/clientset/versioned/fake"
 	multiClusterFake "github.com/Azure/application-gateway-kubernetes-ingress/pkg/crd_client/azure_multicluster_crd_client/clientset/versioned/fake"
@@ -81,6 +82,22 @@ var _ = ginkgo.Describe("K8scontext Secrets Cache Handlers", func() {
 			Expect(len(h.context.Work)).To(Equal(0))
 			h.secretUpdate(secret, secret)
 			Expect(len(h.context.Work)).To(Equal(0))
+		})
+
+		ginkgo.It("should queue the unwrapped secret when secretDelete receives a DeletedFinalStateUnknown tombstone", func() {
+			secret := tests.NewSecretTestFixture()
+			secret.Namespace = "ns"
+			ctx.ingressSecretsMap.Insert("ingress", utils.GetResourceKey(secret.Namespace, secret.Name))
+
+			tombstone := cache.DeletedFinalStateUnknown{
+				Key: "ns/" + secret.Name,
+				Obj: secret,
+			}
+
+			Expect(func() { h.secretDelete(tombstone) }).ToNot(Panic())
+			Expect(len(h.context.Work)).To(Equal(1))
+			event := <-h.context.Work
+			Expect(event.Value).To(Equal(secret))
 		})
 	})
 })


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist
- [x] The title of the PR is clear and informative
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] Issues addressed by the PR are mentioned in the description followed by `Fixes`.

## Description

Fixes panics and silent drops when an informer delivers a delete tombstone instead of the typed object.

- unwrap tombstones in `deleteFunc`, `secretDelete`, `ingressDelete` before use
- forward the unwrapped object, not the tombstone, to the work queue
- drop events with no recoverable object instead of panicking or forwarding one
- fix `ingressDelete` to accept `extensions/v1beta1` Ingress tombstones too
- share one unwrap helper so all three handlers behave and log consistently
- add tests for the tombstone, nil-object, and wrong-type-object cases

`client-go`'s `DeltaFIFO` can hand `OnDelete` a tombstone instead of the typed object when it misses a delete event during a relist. Observed panic in production, matching several reports in #1147 going back to 2021:

```
panic: reflect: call of reflect.Value.Elem on struct Value [recovered]
	panic: reflect: call of reflect.Value.Elem on struct Value

goroutine 178 [running]:
	.../pkg/k8scontext/handlers.go:66 +0x71
	.../pkg/k8scontext/handlers.go:50 +0x2c
	created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 163
```

## Fixes

Fixes #1147
