### PR TITLE
fix: align default probe and backend protocols

### DIFF
--- a/pkg/appgw/backendhttpsettings.go
+++ b/pkg/appgw/backendhttpsettings.go
@@ -13,6 +13,7 @@ import (
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-03-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	v1 "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
 
@@ -239,14 +240,6 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 			RequestTimeout:                 to.Int32Ptr(30),
 		},
 	}
-	_, probesMap := c.newProbesMap(cbCtx)
-
-	if probesMap[backendID] != nil {
-		probeName := probesMap[backendID].Name
-		probeID := c.appGwIdentifier.probeID(*probeName)
-		httpSettings.ApplicationGatewayBackendHTTPSettingsPropertiesFormat.Probe = resourceRef(probeID)
-	}
-
 	if pathPrefix, err := annotations.BackendPathPrefix(backendID.Ingress); err == nil {
 		httpSettings.Path = to.StringPtr(pathPrefix)
 	} else if !controllererrors.IsErrorCode(err, controllererrors.ErrorMissingAnnotation) {
@@ -291,19 +284,16 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
 	}
 
-	// when ingress is defined with backend at port 443 but without annotation backend-protocol set to https.
-	if int32(port) == 443 {
-		httpSettings.Protocol = n.ApplicationGatewayProtocolHTTPS
+	protocol, err := backendProtocolForPort(backendID.Ingress, port)
+	httpSettings.Protocol = protocol
+	if err != nil && !controllererrors.IsErrorCode(err, controllererrors.ErrorMissingAnnotation) {
+		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
 	}
 
-	// backend protocol take precedence over port
-	backendProtocol, err := annotations.BackendProtocol(backendID.Ingress)
-	if err == nil && backendProtocol == annotations.HTTPS {
-		httpSettings.Protocol = n.ApplicationGatewayProtocolHTTPS
-	} else if err == nil && backendProtocol == annotations.HTTP {
-		httpSettings.Protocol = n.ApplicationGatewayProtocolHTTP
-	} else if err != nil && !controllererrors.IsErrorCode(err, controllererrors.ErrorMissingAnnotation) {
-		c.recorder.Event(backendID.Ingress, v1.EventTypeWarning, events.ReasonInvalidAnnotation, err.Error())
+	_, probesMap := c.newProbesMap(cbCtx)
+	if probesMap[backendID] != nil {
+		probeName := probesMap[backendID].Name
+		httpSettings.Probe = resourceRef(c.appGwIdentifier.probeID(*probeName))
 	}
 
 	if trustedRootCertificates, err := annotations.GetAppGwTrustedRootCertificate(backendID.Ingress); err == nil {
@@ -333,4 +323,20 @@ func (c *appGwConfigBuilder) generateHTTPSettings(backendID backendIdentifier, p
 	}
 
 	return httpSettings
+}
+
+func backendProtocolForPort(ingress *networking.Ingress, port Port) (n.ApplicationGatewayProtocol, error) {
+	protocol := n.ApplicationGatewayProtocolHTTP
+	if port == Port(443) {
+		protocol = n.ApplicationGatewayProtocolHTTPS
+	}
+
+	backendProtocol, err := annotations.BackendProtocol(ingress)
+	if err != nil {
+		return protocol, err
+	}
+	if backendProtocol == annotations.HTTPS {
+		return n.ApplicationGatewayProtocolHTTPS, nil
+	}
+	return n.ApplicationGatewayProtocolHTTP, nil
 }

--- a/pkg/appgw/backendhttpsettings_test.go
+++ b/pkg/appgw/backendhttpsettings_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/annotations"
 	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/tests"
@@ -166,6 +167,46 @@ var _ = Describe("Test the creation of Backend http settings from Ingress defini
 					// Dummy Failure, This should not happen
 					Expect(23).To(Equal(75), "setting %s is not expected to be created", *setting.Name)
 				}
+			}
+		})
+	})
+
+	Context("ensure backend settings and probes use the same protocol", func() {
+		It("uses the HTTPS default probe when the referenced Service is missing", func() {
+			cb := newConfigBuilderFixture(nil)
+			backend := tests.NewIngressBackendFixture(tests.ServiceName, 443)
+			ing := &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tests.Name,
+					Namespace: tests.Namespace,
+				},
+				Spec: networking.IngressSpec{
+					Rules: []networking.IngressRule{
+						tests.NewIngressRuleFixture(tests.Host, "/", *backend),
+					},
+				},
+			}
+
+			cbCtx := &ConfigBuilderContext{
+				IngressList: []*networking.Ingress{ing},
+			}
+
+			Expect(cb.HealthProbesCollection(cbCtx)).To(Succeed())
+			Expect(cb.BackendHTTPSettingsCollection(cbCtx)).To(Succeed())
+			settings := *cb.appGw.BackendHTTPSettingsCollection
+			Expect(settings).To(HaveLen(2))
+			probes := make(map[string]n.ApplicationGatewayProbe)
+			for _, probe := range *cb.appGw.Probes {
+				probes[*probe.Name] = probe
+			}
+
+			for _, setting := range settings {
+				if *setting.Name == DefaultBackendHTTPSettingsName {
+					continue
+				}
+				Expect(setting.Protocol).To(Equal(n.ApplicationGatewayProtocolHTTPS))
+				Expect(utils.GetLastChunkOfSlashed(*setting.Probe.ID)).To(Equal(defaultProbeName(n.ApplicationGatewayProtocolHTTPS)))
+				Expect(probes[utils.GetLastChunkOfSlashed(*setting.Probe.ID)].Protocol).To(Equal(setting.Protocol))
 			}
 		})
 	})

--- a/pkg/appgw/health_probes.go
+++ b/pkg/appgw/health_probes.go
@@ -62,8 +62,10 @@ func (c *appGwConfigBuilder) newProbesMap(cbCtx *ConfigBuilderContext) (map[stri
 			probesMap[backendID] = probe
 			healthProbeCollection[*probe.Name] = *probe
 		} else {
+			backendPort, _ := c.resolveBackendPort(backendID)
+			backendProtocol, _ := backendProtocolForPort(backendID.Ingress, backendPort)
 			probesMap[backendID] = &defaultHTTPProbe
-			if protocol, _ := annotations.BackendProtocol(backendID.Ingress); protocol == annotations.HTTPS {
+			if backendProtocol == n.ApplicationGatewayProtocolHTTPS {
 				probesMap[backendID] = &defaultHTTPSProbe
 			}
 		}


### PR DESCRIPTION
## Summary

Use the same effective protocol decision for backend HTTP settings and default health probes.

When an Ingress references a missing Service on numeric port 443, AGIC currently:

1. Retains the unresolved backend in the generated model.
2. Falls back to the numeric Ingress port, 443.
3. Creates an HTTPS backend HTTP setting.
4. Selects `defaultprobe-Http` unless `backend-protocol: https` is explicitly set.

Application Gateway rejects that probe/setting pair, which prevents the complete gateway update from being applied.

## Change

- Extract the existing port-and-annotation protocol selection into `backendProtocolForPort`.
- Use that helper for backend HTTP settings.
- Use the same helper when selecting a default probe after custom-probe generation returns `nil`.
- Add regression coverage for an Ingress that references a missing Service on numeric port 443.

Custom probes derived from readiness or liveness probes are unchanged.

## Reproduction

The minimal case is an Ingress with no corresponding Service:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: repro
  namespace: agic-missing-service
spec:
  ingressClassName: azure-application-gateway
  rules:
  - http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: backend
            port:
              number: 443
```

With the stock 1.9.10 image, the controller generates `defaultprobe-Http` and an HTTPS backend setting. ARM returns:

```text
ApplicationGatewayProbeProtocolMustMatchBackendHttpSettinsProtocol
Probe .../defaultprobe-Http protocol (Http) does not match
Backend Http Setting ... protocol (Https).
```

## Verification

```text
go test -tags unittest ./pkg/appgw -run TestAppgw -count=1
```

The stock Helm 1.9.10 image reproduced the ARM HTTP 400 in a fresh AKS/Application Gateway environment. An image built from this change produced an HTTPS backend setting referencing `defaultprobe-Https`; the gateway update reached `Succeeded`.
